### PR TITLE
fix: rewrite of restore and dump commands

### DIFF
--- a/cmd/client-daemon.go
+++ b/cmd/client-daemon.go
@@ -106,22 +106,18 @@ LOOP:
 			if err != nil {
 				// we don't want the daemon blowing up, so don't pass the error up
 				c.logger.Warn().Msgf("could not checkpoint with error: %v", err)
-				c.chkptState.CheckpointState = CheckpointFailed
 				c.publishStateOnce()
 			}
-			c.chkptState.CheckpointState = CheckpointSuccess
 			c.publishStateOnce()
 
 		case cmd := <-c.channels.restore_command:
 			// same here - want the restore to be retriable in the future, so makes sense not to blow it up
 			c.logger.Info().Msg("received restore command from the NATS server")
-			err := c.restore(&cmd)
+			err := c.restore(&cmd, nil)
 			if err != nil {
 				c.logger.Warn().Msgf("could not restore with error: %v", err)
-				c.chkptState.RestoreState = RestoreFailed
 				c.publishStateOnce()
 			}
-			c.chkptState.RestoreState = RestoreSuccess
 			c.publishStateOnce()
 
 		case <-stop:

--- a/utils/config.go
+++ b/utils/config.go
@@ -45,8 +45,7 @@ type Docker struct {
 }
 
 type SharedStorage struct {
-	// only useful for multi-machine checkpoint/restore
-	MountPoint     string `json:"mount_point" mapstructure:"mount_point"`
+	MountPoint     string `json:"mount_point" mapstructure:"mount_point"` // for multi-machine checkpoint/restore
 	DumpStorageDir string `json:"dump_storage_dir" mapstructure:"dump_storage_dir"`
 }
 

--- a/utils/files.go
+++ b/utils/files.go
@@ -1,0 +1,64 @@
+package utils
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+)
+
+func CopyFile(src, dstFolder string) error {
+	sfi, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	if !sfi.Mode().IsRegular() {
+		return fmt.Errorf("%s is not a regular file", src)
+	}
+
+	// Get the base name of the source file
+	srcBaseName := filepath.Base(src)
+
+	// Append the source file base name to the destination folder to get the destination file path
+	dst := filepath.Join(dstFolder, srcBaseName)
+
+	_, err = os.Stat(dst)
+	if err != nil {
+		if !os.IsNotExist(err) {
+			return nil
+		}
+	} else {
+		return fmt.Errorf("File %s already exists.", dst)
+	}
+
+	return copyFileContents(src, dst)
+}
+
+// copyFileContents copies the contents of the file named src to the file named
+// by dst. The file will be created if it does not already exist. If the
+// destination file exists, all it's contents will be replaced by the contents
+// of the source file.
+func copyFileContents(src, dst string) (err error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return
+	}
+	defer func() {
+		cerr := out.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	if _, err = io.Copy(out, in); err != nil {
+		return
+	}
+	err = out.Sync()
+	return
+}


### PR DESCRIPTION
- MVP for filesystem checkpointing, open files are sent as part of a larger checkpoint 
- Pytorch checkpointing more robust 
- Restore command rewritten for ease of use w/ commandline