### PR TITLE
resolve containerd rootfs restores

### DIFF
--- a/api/containerd.go
+++ b/api/containerd.go
@@ -87,7 +87,7 @@ func (s *service) ContainerdQuery(ctx context.Context, args *task.ContainerdQuer
 
 func (s *service) ContainerdRootfsDump(ctx context.Context, args *task.ContainerdRootfsDumpArgs) (*task.ContainerdRootfsDumpResp, error) {
 
-	containerdService, err := containerd.New(ctx, args.Address)
+	containerdService, err := containerd.New(ctx, args.Address, s.logger)
 	if err != nil {
 		return &task.ContainerdRootfsDumpResp{}, err
 	}
@@ -103,7 +103,7 @@ func (s *service) ContainerdRootfsDump(ctx context.Context, args *task.Container
 func (s *service) ContainerdRootfsRestore(ctx context.Context, args *task.ContainerdRootfsRestoreArgs) (*task.ContainerdRootfsRestoreResp, error) {
 	resp := &task.ContainerdRootfsRestoreResp{}
 
-	containerdService, err := containerd.New(ctx, args.Address)
+	containerdService, err := containerd.New(ctx, args.Address, s.logger)
 	if err != nil {
 		return resp, err
 	}

--- a/api/containerd/containerd.go
+++ b/api/containerd/containerd.go
@@ -42,7 +42,7 @@ func New(ctx context.Context, address string, logger *zerolog.Logger) (*Containe
 func (service *ContainerdService) DumpRootfs(ctx context.Context, containerID, imageRef, ns string) (string, error) {
 	ctx = namespaces.WithNamespace(ctx, ns)
 
-	if err := container.ContainerdCheckpoint(ctx, service.client, containerID, imageRef); err != nil {
+	if err := container.ContainerdRootfsCheckpoint(ctx, service.client, containerID, imageRef); err != nil {
 		return "", err
 	}
 
@@ -71,6 +71,7 @@ func (service *ContainerdService) RestoreRootfs(ctx context.Context, containerID
 		containerd.WithRestoreSpec,
 	}
 
+	// complete rootfs restore using containerd client
 	ctr, err := service.client.Restore(ctx, containerID, checkpoint, opts...)
 	if err != nil {
 		return err

--- a/api/containerd/containerd.go
+++ b/api/containerd/containerd.go
@@ -11,11 +11,13 @@ import (
 	"github.com/containerd/containerd/namespaces"
 	"github.com/containerd/errdefs"
 	"github.com/containerd/log"
+	"github.com/rs/zerolog"
 	"golang.org/x/net/context"
 )
 
 type ContainerdService struct {
 	client *containerd.Client
+	logger *zerolog.Logger
 }
 
 //func NewClient(context *cli.Context, opts ...containerd.Opt) (*containerd.Client, gocontext.Context, gocontext.CancelFunc, error) {
@@ -23,7 +25,7 @@ type ContainerdService struct {
 //opts = append(opts, timeoutOpt)
 //kclient, err := containerd.New(context.String("address"), opts...)
 
-func New(ctx context.Context, address string) (*ContainerdService, error) {
+func New(ctx context.Context, address string, logger *zerolog.Logger) (*ContainerdService, error) {
 
 	client, err := containerd.New(address)
 
@@ -31,7 +33,10 @@ func New(ctx context.Context, address string) (*ContainerdService, error) {
 		return nil, err
 	}
 
-	return &ContainerdService{client}, nil
+	return &ContainerdService{
+		client,
+		logger,
+	}, nil
 }
 
 func (service *ContainerdService) DumpRootfs(ctx context.Context, containerID, imageRef, ns string) (string, error) {
@@ -63,6 +68,7 @@ func (service *ContainerdService) RestoreRootfs(ctx context.Context, containerID
 		containerd.WithRestoreImage,
 		containerd.WithRestoreRuntime,
 		containerd.WithRestoreRW,
+		containerd.WithRestoreSpec,
 	}
 
 	ctr, err := service.client.Restore(ctx, containerID, checkpoint, opts...)

--- a/api/containerd/containerd.go
+++ b/api/containerd/containerd.go
@@ -90,7 +90,6 @@ func (service *ContainerdService) RestoreRootfs(ctx context.Context, containerID
 
 	opts := []containerd.RestoreOpts{
 		containerd.WithRestoreImage,
-		containerd.WithRestoreSpec,
 		containerd.WithRestoreRuntime,
 		containerd.WithRestoreRW,
 	}

--- a/api/dump.go
+++ b/api/dump.go
@@ -222,17 +222,12 @@ func (s *service) runcDump(ctx context.Context, root, containerID string, pid in
 }
 
 func (s *service) containerdDump(ctx context.Context, imagePath, containerID string, state *task.ProcessState) error {
-	err := container.ContainerdCheckpoint(imagePath, containerID)
-	if err != nil {
-		s.logger.Fatal().Err(err)
-		return err
-	}
 
 	// CRIU ntfy hooks get run before this,
 	// so have to ensure that image files aren't tampered with
 	s.postDump(ctx, imagePath, state)
 
-	return err
+	return nil
 }
 
 func (s *service) dump(ctx context.Context, state *task.ProcessState, args *task.DumpArgs) error {

--- a/api/services/cts.go
+++ b/api/services/cts.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	DEFAULT_PROCESS_DEADLINE    = 20 * time.Minute
-	DEFAULT_CONTAINERD_DEADLINE = 1 * time.Minute
+	DEFAULT_CONTAINERD_DEADLINE = 10 * time.Minute
 	DEFAULT_RUNC_DEADLINE       = 1 * time.Minute
 )
 

--- a/container/checkpoint.go
+++ b/container/checkpoint.go
@@ -1005,7 +1005,8 @@ func ContainerdCheckpoint(ctx context.Context, containerdClient *containerd.Clie
 	}
 
 	containerdContainer := &ContainerdContainer{
-		client: containerdClient,
+		Container: container,
+		client:    containerdClient,
 	}
 
 	task, err := container.Task(ctx, nil)

--- a/container/checkpoint.go
+++ b/container/checkpoint.go
@@ -985,7 +985,8 @@ type ContainerdContainer struct {
 	client *containerd.Client
 }
 
-func ContainerdCheckpoint(ctx context.Context, containerdClient *containerd.Client, id, ref string) error {
+// for a full containerd checkpoint, we'd use the runc checkpointing primitives + rootfs
+func ContainerdRootfsCheckpoint(ctx context.Context, containerdClient *containerd.Client, id, ref string) error {
 
 	containers, err := containerdClient.Containers(ctx)
 	if err != nil {

--- a/container/checkpoint.go
+++ b/container/checkpoint.go
@@ -890,6 +890,7 @@ func localCheckpointTask(ctx gocontext.Context, client *containerd.Client, index
 		if err != nil {
 			return &apiTasks.CheckpointTaskResponse{}, err
 		}
+
 		criuOpts.ImagesDirectory = image
 		fmt.Printf("Checkpointing to %s\n", image)
 		defer os.RemoveAll(image)
@@ -901,6 +902,11 @@ func localCheckpointTask(ctx gocontext.Context, client *containerd.Client, index
 	if err != nil {
 		return &apiTasks.CheckpointTaskResponse{}, err
 	}
+
+	if err := os.WriteFile(filepath.Join(image, "spec"), data, 0777); err != nil {
+		return &apiTasks.CheckpointTaskResponse{}, err
+	}
+
 	spec := bytes.NewReader(data)
 	specD, err := localWriteContent(ctx, client, images.MediaTypeContainerd1CheckpointConfig, filepath.Join(image, "spec"), spec)
 	if err != nil {

--- a/container/checkpoint.go
+++ b/container/checkpoint.go
@@ -13,7 +13,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
-	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -902,11 +901,9 @@ func localCheckpointTask(ctx gocontext.Context, client *containerd.Client, index
 	if err != nil {
 		return &apiTasks.CheckpointTaskResponse{}, err
 	}
-
 	if err := os.WriteFile(filepath.Join(image, "spec"), data, 0777); err != nil {
 		return &apiTasks.CheckpointTaskResponse{}, err
 	}
-
 	spec := bytes.NewReader(data)
 	specD, err := localWriteContent(ctx, client, images.MediaTypeContainerd1CheckpointConfig, filepath.Join(image, "spec"), spec)
 	if err != nil {
@@ -1069,21 +1066,6 @@ func WithCheckpointState(ctx context.Context, client *containerd.Client, c *cont
 		})
 	}
 
-	// save copts
-	data, err := proto.Marshal(any)
-	if err != nil {
-		return err
-	}
-	r := bytes.NewReader(data)
-	desc, err := writeContent(ctx, client.ContentStore(), images.MediaTypeContainerd1CheckpointOptions, c.ID+"-checkpoint-options", r)
-	if err != nil {
-		return err
-	}
-	desc.Platform = &imagespec.Platform{
-		OS:           runtime.GOOS,
-		Architecture: runtime.GOARCH,
-	}
-	index.Manifests = append(index.Manifests, desc)
 	return nil
 }
 

--- a/container/checkpoint.go
+++ b/container/checkpoint.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"sync"
 	"syscall"
@@ -28,10 +29,10 @@ import (
 	"github.com/checkpoint-restore/go-criu/v6"
 	criurpc "github.com/checkpoint-restore/go-criu/v6/rpc"
 	containerd "github.com/containerd/containerd"
+	"github.com/containerd/containerd/api/services/tasks/v1"
 	apiTasks "github.com/containerd/containerd/api/services/tasks/v1"
 	"github.com/containerd/containerd/api/types"
 	containerdTypes "github.com/containerd/containerd/api/types"
-	"github.com/containerd/containerd/archive"
 	"github.com/containerd/containerd/containers"
 	"github.com/containerd/containerd/content"
 	"github.com/containerd/containerd/diff"
@@ -55,6 +56,7 @@ import (
 	"github.com/opencontainers/go-digest"
 	is "github.com/opencontainers/image-spec/specs-go"
 	ver "github.com/opencontainers/image-spec/specs-go"
+	imagespec "github.com/opencontainers/image-spec/specs-go/v1"
 	ocispec "github.com/opencontainers/image-spec/specs-go/v1"
 	v1 "github.com/opencontainers/image-spec/specs-go/v1"
 	"github.com/rs/zerolog"
@@ -773,7 +775,7 @@ func AppContext(context gocontext.Context) (gocontext.Context, gocontext.CancelF
 	return ctx, cancel
 }
 
-func ContainerdCheckpoint(imagePath, id string) error {
+func containerdCheckpoint(imagePath, id string) error {
 	logger := utils.GetLogger()
 
 	ctx := gocontext.Background()
@@ -883,10 +885,7 @@ func localCheckpointTask(ctx gocontext.Context, client *containerd.Client, index
 
 	image := opts.ImagePath
 
-	checkpointImageExists := false
-
 	if image == "" {
-		checkpointImageExists = true
 		image, err = os.MkdirTemp(os.Getenv("XDG_RUNTIME_DIR"), "ctrd-checkpoint")
 		if err != nil {
 			return &apiTasks.CheckpointTaskResponse{}, err
@@ -896,39 +895,6 @@ func localCheckpointTask(ctx gocontext.Context, client *containerd.Client, index
 		defer os.RemoveAll(image)
 	}
 
-	root := "/run/containerd/runc/default"
-
-	// EKS
-	_, err = os.Stat(root)
-	if err != nil {
-		root = "/run/containerd/runc/k8s.io"
-	}
-
-	c := GetContainerFromRunc(container.ID, root)
-
-	err = c.RuncCheckpoint(criuOpts, c.Pid, root, c.Config)
-	if err != nil {
-		return nil, err
-	}
-
-	// do not commit checkpoint image if checkpoint ImagePath is passed,
-	// return if checkpointImageExists is false
-	if !checkpointImageExists {
-		return &apiTasks.CheckpointTaskResponse{}, nil
-	}
-	// write checkpoint to the content store
-	tar := archive.Diff(ctx, "", image)
-	cp, err := localWriteContent(ctx, client, images.MediaTypeContainerd1Checkpoint, image, tar)
-	if err != nil {
-		return nil, err
-	}
-	// close tar first after write
-	if err := tar.Close(); err != nil {
-		return &apiTasks.CheckpointTaskResponse{}, err
-	}
-	if err != nil {
-		return &apiTasks.CheckpointTaskResponse{}, err
-	}
 	// write the config to the content store
 	pbany := protobuf.FromAny(container.Spec)
 	data, err := proto.Marshal(pbany)
@@ -942,7 +908,6 @@ func localCheckpointTask(ctx gocontext.Context, client *containerd.Client, index
 	}
 	return &apiTasks.CheckpointTaskResponse{
 		Descriptors: []*containerdTypes.Descriptor{
-			cp,
 			specD,
 		},
 	}, nil
@@ -1012,7 +977,188 @@ func CheckRuntime(current, expected string) bool {
 	return true
 }
 
-func runcCheckpointContainerd(ctx gocontext.Context, client *containerd.Client, task containerd.Task, opts ...CheckpointTaskOpts) (containerd.Image, error) {
+type ContainerdContainer struct {
+	containerd.Container
+	client *containerd.Client
+}
+
+func ContainerdCheckpoint(ctx context.Context, containerdClient *containerd.Client, id, ref string) error {
+
+	containers, err := containerdClient.Containers(ctx)
+	if err != nil {
+		return err
+	}
+	for _, container := range containers {
+		fmt.Println(container.ID())
+	}
+
+	opts := []containerd.CheckpointOpts{
+		containerd.WithCheckpointRuntime,
+		containerd.WithCheckpointImage,
+		containerd.WithCheckpointRW,
+		WithCheckpointState,
+	}
+
+	container, err := containerdClient.LoadContainer(ctx, id)
+	if err != nil {
+		return err
+	}
+
+	containerdContainer := &ContainerdContainer{
+		client: containerdClient,
+	}
+
+	task, err := container.Task(ctx, nil)
+	if err != nil {
+		if !errdefs.IsNotFound(err) {
+			return err
+		}
+	}
+	// pause if running
+	if task != nil {
+		if err := task.Pause(ctx); err != nil {
+			return err
+		}
+		defer func() {
+			if err := task.Resume(ctx); err != nil {
+				fmt.Println(fmt.Errorf("error resuming task: %w", err))
+			}
+		}()
+	}
+
+	if err := containerdContainer.ContainerCheckpointContainerd(ctx, ref, opts...); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func WithCheckpointState(ctx context.Context, client *containerd.Client, c *containers.Container, index *imagespec.Index, copts *options.CheckpointOptions) error {
+	any, err := protobuf.MarshalAnyToProto(copts)
+	if err != nil {
+		return nil
+	}
+
+	request := &tasks.CheckpointTaskRequest{
+		ContainerID: c.ID,
+		Options:     any,
+	}
+
+	response, err := localCheckpointTask(ctx, client, index, request, *c)
+	if err != nil {
+		return err
+	}
+
+	for _, d := range response.Descriptors {
+		index.Manifests = append(index.Manifests, v1.Descriptor{
+			MediaType: d.MediaType,
+			Size:      d.Size,
+			Digest:    digest.Digest(d.Digest),
+			Platform: &v1.Platform{
+				OS:           goruntime.GOOS,
+				Architecture: goruntime.GOARCH,
+			},
+			Annotations: d.Annotations,
+		})
+	}
+
+	// save copts
+	data, err := proto.Marshal(any)
+	if err != nil {
+		return err
+	}
+	r := bytes.NewReader(data)
+	desc, err := writeContent(ctx, client.ContentStore(), images.MediaTypeContainerd1CheckpointOptions, c.ID+"-checkpoint-options", r)
+	if err != nil {
+		return err
+	}
+	desc.Platform = &imagespec.Platform{
+		OS:           runtime.GOOS,
+		Architecture: runtime.GOARCH,
+	}
+	index.Manifests = append(index.Manifests, desc)
+	return nil
+}
+
+func (c *ContainerdContainer) ContainerCheckpointContainerd(ctx context.Context, ref string, opts ...containerd.CheckpointOpts) error {
+
+	index := &ocispec.Index{
+		Versioned: ver.Versioned{
+			SchemaVersion: 2,
+		},
+		Annotations: make(map[string]string),
+	}
+	copts := &options.CheckpointOptions{
+		Exit:                false,
+		OpenTcp:             false,
+		ExternalUnixSockets: false,
+		Terminal:            false,
+		FileLocks:           true,
+		EmptyNamespaces:     nil,
+	}
+	info, err := c.Info(ctx)
+	if err != nil {
+		return err
+	}
+
+	img, err := c.Image(ctx)
+	if err != nil {
+		return err
+	}
+
+	ctx, done, err := c.client.WithLease(ctx)
+	if err != nil {
+		return err
+	}
+	defer done(ctx)
+
+	// add image name to manifest
+	index.Annotations[ocispec.AnnotationRefName] = img.Name()
+	// add runtime info to index
+	index.Annotations[checkpointRuntimeNameLabel] = info.Runtime.Name
+	// add snapshotter info to index
+	index.Annotations[checkpointSnapshotterNameLabel] = info.Snapshotter
+
+	// process remaining opts
+	for _, o := range opts {
+		if err := o(ctx, c.client, &info, index, copts); err != nil {
+			err = errdefs.FromGRPC(err)
+			if !errdefs.IsAlreadyExists(err) {
+				return err
+			}
+		}
+	}
+
+	desc, err := writeRefIndex(ctx, index, c.client, c.ID()+"index")
+	if err != nil {
+		return err
+	}
+	i := images.Image{
+		Name:   ref,
+		Target: desc,
+	}
+
+	_, err = c.client.ImageService().Create(ctx, i)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func writeRefIndex(ctx context.Context, index *ocispec.Index, client *containerd.Client, ref string) (d ocispec.Descriptor, err error) {
+	labels := map[string]string{}
+	for i, m := range index.Manifests {
+		labels[fmt.Sprintf("containerd.io/gc.ref.content.%d", i)] = m.Digest.String()
+	}
+	data, err := json.Marshal(index)
+	if err != nil {
+		return ocispec.Descriptor{}, err
+	}
+	return writeContent(ctx, client.ContentStore(), ocispec.MediaTypeImageIndex, ref, bytes.NewReader(data), content.WithLabels(labels))
+}
+
+func RuncCheckpointContainerd(ctx gocontext.Context, client *containerd.Client, task containerd.Task, opts ...CheckpointTaskOpts) (containerd.Image, error) {
 	if ctx == nil {
 		ctx = gocontext.Background()
 	}
@@ -1231,7 +1377,6 @@ func snapshotOpts(id string) error {
 		containerd.WithCheckpointRuntime,
 		containerd.WithCheckpointImage,
 		containerd.WithCheckpointRW,
-		containerd.WithCheckpointTask,
 	}
 
 	containerdClient, err := containerd.New("/run/containerd/containerd.sock")

--- a/test/regression/helper.bash
+++ b/test/regression/helper.bash
@@ -32,8 +32,14 @@ rootfs_checkpoint() {
   local containerd_sock="$3"
   local namespace="$4"
 
-
   cedana dump rootfs -p "$container_id" --ref "$image_ref" -a "$containerd_sock" -n "$namespace"
 }
 
+rootfs_restore() {
+  local container_id="$1"
+  local image_ref="$2"
+  local containerd_sock="$3"
+  local namespace="$4"
 
+  cedana restore rootfs -p "$container_id" --ref "$image_ref" -a "$containerd_sock" -n "$namespace"
+}

--- a/test/regression/helper.bash
+++ b/test/regression/helper.bash
@@ -17,3 +17,23 @@ restore_task() {
     local job_id="$1"
     cedana restore job "$job_id"
 }
+
+start_busybox(){
+  local container_name="$1"
+
+  sudo ctr image pull docker.io/library/busybox:latest
+
+  sudo ctr run -d docker.io/library/busybox:latest "$container_name" sh -c 'while true; do sleep 3600; done'
+}
+
+rootfs_checkpoint() {
+  local container_id="$1"
+  local image_ref="$2"
+  local containerd_sock="$3"
+  local namespace="$4"
+
+
+  cedana dump rootfs -p "$container_id" --ref "$image_ref" -a "$containerd_sock" -n "$namespace"
+}
+
+

--- a/test/regression/main.bats
+++ b/test/regression/main.bats
@@ -13,7 +13,7 @@ load helper.bash
     [ -f /var/log/cedana-output.log ]
     sleep 2
     [ -s /var/log/cedana-output.log ]
-    
+
     # kill the process
     pid=$(ps -aux | grep $task | awk '{print $2}')
     kill -9 $pid
@@ -42,4 +42,19 @@ load helper.bash
     # kill the process
     pid=$(ps -aux | grep $task | awk '{print $2}')
     kill -9 $pid
+}
+
+@test "Rootfs snapshot reaches containerd image service" {
+  local container_id="busybox"
+  local image_ref="checkpoint/test:latest"
+  local containerd_sock="/run/containerd/containerd.sock"
+  local namespace="default"
+
+  local container_name="busybox"
+
+  run start_busybox $container_name
+  run rootfs_checkpoint $container_id $image_ref $containerd_sock $namespace
+
+  [[ "$output" -eq "$image_ref" ]]
+
 }

--- a/test/regression/main.bats
+++ b/test/regression/main.bats
@@ -44,17 +44,29 @@ load helper.bash
     kill -9 $pid
 }
 
-@test "Rootfs snapshot reaches containerd image service" {
-  local container_id="busybox"
+@test "Rootfs snapshot of containerd container" {
+  local container_id="busybox-test"
   local image_ref="checkpoint/test:latest"
   local containerd_sock="/run/containerd/containerd.sock"
   local namespace="default"
 
-  local container_name="busybox"
 
-  run start_busybox $container_name
+  run start_busybox $container_id
   run rootfs_checkpoint $container_id $image_ref $containerd_sock $namespace
+  echo "$output"
 
-  [[ "$output" -eq "$image_ref" ]]
+  [[ "$output" == *"$image_ref"* ]]
+}
 
+@test "Rootfs restore of containerd container" {
+  local container_id="busybox-test-restore"
+  local image_ref="checkpoint/test:latest"
+  local containerd_sock="/run/containerd/containerd.sock"
+  local namespace="default"
+
+
+  run rootfs_restore $container_id $image_ref $containerd_sock $namespace
+  echo "$output"
+
+  [[ "$output" == *"$image_ref"* ]]
 }


### PR DESCRIPTION
## Describe your changes
- Modified containerd checkpoint to use a custom config spec json opt
- Modify dumprootfs function to use this containerd checkpoint from `container/checkpoint.go`

## Issue ticket number 
[CED-395](https://linear.app/cedana/issue/CED-395/fix-rootfs-restore-invalid-media-type)

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 

