### PR TITLE
Add build->test dependency in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Test
 
-on: [push]
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types:
+      - completed
 
 jobs:
   test:


### PR DESCRIPTION
## Describe your changes
Currently, on the CI for cedana tests start even if the build fails. The base of PR is currently a failed build to test it out.

## Issue ticket number 
CED-388

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.