### PR TITLE
fix: missing buildah dep for crio rootfs c/r

### DIFF
--- a/scripts/k8s/setup-host.sh
+++ b/scripts/k8s/setup-host.sh
@@ -6,13 +6,13 @@ chroot /host <<"EOT"
 YUM_PACKAGES="wget git gcc make libnet-devel protobuf \
     protobuf-c protobuf-c-devel protobuf-c-compiler \
     protobuf-compiler protobuf-devel python3-protobuf \
-    libnl3-devel libcap-devel libseccomp-devel gpgme-devel btrfs-progs-devel"
+    libnl3-devel libcap-devel libseccomp-devel gpgme-devel btrfs-progs-devel buildah"
 
 APT_PACKAGES="wget git make libnl-3-dev libnet-dev \
     libbsd-dev libcap-dev pkg-config \
     libprotobuf-dev libprotobuf-c-dev protobuf-c-compiler pkg-config \
     protobuf-compiler python3-protobuf build-essential \
-    libgpgme-dev libseccomp-dev libbtrfs-dev"
+    libgpgme-dev libseccomp-dev libbtrfs-dev buildah"
 
 install_apt_packages() {
     apt-get update


### PR DESCRIPTION
## Describe your changes
- Added buildah install to k8s install script

## Issue ticket number 
n/a

## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the README if changes have resulted in it being out of date?
- [ ]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 

