### PR TITLE
Relax daemon's runc context deadline

### DIFF
--- a/api/services/cts.go
+++ b/api/services/cts.go
@@ -15,7 +15,7 @@ import (
 const (
 	DEFAULT_PROCESS_DEADLINE    = 20 * time.Minute
 	DEFAULT_CONTAINERD_DEADLINE = 10 * time.Minute
-	DEFAULT_RUNC_DEADLINE       = 1 * time.Minute
+	DEFAULT_RUNC_DEADLINE       = 10 * time.Minute
 )
 
 type ServiceClient struct {


### PR DESCRIPTION
## Describe your changes
Currently, the deadline is causing issues with benchmarks when it runs some larger workloads. Deadline of 1 minute is too low.

## Issue ticket number 
CED-416

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.