### PR TITLE
CED-139: Reorganize into RPC 

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -550,13 +550,15 @@ func (c *Client) startNATSService() {
 
 		case cmd := <-restoreCmdChn:
 			c.logger.Info().Msg("received restore command from NATS server")
-			err := c.Restore(&cmd, nil)
+			pid, err := c.Restore(&cmd, nil)
 			if err != nil {
 				c.logger.Warn().Msgf("could not restore process: %v", err)
 				c.state.CheckpointState = cedana.RestoreFailed
 				c.publishStateOnce(c.getState(c.Process.PID))
 			}
 			c.state.CheckpointState = cedana.RestoreSuccess
+			c.Process.PID = *pid
+			c.publishStateOnce(c.getState(c.Process.PID))
 
 		default:
 			time.Sleep(1 * time.Second)

--- a/api/client.go
+++ b/api/client.go
@@ -358,7 +358,11 @@ func (c *Client) timeTrack(start time.Time, name string) {
 }
 
 func (c *Client) getState(pid int32) *cedana.CedanaState {
-	// inefficient - but unsure about race condition issues
+
+	if pid == 0 {
+		return nil
+	}
+
 	p, err := process.NewProcess(pid)
 	if err != nil {
 		c.logger.Info().Msgf("Could not instantiate new gopsutil process with error %v", err)

--- a/api/client.go
+++ b/api/client.go
@@ -533,6 +533,22 @@ func (c *Client) startNATSService() {
 
 	go c.publishStateContinuous(30)
 
+	// listen for broadcast commands
+	// subscribe to our broadcasters
+	dumpCmdChn := c.channels.dumpCmdBroadcaster.Subscribe()
+	restoreCmdChn := c.channels.restoreCmdBroadcaster.Subscribe()
+
+	for {
+		select {
+		case <-dumpCmdChn:
+			c.logger.Info().Msg("received checkpoint command from NATS server")
+		case <-restoreCmdChn:
+			c.logger.Info().Msg("received restore command from NATS server")
+		default:
+			time.Sleep(1 * time.Second)
+		}
+	}
+
 }
 
 func (c *Client) tryStartJob() error {

--- a/api/client.go
+++ b/api/client.go
@@ -570,6 +570,7 @@ func (c *Client) TryStartJob(task *string) error {
 	if task == nil {
 		// try config
 		task = &c.config.Client.Task
+		c.logger.Info().Msgf("no task provided, using task in config: %s", *task)
 	}
 	// 5 attempts arbitrarily chosen - up to the orchestrator to send the correct task
 	var err error

--- a/api/client.go
+++ b/api/client.go
@@ -185,7 +185,6 @@ func (c *Client) AddNATS(selfID, jobID, authToken string) error {
 		return err
 	}
 
-	// until market server is deployed, use NATS as a store
 	natsStore := utils.NewNATSStore(c.logger, jsc, c.jobId)
 	c.store = natsStore
 
@@ -524,12 +523,6 @@ func setupConnOptions(opts []nats.Option, logger *zerolog.Logger) []nats.Option 
 func (c *Client) startNATSService() {
 	// create a subscription to NATS commands from the orchestrator first
 	go c.subscribeToCommands(300)
-
-	err := c.tryStartJob()
-	// if we hit an error here, unrecoverable
-	if err != nil {
-		c.logger.Fatal().Err(err).Msg("could not start job")
-	}
 
 	go c.publishStateContinuous(30)
 

--- a/api/client.go
+++ b/api/client.go
@@ -137,7 +137,6 @@ func InstantiateClient() (*Client, error) {
 }
 
 // Layers daemon capabilities onto client (adding nats, jetstream and jetstream contexts)
-
 func (c *Client) AddNATS(selfID, jobID, authToken string) error {
 	c.selfId = selfID
 	c.jobId = jobID

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -1,4 +1,4 @@
-package cmd
+package api
 
 import (
 	"os"

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -137,7 +137,7 @@ func TestClient_TryStartJob(t *testing.T) {
 		}
 
 		go mockServerRetryCmd(c)
-		err := c.tryStartJob()
+		err := c.TryStartJob()
 		if err != nil {
 			t.Errorf("Expected no error, but got %v", err)
 		}

--- a/api/client_test.go
+++ b/api/client_test.go
@@ -137,7 +137,7 @@ func TestClient_TryStartJob(t *testing.T) {
 		}
 
 		go mockServerRetryCmd(c)
-		err := c.TryStartJob()
+		err := c.TryStartJob(nil)
 		if err != nil {
 			t.Errorf("Expected no error, but got %v", err)
 		}

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -67,8 +67,6 @@ func (cd *CedanaDaemon) StartNATS(args *StartNATSArgs, resp *StartNATSResp) erro
 	}
 	go cd.client.startNATSService()
 
- // set up broadcasters, listen and c/r, same way we do with the old daemon
-
 	return nil
 }
 

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -28,7 +28,8 @@ type RestoreArgs struct {
 }
 
 type RestoreResp struct {
-	Error error
+	Error  error
+	NewPID int32
 }
 
 type ListCheckpointsArgs struct {
@@ -68,10 +69,11 @@ func (cd *CedanaDaemon) Dump(args *DumpArgs, resp *DumpResp) error {
 }
 
 func (cd *CedanaDaemon) Restore(args *RestoreArgs, resp *RestoreResp) error {
-	err := cd.client.Restore(nil, &args.Path)
+	pid, err := cd.client.Restore(nil, &args.Path)
 	if err != nil {
 		resp.Error = err
 	}
+	resp.NewPID = *pid
 	return err
 }
 

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -1,0 +1,55 @@
+package api
+
+import (
+	"net"
+	"net/rpc"
+	"os"
+
+	"github.com/rs/zerolog"
+)
+
+type CedanaDaemon struct {
+	client *Client
+	logger *zerolog.Logger
+}
+
+func NewDaemon() *CedanaDaemon {
+	c, err := InstantiateClient()
+	if err != nil {
+		c.logger.Fatal().Err(err).Msg("Could not instantiate client")
+	}
+
+	return &CedanaDaemon{
+		client: c,
+		logger: c.logger,
+	}
+}
+
+func (cd *CedanaDaemon) Cleanup(listener net.Listener) {
+	if listener != nil {
+		listener.Close()
+	}
+	os.Remove("/tmp/cedana.sock")
+}
+
+func (cd *CedanaDaemon) StartDaemon() {
+	_, err := os.Stat("/tmp/cedana.sock")
+	if err == nil {
+		os.Remove("/tmp/cedana.sock")
+	}
+
+	listener, err := net.Listen("unix", "/tmp/cedana.sock")
+	if err != nil {
+		cd.logger.Fatal().Err(err).Msg("could not start daemon")
+	}
+
+	for {
+		conn, err := listener.Accept()
+		if err != nil {
+			cd.logger.Fatal().Err(err).Msg("could not start daemon")
+		}
+		rpc.ServeConn(conn)
+	}
+
+	defer cd.Cleanup(listener)
+}

--- a/api/daemon.go
+++ b/api/daemon.go
@@ -67,6 +67,8 @@ func (cd *CedanaDaemon) StartNATS(args *StartNATSArgs, resp *StartNATSResp) erro
 	}
 	go cd.client.startNATSService()
 
+ // set up broadcasters, listen and c/r, same way we do with the old daemon
+
 	return nil
 }
 

--- a/api/dump.go
+++ b/api/dump.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -67,6 +68,9 @@ func (c *Client) prepareDump(pid int32, dir string, opts *rpc.CriuOpts) (string,
 	}
 
 	state := c.getState(pid)
+	if state == nil {
+		return "", fmt.Errorf("could not get state")
+	}
 	c.Process = state.ProcessInfo
 
 	// save state for serialization at this point

--- a/api/dump.go
+++ b/api/dump.go
@@ -1,4 +1,4 @@
-package cmd
+package api
 
 import (
 	"os"
@@ -11,67 +11,16 @@ import (
 	"github.com/cedana/cedana/utils"
 	"github.com/checkpoint-restore/go-criu/v5/rpc"
 	"github.com/shirou/gopsutil/v3/process"
-	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
 
 	cedana "github.com/cedana/cedana/types"
 )
-
-var dir string
-var pid int32
 
 const (
 	sys_pidfd_send_signal = 424
 	sys_pidfd_open        = 434
 	sys_pidfd_getfd       = 438
 )
-
-func init() {
-	clientCommand.AddCommand(dumpCommand)
-	dumpCommand.Flags().StringVarP(&dir, "dir", "d", "", "folder to dump checkpoint into")
-	dumpCommand.Flags().Int32VarP(&pid, "pid", "p", 0, "pid to dump")
-}
-
-// This is a direct dump command. Won't be used in practice, we want to start a daemon
-var dumpCommand = &cobra.Command{
-	Use:   "dump",
-	Short: "Directly dump a process",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := InstantiateClient()
-		if err != nil {
-			return err
-		}
-		// load from config if flags aren't set
-		if dir == "" {
-			dir = c.config.SharedStorage.DumpStorageDir
-		}
-
-		if pid == 0 {
-			pid, err = utils.GetPid(c.config.Client.Task)
-			if err != nil {
-				c.logger.Err(err).Msg("Could not parse process name from config")
-				return err
-			}
-		}
-
-		c.Process.PID = pid
-
-		// check that folder exists before proceeding
-		_, err = os.Stat(dir)
-		if err != nil {
-			c.logger.Fatal().Err(err).Msg("folder doesn't exist")
-			return err
-		}
-
-		err = c.Dump(dir)
-		if err != nil {
-			return err
-		}
-
-		defer c.cleanupClient()
-		return nil
-	},
-}
 
 // Signals a process prior to dumping with SIGUSR1 and outputs any created checkpoints
 func (c *Client) signalProcessAndWait(pid int32, timeout int) *string {

--- a/api/dump.go
+++ b/api/dump.go
@@ -59,37 +59,6 @@ func (c *Client) signalProcessAndWait(pid int32, timeout int) *string {
 	return &checkpointPath
 }
 
-// consistency for the file is important, so we need to
-// pause the process writing the file.
-// An alternative here could be to use file locks, TODO NR: investigate
-func (c *Client) signalPause() error {
-	process, err := os.FindProcess(int(c.Process.PID))
-	if err != nil {
-		return err
-	}
-
-	err = process.Signal(syscall.SIGSTOP)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *Client) signalContinue() error {
-	process, err := os.FindProcess(int(c.Process.PID))
-	if err != nil {
-		return err
-	}
-
-	err = process.Signal(syscall.SIGCONT)
-	if err != nil {
-		return err
-	}
-
-	return err
-}
-
 func (c *Client) prepareDump(pid int32, dir string, opts *rpc.CriuOpts) (string, error) {
 	pname, err := utils.GetProcessName(pid)
 	if err != nil {

--- a/api/restore.go
+++ b/api/restore.go
@@ -1,4 +1,4 @@
-package cmd
+package api
 
 import (
 	"encoding/json"
@@ -9,42 +9,10 @@ import (
 
 	"github.com/cedana/cedana/utils"
 	"github.com/checkpoint-restore/go-criu/v5/rpc"
-	"github.com/spf13/cobra"
 	"google.golang.org/protobuf/proto"
 
 	cedana "github.com/cedana/cedana/types"
 )
-
-func init() {
-	clientCommand.AddCommand(restoreCmd)
-}
-
-// Restore command is only called when run manually.
-// Otherwise, daemon command is used and a network/cedana-managed restore occurs.
-var restoreCmd = &cobra.Command{
-	Use:   "restore",
-	Args:  cobra.ExactArgs(1),
-	Short: "Initialize client and restore from dumped image",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		c, err := InstantiateClient()
-		if err != nil {
-			return err
-		}
-
-		checkpointPath := args[0]
-		// check if it exists before passing to restore
-		_, err = os.Stat(checkpointPath)
-		if err != nil {
-			return err
-		}
-
-		err = c.Restore(nil, &checkpointPath)
-		if err != nil {
-			return err
-		}
-		return nil
-	},
-}
 
 func (c *Client) prepareRestore(opts *rpc.CriuOpts, cmd *cedana.ServerCommand, checkpointPath string) (*string, error) {
 	tmpdir := "cedana_restore"

--- a/api/tcp_test.go
+++ b/api/tcp_test.go
@@ -1,4 +1,4 @@
-package cmd
+package api
 
 import (
 	"os"

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -51,6 +51,10 @@ func (b *Bootstrap) bootstrap() {
 	}
 }
 
+func (b *Bootstrap) createSystemdService() {
+
+}
+
 func init() {
 	rootCmd.AddCommand(bootstrapCmd)
 }

--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 
@@ -49,10 +50,43 @@ func (b *Bootstrap) bootstrap() {
 	if err != nil {
 		b.l.Fatal().Err(err).Msg("could not initiate generated config")
 	}
+
+	err = b.createSystemdService()
+	if err != nil {
+		b.l.Fatal().Err(err).Msg("could not create systemd service")
+	}
 }
 
-func (b *Bootstrap) createSystemdService() {
+func (b *Bootstrap) createSystemdService() error {
+	unitFilePath := "/etc/systemd/system/cedana.service"
 
+	// Open the unit file for writing
+	unitFile, err := os.Create(unitFilePath)
+	if err != nil {
+		return err
+	}
+	defer unitFile.Close()
+
+	// Write the unit file content
+	unitFileContents := `[Unit]
+Description=Cedana Worker Daemon
+After=network.target
+
+[Service]
+Type=forking
+ExecStart=/usr/bin/cedana daemon
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+`
+	_, err = unitFile.WriteString(unitFileContents)
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Systemd service file created at %s\n", unitFilePath)
+	return nil
 }
 
 func init() {

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -75,6 +75,8 @@ var dumpCmd = &cobra.Command{
 	},
 }
 
+var restoreCmd = &cobra.Command{}
+
 var natsCmd = &cobra.Command{
 	Use:   "nats",
 	Short: "Start NATS server for cedana client",
@@ -119,6 +121,8 @@ var natsCmd = &cobra.Command{
 
 func init() {
 	rootCmd.AddCommand(dumpCmd)
-	rootCmd.AddCommand(natsCmd)
+	rootCmd.AddCommand(restoreCmd)
+	clientDaemonCmd.AddCommand(natsCmd)
+	clientDaemonCmd.AddCommand()
 	dumpCmd.Flags().StringVarP(&dir, "dir", "d", "", "directory to dump to")
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -101,6 +101,30 @@ var restoreCmd = &cobra.Command{
 	},
 }
 
+var startTaskCmd = &cobra.Command{
+	Use:   "start",
+	Short: "Start and register a new process with Cedana",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := NewCLI()
+		if err != nil {
+			return err
+		}
+
+		a := api.StartTaskArgs{
+			Task: args[0],
+		}
+
+		var resp api.StartTaskResp
+		err = cli.conn.Call("CedanaDaemon.StartTask", a, &resp)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
 var natsCmd = &cobra.Command{
 	Use:   "nats",
 	Short: "Start NATS server for cedana client",
@@ -146,6 +170,7 @@ var natsCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(dumpCmd)
 	rootCmd.AddCommand(restoreCmd)
+	rootCmd.AddCommand(startTaskCmd)
 	clientDaemonCmd.AddCommand(natsCmd)
 	dumpCmd.Flags().StringVarP(&dir, "dir", "d", "", "directory to dump to")
 }

--- a/cmd/cli.go
+++ b/cmd/cli.go
@@ -1,0 +1,80 @@
+package cmd
+
+import (
+	"fmt"
+	"net/rpc"
+	"strconv"
+
+	"github.com/cedana/cedana/api"
+	"github.com/cedana/cedana/utils"
+	"github.com/rs/zerolog"
+	"github.com/spf13/cobra"
+)
+
+var dir string
+
+type CLI struct {
+	cfg    *utils.Config
+	conn   *rpc.Client
+	logger zerolog.Logger
+}
+
+func NewCLI() (*CLI, error) {
+	cfg, err := utils.InitConfig()
+	if err != nil {
+		return nil, err
+	}
+	client, err := rpc.Dial("unix", "/tmp/cedana.sock")
+	if err != nil {
+		return nil, fmt.Errorf("could not connect to daemon at /tmp/cedana.sock, running as root?: %w", err)
+	}
+	logger := utils.GetLogger()
+
+	return &CLI{
+		cfg:    cfg,
+		conn:   client,
+		logger: logger,
+	}, nil
+}
+
+var dumpCmd = &cobra.Command{
+	Use:   "dump",
+	Short: "Directly checkpoint a running process to a directory",
+	Args:  cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		cli, err := NewCLI()
+		if err != nil {
+			return err
+		}
+
+		pid, err := strconv.Atoi(args[0])
+		if err != nil {
+			return err
+		}
+
+		if dir == "" {
+			if cli.cfg.SharedStorage.DumpStorageDir == "" {
+				return fmt.Errorf("no dump directory specified")
+			}
+			dir = cli.cfg.SharedStorage.DumpStorageDir
+		}
+
+		a := api.DumpArgs{
+			PID: int32(pid),
+			Dir: dir,
+		}
+
+		var resp api.DumpResp
+		err = cli.conn.Call("CedanaDaemon.Dump", a, &resp)
+		if err != nil {
+			return err
+		}
+
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(dumpCmd)
+	dumpCmd.Flags().StringVarP(&dir, "dir", "d", "", "directory to dump to")
+}

--- a/cmd/client-daemon.go
+++ b/cmd/client-daemon.go
@@ -24,7 +24,7 @@ var daemonSignal = flag.String("s", "", "")
 
 var clientDaemonCmd = &cobra.Command{
 	Use:   "daemon",
-	Short: "Start daemon, and dump checkpoints to disk as commanded by an orchestrator",
+	Short: "Start daemon for cedana client. Must be run as root, needed for all other cedana functionality.",
 	Run: func(cmd *cobra.Command, args []string) {
 		c, err := InstantiateClient()
 		if err != nil {

--- a/cmd/client-daemon.go
+++ b/cmd/client-daemon.go
@@ -39,7 +39,7 @@ var clientDaemonCmd = &cobra.Command{
 			LogFilePerm: 0o664,
 			WorkDir:     "./",
 			Umask:       027,
-			Args:        []string{executable, "client", "daemon"},
+			Args:        []string{executable, "daemon"},
 		}
 
 		gd.AddCommand(gd.StringFlag(daemonSignal, "stop"), syscall.SIGTERM, termHandler)
@@ -57,12 +57,12 @@ var clientDaemonCmd = &cobra.Command{
 
 		logger.Info().Msgf("daemon started at %s", time.Now().Local())
 
+		go cd.StartDaemon()
+
 		err = gd.ServeSignals()
 		if err != nil {
 			logger.Fatal().Err(err)
 		}
-
-		go cd.StartDaemon()
 
 		logger.Info().Msg("daemon terminated")
 	},

--- a/cmd/client-daemon.go
+++ b/cmd/client-daemon.go
@@ -87,6 +87,8 @@ var clientDaemonCmd = &cobra.Command{
 	},
 }
 
+func (c *Client) 
+
 func (c *Client) startNATSService() {
 	// create a subscription to NATS commands from the orchestrator first
 	go c.subscribeToCommands(300)

--- a/cmd/client-daemon.go
+++ b/cmd/client-daemon.go
@@ -2,22 +2,16 @@ package cmd
 
 import (
 	"flag"
-	"fmt"
+	"net/rpc"
 	"os"
-	"os/exec"
 	"syscall"
 	"time"
 
+	"github.com/cedana/cedana/api"
+	"github.com/cedana/cedana/utils"
 	gd "github.com/sevlyar/go-daemon"
 	"github.com/spf13/cobra"
-
-	cedana "github.com/cedana/cedana/types"
 )
-
-func init() {
-	clientCommand.AddCommand(clientDaemonCmd)
-	clientDaemonCmd.Flags().Int32VarP(&pid, "pid", "p", 0, "pid to manage")
-}
 
 var stop = make(chan struct{})
 var done = make(chan struct{})
@@ -27,25 +21,15 @@ var clientDaemonCmd = &cobra.Command{
 	Use:   "daemon",
 	Short: "Start daemon for cedana client. Must be run as root, needed for all other cedana functionality.",
 	Run: func(cmd *cobra.Command, args []string) {
-		c, err := InstantiateClient()
-		if err != nil {
-			c.logger.Fatal().Err(err).Msg("Could not instantiate client")
-		}
 
-		c.Process.PID = pid
+		logger := utils.GetLogger()
 
-		if dir == "" {
-			dir = c.config.SharedStorage.DumpStorageDir
-		}
-
-		// verify channels exist to listen on
-		if c.channels == nil {
-			c.logger.Fatal().Msg("Dump and restore channels uninitialized!")
-		}
+		cd := api.NewDaemon()
+		rpc.Register(cd)
 
 		executable, err := os.Executable()
 		if err != nil {
-			c.logger.Fatal().Msg("Could not find cedana executable")
+			logger.Fatal().Msg("Could not find cedana executable")
 		}
 
 		ctx := &gd.Context{
@@ -55,14 +39,14 @@ var clientDaemonCmd = &cobra.Command{
 			LogFilePerm: 0o664,
 			WorkDir:     "./",
 			Umask:       027,
-			Args:        []string{executable, "client", "daemon", "-p", fmt.Sprint(pid)},
+			Args:        []string{executable, "client", "daemon"},
 		}
 
 		gd.AddCommand(gd.StringFlag(daemonSignal, "stop"), syscall.SIGTERM, termHandler)
 
 		d, err := ctx.Reborn()
 		if err != nil {
-			c.logger.Err(err).Msg("could not start daemon")
+			logger.Err(err).Msg("could not start daemon")
 		}
 
 		if d != nil {
@@ -71,148 +55,17 @@ var clientDaemonCmd = &cobra.Command{
 
 		defer ctx.Release()
 
-		c.logger.Info().Msgf("daemon started at %s", time.Now().Local())
-
-		// start daemon worker with state subscribers
-		dumpChn := c.channels.dumpCmdBroadcaster.Subscribe()
-		restoreChn := c.channels.restoreCmdBroadcaster.Subscribe()
-		go c.startDaemon(pid, dumpChn, restoreChn)
+		logger.Info().Msgf("daemon started at %s", time.Now().Local())
 
 		err = gd.ServeSignals()
 		if err != nil {
-			c.logger.Fatal().Err(err)
+			logger.Fatal().Err(err)
 		}
 
-		c.logger.Info().Msg("daemon terminated")
+		go cd.StartDaemon()
+
+		logger.Info().Msg("daemon terminated")
 	},
-}
-
-func (c *Client) 
-
-func (c *Client) startNATSService() {
-	// create a subscription to NATS commands from the orchestrator first
-	go c.subscribeToCommands(300)
-
-	if pid == 0 {
-		err := c.tryStartJob()
-		// if we hit an error here, unrecoverable
-		if err != nil {
-			c.logger.Fatal().Err(err).Msg("could not start job")
-		}
-	}
-
-	go c.publishStateContinuous(30)
-
-}
-
-func (c *Client) tryStartJob() error {
-	var task string = c.config.Client.Task
-	// 5 attempts arbitrarily chosen - up to the orchestrator to send the correct task
-	var err error
-	for i := 0; i < 5; i++ {
-		pid, err := c.RunTask(task)
-		if err == nil {
-			c.logger.Info().Msgf("managing process with pid %d", pid)
-			c.state.Flag = cedana.JobRunning
-			c.Process.PID = pid
-			break
-		} else {
-			// enter a failure state, where we wait indefinitely for a command from NATS instead of
-			// continuing
-			c.logger.Info().Msgf("failed to run task with error: %v, attempt %d", err, i+1)
-			c.state.Flag = cedana.JobStartupFailed
-			recoveryCmd := c.enterDoomLoop()
-			task = recoveryCmd.UpdatedTask
-		}
-	}
-
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (c *Client) RunTask(task string) (int32, error) {
-	var pid int32
-
-	if task == "" {
-		return 0, fmt.Errorf("could not find task in config")
-	}
-
-	// need a more resilient/retriable way of doing this
-	r, w, err := os.Pipe()
-	if err != nil {
-		return 0, err
-	}
-
-	nullFile, err := os.OpenFile(os.DevNull, os.O_WRONLY, 0)
-	if err != nil {
-		return 0, err
-	}
-
-	cmd := exec.Command("bash", "-c", task)
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setsid: true,
-	}
-
-	cmd.Stdin = nullFile
-	cmd.Stdout = w
-	cmd.Stderr = w
-
-	err = cmd.Start()
-	if err != nil {
-		return 0, err
-	}
-
-	pid = int32(cmd.Process.Pid)
-	ppid := int32(os.Getpid())
-
-	c.closeCommonFds(ppid, pid)
-
-	if c.config.Client.ForwardLogs {
-		go c.publishLogs(r, w)
-	}
-
-	return pid, nil
-}
-
-func (c *Client) startDaemon(pid int32, dumpChn chan int, restoreChn chan cedana.ServerCommand) {
-LOOP:
-	for {
-		select {
-		case <-dumpChn:
-			c.logger.Info().Msg("received checkpoint command from NATS server")
-			err := c.Dump(dir)
-			if err != nil {
-				// we don't want the daemon blowing up, so don't pass the error up
-				c.logger.Warn().Msgf("could not checkpoint with error: %v", err)
-				c.state.CheckpointState = cedana.CheckpointFailed
-				c.publishStateOnce(c.getState(c.Process.PID))
-			}
-			c.state.CheckpointState = cedana.CheckpointSuccess
-			c.publishStateOnce(c.getState(c.Process.PID))
-
-		case cmd := <-restoreChn:
-			// same here - want the restore to be retriable in the future, so makes sense not to blow it up
-			c.logger.Info().Msg("received restore command from the NATS server")
-			err := c.Restore(&cmd, nil)
-			if err != nil {
-				c.logger.Warn().Msgf("could not restore with error: %v", err)
-				c.state.CheckpointState = cedana.RestoreFailed
-				c.publishStateOnce(c.getState(c.Process.PID))
-			}
-			c.state.CheckpointState = cedana.RestoreSuccess
-			c.publishStateOnce(c.getState(c.Process.PID))
-
-		case <-stop:
-			c.logger.Info().Msg("stop hit")
-			break LOOP
-
-		default:
-			time.Sleep(1 * time.Second)
-		}
-	}
 }
 
 func termHandler(sig os.Signal) error {
@@ -221,4 +74,8 @@ func termHandler(sig os.Signal) error {
 		<-done
 	}
 	return gd.ErrStop
+}
+
+func init() {
+	rootCmd.AddCommand(clientDaemonCmd)
 }

--- a/cmd/client-daemon.go
+++ b/cmd/client-daemon.go
@@ -24,7 +24,7 @@ var clientDaemonCmd = &cobra.Command{
 
 		logger := utils.GetLogger()
 
-		cd := api.NewDaemon()
+		cd := api.NewDaemon(stop)
 		rpc.Register(cd)
 
 		executable, err := os.Executable()

--- a/cmd/client.go
+++ b/cmd/client.go
@@ -33,9 +33,8 @@ var AppFs = afero.NewOsFs()
 type Client struct {
 	CRIU *utils.Criu
 
-	nc  *nats.Conn
-	js  jetstream.JetStream
-	jsc nats.JetStreamContext
+	nc *nats.Conn
+	js jetstream.JetStream
 
 	logger *zerolog.Logger
 	config *utils.Config
@@ -146,29 +145,12 @@ func InstantiateClient() (*Client, error) {
 }
 
 // Layers daemon capabilities onto client (adding nats, jetstream and jetstream contexts)
-func (c *Client) AddDaemonLayer() error {
-	// get ids. TODO NR: uuid verification
-	// these should also be added to the config just in case
-	// TODO NR: some code kicking around too to transfer b/ween stuff in config and stuff in env
-	selfId, exists := os.LookupEnv("CEDANA_CLIENT_ID")
-	if !exists {
-		c.logger.Fatal().Msg("Could not find CEDANA_CLIENT_ID - something went wrong during instance creation")
-	}
-	c.selfId = selfId
 
-	jobId, exists := os.LookupEnv("CEDANA_JOB_ID")
-	if !exists {
-		c.logger.Fatal().Msg("Could not find CEDANA_JOB_ID - something went wrong during instance creation")
-	}
-	c.jobId = jobId
+func (c *Client) AddNATS(selfID, jobID, authToken string) error {
+	c.selfId = selfID
+	c.jobId = jobID
 
-	authToken, exists := os.LookupEnv("CEDANA_AUTH_TOKEN")
-	if !exists {
-		c.logger.Fatal().Msg("Could not find CEDANA_AUTH_TOKEN - something went wrong during instance creation")
-	}
-
-	// connect to NATS
-	opts := []nats.Option{nats.Name(fmt.Sprintf("CEDANA_CLIENT_%s", selfId))}
+	opts := []nats.Option{nats.Name(fmt.Sprintf("CEDANA_CLIENT_%s", selfID))}
 	opts = setupConnOptions(opts, c.logger)
 	opts = append(opts, nats.Token(authToken))
 

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -26,7 +26,7 @@ var cfgCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Sprintf("config file used: %s", viper.GetViper().ConfigFileUsed())
+		fmt.Printf("config file used: %s", viper.GetViper().ConfigFileUsed())
 		// pretty print config for debugging to make sure it's been loaded correctly
 		prettyCfg, err := json.MarshalIndent(cfg, "", "  ")
 		if err != nil {

--- a/dev.sh
+++ b/dev.sh
@@ -12,4 +12,5 @@ echo $CEDANA_CONFIG > ~/.cedana/client_config.json
 
 
 ## start cedana 
-sudo CEDANA_CLIENT_ID=devclient CEDANA_JOB_ID=devjob CEDANA_AUTH_TOKEN=test ./cedana client daemon 
+sudo ./cedana daemon &
+& sudo CEDANA_CLIENT_ID=devclient CEDANA_JOB_ID=devjob CEDANA_AUTH_TOKEN=test ./cedana nats

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.18
 require (
 	github.com/checkpoint-restore/go-criu/v5 v5.3.0
 	github.com/docker/docker v24.0.4+incompatible
+	github.com/eapache/go-resiliency v1.4.0
 	github.com/glebarez/sqlite v1.9.0
 	github.com/google/uuid v1.3.0
 	github.com/nats-io/nats-server/v2 v2.9.21
@@ -16,6 +17,7 @@ require (
 	github.com/spf13/afero v1.9.5
 	github.com/spf13/cobra v1.5.0
 	golang.org/x/sys v0.10.0
+	golang.org/x/time v0.3.0
 	google.golang.org/protobuf v1.31.0
 	gorm.io/gorm v1.25.3
 )
@@ -30,7 +32,6 @@ require (
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
-	github.com/eapache/go-resiliency v1.4.0 // indirect
 	github.com/fsnotify/fsnotify v1.6.0 // indirect
 	github.com/glebarez/go-sqlite v1.21.2 // indirect
 	github.com/go-ole/go-ole v1.2.6 // indirect
@@ -79,7 +80,6 @@ require (
 	golang.org/x/mod v0.8.0 // indirect
 	golang.org/x/net v0.10.0 // indirect
 	golang.org/x/text v0.11.0 // indirect
-	golang.org/x/time v0.3.0 // indirect
 	golang.org/x/tools v0.6.0 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/test/benchmarks/Dockerfile
+++ b/test/benchmarks/Dockerfile
@@ -20,7 +20,6 @@ WORKDIR /cedana
 RUN pip install -r test/benchmarks/requirements
 
 
-RUN git checkout feat/ced-112
 ENV USER="root"
 RUN go build && ./cedana bootstrap 
 

--- a/test/benchmarks/dump_test.go
+++ b/test/benchmarks/dump_test.go
@@ -13,7 +13,7 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/cedana/cedana/cmd"
+	"github.com/cedana/cedana/api"
 	"github.com/cedana/cedana/utils"
 	"github.com/glebarez/sqlite"
 	"github.com/rs/xid"
@@ -65,7 +65,7 @@ func getFilenames(directoryPath string, prefix string) ([]string, error) {
 func BenchmarkDumpLoop(b *testing.B) {
 	skipCI(b)
 	dumpDir := "./benchmarking/temp/loop"
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -102,7 +102,7 @@ func BenchmarkDumpLoop(b *testing.B) {
 func BenchmarkDumpServer(b *testing.B) {
 	skipCI(b)
 	dumpDir := "./benchmarking/temp/server"
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -135,7 +135,7 @@ func BenchmarkDumpServer(b *testing.B) {
 func BenchmarkDumpPytorch(b *testing.B) {
 	skipCI(b)
 	dumpDir := "./benchmarking/temp/pytorch"
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -169,7 +169,7 @@ func BenchmarkDumpPytorch(b *testing.B) {
 func BenchmarkDumpPytorchVision(b *testing.B) {
 	skipCI(b)
 	dumpDir := "./benchmarking/temp/pytorch-vision"
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -206,7 +206,7 @@ func BenchmarkDumpPytorchRegression(b *testing.B) {
 
 	dumpDir := "./benchmarking/temp/pytorch-regression"
 
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -289,7 +289,7 @@ func ZipFileSize(filePath string) (int64, error) {
 	return size, nil
 }
 
-func LookForPid(c *cmd.Client, filename []string) ([]string, []int32, error) {
+func LookForPid(c *api.Client, filename []string) ([]string, []int32, error) {
 
 	var pidInt32s []int32
 	var fileNames []string
@@ -475,7 +475,7 @@ func TestMain(m *testing.M) {
 }
 
 func finalCleanup() {
-	c, _ := cmd.InstantiateClient()
+	c, _ := api.InstantiateClient()
 
 	pids, err := getFilenames("./benchmarking/pids/", "")
 

--- a/test/benchmarks/restore_test.go
+++ b/test/benchmarks/restore_test.go
@@ -7,12 +7,12 @@ import (
 	"syscall"
 	"testing"
 
-	"github.com/cedana/cedana/cmd"
+	"github.com/cedana/cedana/api"
 )
 
 func BenchmarkLoopRestore(b *testing.B) {
 	skipCI(b)
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -43,7 +43,7 @@ func BenchmarkLoopRestore(b *testing.B) {
 
 func BenchmarkServerRestore(b *testing.B) {
 	skipCI(b)
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -74,7 +74,7 @@ func BenchmarkServerRestore(b *testing.B) {
 
 func BenchmarkPytorchRestore(b *testing.B) {
 	skipCI(b)
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -106,7 +106,7 @@ func BenchmarkPytorchRestore(b *testing.B) {
 
 func BenchmarkRegressionRestore(b *testing.B) {
 	skipCI(b)
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -136,7 +136,7 @@ func BenchmarkRegressionRestore(b *testing.B) {
 }
 func BenchmarkVisionRestore(b *testing.B) {
 	skipCI(b)
-	c, err := cmd.InstantiateClient()
+	c, err := api.InstantiateClient()
 
 	if err != nil {
 		b.Errorf("Error in instantiateClient(): %v", err)
@@ -165,7 +165,7 @@ func BenchmarkVisionRestore(b *testing.B) {
 
 }
 
-func finishBenchmark(b *testing.B, c *cmd.Client) {
+func finishBenchmark(b *testing.B, c *api.Client) {
 	_, err := os.Stat("cedana_restore")
 	if err == nil {
 		os.RemoveAll("cedana_restore")
@@ -214,7 +214,7 @@ func setup(b *testing.B, dir string) (string, bool) {
 	return checkpoint, false
 }
 
-func destroyPid(b *testing.B, c *cmd.Client) {
+func destroyPid(b *testing.B, c *api.Client) {
 	pids, err := getFilenames("./benchmarking/pids/", "")
 
 	if err != nil {

--- a/test/benchmarks/restore_test.go
+++ b/test/benchmarks/restore_test.go
@@ -26,7 +26,7 @@ func BenchmarkLoopRestore(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := c.Restore(nil, &checkpoint)
+		_, err := c.Restore(nil, &checkpoint)
 		if err != nil {
 			b.Errorf("Error in c.restore(): %v", err)
 		}
@@ -57,7 +57,7 @@ func BenchmarkServerRestore(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := c.Restore(nil, &checkpoint)
+		_, err := c.Restore(nil, &checkpoint)
 		if err != nil {
 			b.Errorf("Error in c.restore(): %v", err)
 		}
@@ -88,7 +88,7 @@ func BenchmarkPytorchRestore(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := c.Restore(nil, &checkpoint)
+		_, err := c.Restore(nil, &checkpoint)
 		if err != nil {
 			b.Errorf("Error in c.restore(): %v", err)
 		}
@@ -120,7 +120,7 @@ func BenchmarkRegressionRestore(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := c.Restore(nil, &checkpoint)
+		_, err := c.Restore(nil, &checkpoint)
 		if err != nil {
 			b.Errorf("Error in c.restore(): %v", err)
 		}
@@ -150,7 +150,7 @@ func BenchmarkVisionRestore(b *testing.B) {
 	b.ResetTimer()
 
 	for i := 0; i < b.N; i++ {
-		err := c.Restore(nil, &checkpoint)
+		_, err := c.Restore(nil, &checkpoint)
 		if err != nil {
 			b.Errorf("Error in c.restore(): %v", err)
 		}

--- a/utils/override.go
+++ b/utils/override.go
@@ -29,7 +29,6 @@ func LoadOverrides(cdir string) (*ConfigClient, error) {
 	_, err := os.OpenFile(overridePath, 0, 0o644)
 	if errors.Is(err, os.ErrNotExist) {
 		// do nothing, drop and leave
-		fmt.Printf("No server overrides found..\n")
 		return nil, err
 	} else {
 		f, err := os.ReadFile(overridePath)


### PR DESCRIPTION
Bit of a refactor, moving code around so core capabilities can only be called via RPC. Daemon is now also more of a daemon, and listens on /tmp/cedana.sock. 

Still a lot of features to implement back, but purpose of this ticket is to gain back parity with what it was like pre-refactor.