### PR TITLE
Fix exit status on errors

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -86,6 +86,7 @@ var startDaemonCmd = &cobra.Command{
 		err = api.StartServer(ctx)
 		if err != nil {
 			logger.Error().Err(err).Msgf("stopping daemon")
+			return err
 		}
 
 		return nil

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -25,20 +25,20 @@ var dumpProcessCmd = &cobra.Command{
 	Use:   "process",
 	Short: "Manually checkpoint a running process [pid] to a directory [-d]",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Msgf("Error creating client: %v", err)
-			return
+			return err
 		}
 		defer cts.Close()
 
 		pid, err := strconv.Atoi(args[0])
 		if err != nil {
 			logger.Error().Msgf("Error parsing pid: %v", err)
-			return
+			return err
 		}
 
 		id := xid.New().String()
@@ -50,7 +50,7 @@ var dumpProcessCmd = &cobra.Command{
 			dir = viper.GetString("shared_storage.dump_storage_dir")
 			if dir == "" {
 				logger.Error().Msgf("no dump directory specified")
-				return
+				return err
 			}
 			logger.Info().Msgf("no directory specified as input, using %s from config", dir)
 		}
@@ -71,9 +71,11 @@ var dumpProcessCmd = &cobra.Command{
 			} else {
 				logger.Error().Msgf("Checkpoint task failed: %v", err)
 			}
-			return
+			return err
 		}
 		logger.Info().Msgf("Response: %v", resp.Message)
+
+		return nil
 	},
 }
 
@@ -86,14 +88,14 @@ var dumpJobCmd = &cobra.Command{
 		return nil
 	},
 	Short: "Manually checkpoint a running job to a directory [-d]",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 		// TODO NR - this needs to be extended to include container checkpoints
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Msgf("Error creating client: %v", err)
-			return
+			return err
 		}
 		defer cts.Close()
 
@@ -101,7 +103,7 @@ var dumpJobCmd = &cobra.Command{
 
 		if id == "" {
 			logger.Error().Msgf("no job id specified")
-			return
+			return err
 		}
 
 		dir, _ := cmd.Flags().GetString(dirFlag)
@@ -109,7 +111,7 @@ var dumpJobCmd = &cobra.Command{
 			dir = viper.GetString("shared_storage.dump_storage_dir")
 			if dir == "" {
 				logger.Error().Msgf("no dump directory specified")
-				return
+				return err
 			}
 			logger.Info().Msgf("no directory specified as input, using %s from config", dir)
 		}
@@ -137,9 +139,11 @@ var dumpJobCmd = &cobra.Command{
 			} else {
 				logger.Error().Err(err).Msgf("checkpoint task failed")
 			}
-			return
+			return err
 		}
 		logger.Info().Msgf("Response: %v", resp.Message)
+
+		return nil
 	},
 }
 
@@ -147,13 +151,13 @@ var dumpContainerdCmd = &cobra.Command{
 	Use:   "containerd",
 	Short: "Manually checkpoint a running container to a directory",
 	Args:  cobra.ArbitraryArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Msgf("Error creating client: %v", err)
-			return
+			return err
 		}
 		defer cts.Close()
 
@@ -171,9 +175,11 @@ var dumpContainerdCmd = &cobra.Command{
 			} else {
 				logger.Error().Msgf("Checkpoint task failed: %v", err)
 			}
-			return
+			return err
 		}
 		logger.Info().Msgf("Response: %v", resp.Message)
+
+		return nil
 	},
 }
 
@@ -181,13 +187,13 @@ var dumpContainerdRootfsCmd = &cobra.Command{
 	Use:   "rootfs",
 	Short: "Manually checkpoint a running runc container's rootfs and bundle into an image",
 	Args:  cobra.ArbitraryArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Msgf("Error creating client: %v", err)
-			return
+			return err
 		}
 		defer cts.Close()
 
@@ -216,10 +222,11 @@ var dumpContainerdRootfsCmd = &cobra.Command{
 			} else {
 				logger.Error().Msgf("Checkpoint rootfs failed: %v", err)
 			}
-			return
+			return err
 		}
 		logger.Info().Msgf("Saved rootfs and stored in new image: %s", resp.ImageRef)
 
+		return nil
 	},
 }
 
@@ -227,20 +234,20 @@ var dumpRuncCmd = &cobra.Command{
 	Use:   "runc",
 	Short: "Manually checkpoint a running runc container to a directory",
 	Args:  cobra.ArbitraryArgs,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Msgf("Error creating client: %v", err)
-			return
+			return err
 		}
 		defer cts.Close()
 
 		root, _ := cmd.Flags().GetString(rootFlag)
 		if runcRootPath[root] == "" {
 			logger.Error().Msgf("container root %s not supported", root)
-			return
+			return err
 		}
 
 		dir, _ := cmd.Flags().GetString(dirFlag)
@@ -296,9 +303,11 @@ var dumpRuncCmd = &cobra.Command{
 			} else {
 				logger.Error().Msgf("Checkpoint task failed: %v", err)
 			}
-			return
+			return err
 		}
 		logger.Info().Msgf("Response: %v", resp.Message)
+
+		return nil
 	},
 }
 

--- a/cmd/exec.go
+++ b/cmd/exec.go
@@ -23,14 +23,14 @@ var execTaskCmd = &cobra.Command{
 		}
 		return nil
 	},
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Err(err).Msg("error creating client")
-			return
+			return err
 		}
 		defer cts.Close()
 
@@ -79,9 +79,11 @@ var execTaskCmd = &cobra.Command{
 			} else {
 				logger.Error().Err(err).Msg("start task failed")
 			}
-			return
+			return err
 		}
 		logger.Info().Msgf("Task started: %v", resp)
+
+		return nil
 	},
 }
 

--- a/cmd/helper.go
+++ b/cmd/helper.go
@@ -27,7 +27,7 @@ const (
 var helperCmd = &cobra.Command{
 	Use:   "k8s-helper",
 	Short: "Helper for Cedana running in Kubernetes",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 
@@ -45,6 +45,8 @@ var helperCmd = &cobra.Command{
 			}
 		}
 		startHelper(ctx, startChroot)
+
+		return nil
 	},
 }
 

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -17,13 +17,13 @@ import (
 var psCmd = &cobra.Command{
 	Use:   "ps",
 	Short: "List managed processes",
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Err(err).Msg("error creating client")
-			return
+			return err
 		}
 		defer cts.Close()
 
@@ -33,12 +33,12 @@ var psCmd = &cobra.Command{
 		resp, err := cts.Query(ctx, &task.QueryArgs{}) // get all processes
 		if err != nil {
 			logger.Error().Err(err).Msgf("error querying processes")
-			return
+			return err
 		}
 
 		if len(resp.Processes) == 0 {
 			fmt.Println("No managed processes")
-			return
+			return nil
 		}
 
 		for _, v := range resp.Processes {
@@ -58,6 +58,8 @@ var psCmd = &cobra.Command{
 		}
 
 		table.Render()
+
+		return nil
 	},
 }
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -38,5 +38,8 @@ func Execute(ctx context.Context) error {
 
 	rootCmd.Version = GetVersion()
 
+	// only show usage when true usage error
+	rootCmd.SilenceUsage = true
+
 	return rootCmd.ExecuteContext(ctx)
 }

--- a/cmd/runc.go
+++ b/cmd/runc.go
@@ -23,13 +23,13 @@ var runcGetRuncIdByName = &cobra.Command{
 	Use:   "get",
 	Short: "Get runc id by container name",
 	Args:  cobra.ExactArgs(1),
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
 		cts, err := services.NewClient()
 		if err != nil {
 			logger.Error().Msgf("Error creating client: %v", err)
-			return
+			return err
 		}
 		defer cts.Close()
 
@@ -44,9 +44,11 @@ var runcGetRuncIdByName = &cobra.Command{
 		resp, err := cts.RuncQuery(ctx, query)
 		if err != nil {
 			logger.Error().Err(err).Msgf("Container \"%s\" not found", name)
-			return
+			return err
 		}
 		logger.Info().Msgf("Response: %v", resp.Containers[0])
+
+		return nil
 	},
 }
 

--- a/main.go
+++ b/main.go
@@ -13,5 +13,7 @@ func main() {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
 
-	cmd.Execute(ctx)
+  if err := cmd.Execute(ctx); err != nil {
+    os.Exit(1)
+  }
 }


### PR DESCRIPTION
## Describe your changes
Currently, if the daemon or any other command in `cedana [cmd] …` results in an error, it does not exit with a non-zero code. This creates problems for the benchmark and tests that rely on error code to check for correct execution.

Also, fixes the issue where usage is printed even if it's not a usage error.

## Issue ticket number 
CED-415

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.