### PR TITLE
Update job state after it finishes

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Build 
+name: Build
 
 on: [push]
 
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v4
         with:
-          go-version: '1.20'
+          go-version: '1.22'
 
       - name: Build
         run: go build -v ./...

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push]
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
   test:

--- a/api/process.go
+++ b/api/process.go
@@ -66,6 +66,10 @@ func (s *service) Start(ctx context.Context, args *task.StartArgs) (*task.StartR
 		return nil, status.Error(codes.Internal, "failed to run task")
 		// TODO BS: replace doom loop with just retrying from market
 	}
+	err = s.updateState(ctx, state.JID, state)
+	if err != nil {
+		s.logger.Warn().Err(err).Msg("failed to update state after starting job")
+	}
 
 	s.logger.Info().Msgf("managing process with pid %d", pid)
 
@@ -384,6 +388,7 @@ func (s *service) run(ctx context.Context, args *task.StartArgs) (int32, error) 
 			return
 		}
 		state.JobState = task.JobState_JOB_DONE
+		state.PID = pid
 		err = s.updateState(ctx, args.JID, state)
 		if err != nil {
 			s.logger.Warn().Err(err).Msg("failed to update state after job done")

--- a/api/process.go
+++ b/api/process.go
@@ -62,7 +62,6 @@ func (s *service) Start(ctx context.Context, args *task.StartArgs) (*task.StartR
 
 	s.logger.Info().Msgf("managing process with pid %d", pid)
 
-	// FIXME YA: Should kill process on any errors to fix inconsistent state
 	err = s.updateState(ctx, state.JID, state)
 	if err != nil {
 		s.logger.Error().Err(err).Msg("failed to update state")

--- a/api/process.go
+++ b/api/process.go
@@ -381,15 +381,15 @@ func (s *service) run(ctx context.Context, args *task.StartArgs) (int32, error) 
 		} else {
 			s.logger.Info().Int32("status", 0).Int32("PID", pid).Msg("process terminated")
 		}
-		ctx := context.WithoutCancel(ctx) // since this routine can outlive the parent
-		state, err := s.getState(ctx, args.JID)
+		childCtx := context.WithoutCancel(ctx) // since this routine can outlive the parent
+		state, err := s.getState(childCtx, args.JID)
 		if err != nil {
 			s.logger.Warn().Err(err).Msg("failed to get state after job done")
 			return
 		}
 		state.JobState = task.JobState_JOB_DONE
 		state.PID = pid
-		err = s.updateState(ctx, args.JID, state)
+		err = s.updateState(childCtx, args.JID, state)
 		if err != nil {
 			s.logger.Warn().Err(err).Msg("failed to update state after job done")
 		}


### PR DESCRIPTION
## Describe your changes
Once a job that is run via `cedana exec ...` finishes, the state in the DB is not updated. It should say JOB_DONE.

## Issue ticket number 
CED-386

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.