### PR TITLE
Update runc restore root argument to take keyword

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/cedana/cedana/api"
 	"github.com/cedana/cedana/api/services"
 	"github.com/cedana/cedana/api/services/task"
 	"github.com/rs/xid"
@@ -192,14 +191,8 @@ var dumpRuncCmd = &cobra.Command{
 		}
 		defer cts.Close()
 
-		rootPath := map[string]string{
-			"k8s":     api.K8S_RUNC_ROOT,
-			"docker":  api.DOCKER_RUNC_ROOT,
-			"default": api.DEFAULT_RUNC_ROOT,
-		}
-
-		root, _ := cmd.Flags().GetString(containerRootFlag)
-		if rootPath[root] == "" {
+		root, _ := cmd.Flags().GetString(rootFlag)
+		if runcRootPath[root] == "" {
 			logger.Error().Msgf("container root %s not supported", root)
 			return
 		}
@@ -238,7 +231,7 @@ var dumpRuncCmd = &cobra.Command{
 		}
 
 		dumpArgs := task.RuncDumpArgs{
-			Root: rootPath[root],
+			Root: runcRootPath[root],
 			// CheckpointPath: checkpointPath,
 			// FIXME YA: Where does this come from?
 			Pid:         int32(pid),
@@ -289,7 +282,7 @@ func init() {
 	dumpRuncCmd.Flags().StringP(idFlag, "i", "", "container id")
 	dumpRuncCmd.MarkFlagRequired(idFlag)
 	dumpRuncCmd.Flags().BoolP(tcpEstablishedFlag, "t", false, "tcp established")
-	dumpRuncCmd.Flags().StringP(containerRootFlag, "r", "k8s", "container root")
+	dumpRuncCmd.Flags().StringP(rootFlag, "r", "k8s", "container root")
 	dumpRuncCmd.Flags().BoolP(gpuEnabledFlag, "g", false, "gpu enabled")
 	dumpRuncCmd.Flags().IntP(pidFlag, "p", 0, "pid")
 	dumpRuncCmd.Flags().String(externalFlag, "", "external")

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -9,7 +9,6 @@ const (
 	rootFlag           = "root"
 	wdFlag             = "working-dir"
 	containerNameFlag  = "container-name"
-	containerRootFlag  = "container-root"
 	bundleFlag         = "bundle"
 	consoleSocketFlag  = "console-socket"
 	detachFlag         = "detach"

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -175,12 +175,16 @@ var runcRestoreCmd = &cobra.Command{
 		defer cts.Close()
 
 		root, err := cmd.Flags().GetString(rootFlag)
+		if runcRootPath[root] == "" {
+			logger.Error().Msgf("container root %s not supported", root)
+			return
+		}
 		bundle, err := cmd.Flags().GetString(bundleFlag)
 		consoleSocket, err := cmd.Flags().GetString(consoleSocketFlag)
 		detach, err := cmd.Flags().GetBool(detachFlag)
 		netPid, err := cmd.Flags().GetInt32(netPidFlag)
 		opts := &task.RuncOpts{
-			Root:          root,
+			Root:          runcRootPath[root],
 			Bundle:        bundle,
 			ConsoleSocket: consoleSocket,
 			Detatch:       detach,
@@ -237,7 +241,7 @@ func init() {
 	runcRestoreCmd.Flags().StringP(bundleFlag, "b", "", "bundle path")
 	runcRestoreCmd.MarkFlagRequired(bundleFlag)
 	runcRestoreCmd.Flags().StringP(consoleSocketFlag, "c", "", "console socket path")
-	runcRestoreCmd.Flags().StringP(rootFlag, "r", RuncRootDir, "runc root directory")
+	runcRestoreCmd.Flags().StringP(rootFlag, "r", runcRootPath["default"], "runc root directory")
 	runcRestoreCmd.Flags().BoolP(detachFlag, "e", false, "run runc container in detached mode")
 	runcRestoreCmd.Flags().Bool(isK3sFlag, false, "pass whether or not we are checkpointing a container in a k3s agent")
 	runcRestoreCmd.Flags().Int32P(netPidFlag, "n", 0, "provide the network pid to restore to in k3s")

--- a/cmd/runc.go
+++ b/cmd/runc.go
@@ -1,13 +1,18 @@
 package cmd
 
 import (
+	"github.com/cedana/cedana/api"
 	"github.com/cedana/cedana/api/services"
 	"github.com/cedana/cedana/api/services/task"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
 )
 
-const RuncRootDir = "/var/run/runc"
+var runcRootPath = map[string]string{
+	"k8s":     api.K8S_RUNC_ROOT,
+	"docker":  api.DOCKER_RUNC_ROOT,
+	"default": api.DEFAULT_RUNC_ROOT,
+}
 
 var runcCmd = &cobra.Command{
 	Use:   "runc",
@@ -46,7 +51,7 @@ var runcGetRuncIdByName = &cobra.Command{
 }
 
 func init() {
-	runcGetRuncIdByName.Flags().StringP(rootFlag, "r", RuncRootDir, "runc root directory")
+	runcGetRuncIdByName.Flags().StringP(rootFlag, "r", runcRootPath["default"], "runc root directory")
 	runcCmd.AddCommand(runcGetRuncIdByName)
 
 	rootCmd.AddCommand(runcCmd)


### PR DESCRIPTION
## Describe your changes
The base of the PR is intentionally `feat/ced-355`, to avoid conflicts.
For cedana restore runc ..., currently the argument needs absolute path, unlike its dump counterpart. This PR fixes that.

## Issue ticket number 
CED-391

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 

