### PR TITLE
readme: update checkpoint/restore examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ which also provides information about any local or remote checkpoints associated
 To checkpoint a running job, you can run:
 
 ```sh
-cedana client dump job JOBID -d DIR
+cedana dump job JOBID -d DIR
 ```
 A successsful `dump` creates a `process_name_datetime.tar` file in the directory specified with `-d`. Alternatively, you can forego the flag by describing a folder to store the checkpoint in in the config:
 
@@ -66,7 +66,7 @@ See the configuration section for more toggles.
 ### Restoring
 
 ```sh
-cedana client restore job JOBID
+cedana restore job JOBID
 ```
 
 Currently, we also support `runc` and by extension Docker, `containerd` checkpointing and more container runtime support planned in the future. It should be noted that container checkpointing is generally orchestrated externally, leading the CLI options to be a little janky.

--- a/README.md
+++ b/README.md
@@ -15,81 +15,81 @@ Some problems Cedana can help solve include:
 You can get started using cedana today (outside of the base checkpoint/restore functionality) by trying out our [CLI tool](https://github.com/cedana/cedana-cli) that leverages this system to arbitrage compute across clouds.
 
 
-## Build 
+## Build
 
 ```go build```
 
 
 ## Usage
 
-To use Cedana in a standalone context, you can directly checkpoint and restore processes with the cedana client. Configuration gets created at `~/.cedana/cedana_config.json` by calling `cedana bootstrap`. To use Cedana, you'll need to spin up the daemon, which is a simple gRPC daemon listening on 8080: 
+To use Cedana in a standalone context, you can directly checkpoint and restore processes with the cedana client. Configuration gets created at `~/.cedana/cedana_config.json` by calling `cedana bootstrap`. To use Cedana, you'll need to spin up the daemon, which is a simple gRPC daemon listening on 8080:
 
 ```sh
-sudo cedana daemon start 
+sudo cedana daemon start
 ```
 
-All further commands interact with the daemon over RPC. 
+All further commands interact with the daemon over RPC.
 
 
-## Launching Work 
+## Launching Work
 
-Using cedana, you can checkpoint PIDs already running on the system, but may run into issues around process groups and/or file descriptors and network sockets. To bridge this gap and make the jobs more migratable, you can launch processes or work using `cedana exec`. For example: 
+Using cedana, you can checkpoint PIDs already running on the system, but may run into issues around process groups and/or file descriptors and network sockets. To bridge this gap and make the jobs more migratable, you can launch processes or work using `cedana exec`. For example:
 
 ```sh
-cedana exec 'python3 example.py' example_job 
+cedana exec 'python3 example.py' example_job
 ```
 
-where example_job is a job id associated with your task. To see tasks managed by `cedana`, you can use: 
+where example_job is a job id associated with your task. To see tasks managed by `cedana`, you can use:
 
-```sh 
+```sh
 cedana ps
 ```
 
 which also provides information about any local or remote checkpoints associated with the id. There's additional arguments you can pass to `exec` (such as passing a file for environment variables to launch the process with) which you can explore with `--help`.
 
-### Checkpointing 
-To checkpoint a running job, you can run: 
+### Checkpointing
+To checkpoint a running job, you can run:
 
 ```sh
-cedana client dump job JOBID -d DIR 
+cedana client dump job JOBID -d DIR
 ```
-A successsful `dump` creates a `process_name_datetime.tar` file in the directory specified with `-d`. Alternatively, you can forego the flag by describing a folder to store the checkpoint in in the config: 
+A successsful `dump` creates a `process_name_datetime.tar` file in the directory specified with `-d`. Alternatively, you can forego the flag by describing a folder to store the checkpoint in in the config:
 
-```json 
+```json
 "shared_storage": {
     "dump_storage_dir": "/home/johnAdams/cedana_dumps/"
   }
 ```
 
-See the configuration section for more toggles. 
+See the configuration section for more toggles.
 
-### Restoring 
+### Restoring
 
-```sh 
+```sh
 cedana client restore job JOBID
 ```
 
 Currently, we also support `runc` and by extension Docker, `containerd` checkpointing and more container runtime support planned in the future. It should be noted that container checkpointing is generally orchestrated externally, leading the CLI options to be a little janky.
 
-Checkpointing these is as simple as prepending the `dump/restore` commands with the correct runtime. For example, to checkpoint a `containerd` container: 
+Checkpointing these is as simple as prepending the `dump/restore` commands with the correct runtime. For example, to checkpoint a `containerd` container:
 
-```sh 
-sudo cedana dump containerd -i test -p test 
+```sh
+sudo cedana dump containerd -i test -p test
 ```
 
-where `i` is the imageRef and `p` is the containerID. 
+where `i` is the imageRef and `p` is the containerID.
 
-For a Docker container (which generally wraps a runc runtime): 
+For a Docker container (which generally wraps a runc runtime):
 
 ```sh
 sudo cedana dump runc -i runcID -d DIRECTORY
 ```
 
-where `runcID` is the ID of the runc container (separate from what Docker daemon uses) which you can grab from `runc ps`. To restore, you'll need the container bundle, which you can pass to restore with `--bundle`. You can make a copy from a running container using `docker export CONTAINER_ID -o container_bundle.tar` and then: 
+where `runcID` is the ID of the runc container (separate from what Docker daemon uses) which you can grab from `runc ps`. To restore, you'll need the container bundle, which you can pass to restore with `--bundle`. You can make a copy from a running container using `docker export CONTAINER_ID -o container_bundle.tar` and then:
 
 ```sh
 sudo cedana restore --bundle container_bundle.tar -i new_runc_id -d DIRECTORY
 ```
 
 ## Contributing
-See CONTRIBUTING.md for guidelines. 
+See CONTRIBUTING.md for guidelines.


### PR DESCRIPTION
The `cedana client` command has been removed recently (https://github.com/cedana/cedana/pull/159). This pull request updates the checkpoint/restore examples in the README file to reflect these changes.