### PR TITLE
Skip external mounts from state.json during runc restore if not present

### DIFF
--- a/container/restore.go
+++ b/container/restore.go
@@ -159,21 +159,25 @@ func RuncRestore(imgPath string, containerId string, opts RuncOpts) error {
 		}
 	}
 
-	if opts.Root != "" {
+	if opts.StateRoot != "" {
 		var baseState libcontainer.BaseState
 
 		split := strings.Split(opts.Bundle, "/")
 		containerID := split[len(split)-1]
 
-		stateJsonPath := filepath.Join(opts.Root, containerID, "state.json")
+		stateJsonPath := filepath.Join(opts.StateRoot, containerID, "state.json")
 
-		if err := readJSON(stateJsonPath, &baseState); err != nil {
-			return err
-		}
+    // skip if the file does not exist
+		if _, err := os.Stat(stateJsonPath); err == nil {
+      // if it exists we dont accept an error
+			if err := readJSON(stateJsonPath, &baseState); err != nil {
+				return err
+			}
 
-		for _, m := range baseState.Config.Mounts {
-			if m.Device == "bind" {
-				externalMounts = append(externalMounts, fmt.Sprintf("mnt[%s]:%s", m.Destination, m.Source))
+			for _, m := range baseState.Config.Mounts {
+				if m.Device == "bind" {
+					externalMounts = append(externalMounts, fmt.Sprintf("mnt[%s]:%s", m.Destination, m.Source))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## Describe your changes
If the state.json is not found, simply prints a warning but proceed with restore.

## Issue ticket number 
CED-404

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 

