### PR TITLE
Fix job running despite existing JID

### DIFF
--- a/api/process.go
+++ b/api/process.go
@@ -62,7 +62,6 @@ func (s *service) Start(ctx context.Context, args *task.StartArgs) (*task.StartR
 
 	s.logger.Info().Msgf("managing process with pid %d", pid)
 
-	// FIXME YA: Should kill process on any errors to fix inconsistent state
 	err = s.updateState(ctx, state.JID, state)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update state")

--- a/api/process.go
+++ b/api/process.go
@@ -54,10 +54,8 @@ func (s *service) Start(ctx context.Context, args *task.StartArgs) (*task.StartR
 	pid, err := s.run(ctx, args)
 	state.PID = pid
 	if err != nil {
-		// TODO BS: this should be at market level
 		s.logger.Error().Err(err).Msgf("failed to run task, attempt %d", 1)
 		return nil, status.Error(codes.Internal, "failed to run task")
-		// TODO BS: replace doom loop with just retrying from market
 	}
 
 	s.logger.Info().Msgf("managing process with pid %d", pid)


### PR DESCRIPTION
## Describe your changes
If an existing JID is given to `cedana exec ...`, the command fails, but the daemon is still running the job.

## Issue ticket number 
[CED-385 : Fix job running despite existing job ID error](https://linear.app/cedana/issue/CED-385/fix-job-running-despite-existing-job-id-error)

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.