### PR TITLE
Improve debugging capabilities of CI workflows

### DIFF
--- a/.github/workflows/benchmark-and-push.yml
+++ b/.github/workflows/benchmark-and-push.yml
@@ -42,6 +42,8 @@ jobs:
     - name: Setup tmate session
       uses: mxschmitt/action-tmate@v3
       if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_benchmark }}
+      with:
+        limit-access-to-actor: true
 
     - name: Setup CI
       run:  sudo -E make -C scripts/ci setup-full

--- a/.github/workflows/benchmark-and-push.yml
+++ b/.github/workflows/benchmark-and-push.yml
@@ -1,8 +1,14 @@
-name: Benchmark and Publish 
-on: 
-  schedule: 
+name: Benchmark and Publish
+on:
+  schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:
+      inputs:
+        debug_benchmark:
+          type: boolean
+          description: 'Run benchmark with tmate debugging enabled'
+          required: false
+          default: false
 
 # Cancel any preceding run on the pull request.
 concurrency:
@@ -11,14 +17,14 @@ concurrency:
 
 jobs:
    benchmark:
-    
+
     permissions:
       contents: 'read'
       packages: 'read'
       id-token: 'write'
 
     runs-on: ubicloud-standard-8
-    
+
     steps:
     - name: Checkout cedana
       uses: actions/checkout@v2
@@ -26,17 +32,22 @@ jobs:
     - id: 'auth'
       name: 'Authenticate to Google Cloud'
       uses: 'google-github-actions/auth@v1'
-      env: 
+      env:
         WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_POOL }}
       with:
         workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
         service_account: 'benchmark-uploader@cedana-benchmarking.iam.gserviceaccount.com'
 
+    # Enable tmate debugging of manually-triggered workflows if the input option was provided
+    - name: Setup tmate session
+      uses: mxschmitt/action-tmate@v3
+      if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_benchmark }}
+
     - name: Setup CI
       run:  sudo -E make -C scripts/ci setup-full
 
     - name: Run Benchmarking Script (${{ matrix.os }})
-      run: sudo -E make -C scripts/ci benchmark 
+      run: sudo -E make -C scripts/ci benchmark
       env:
         GOOGLE_APPLICATION_CREDENTIALS: ${{ steps.auth.outputs.credentials_file_path }}
         GOOGLE_CLOUD_PROJECT: ${{ steps.auth.outputs.project_id }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,14 @@
 name: Build
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+      inputs:
+        debug_build:
+          type: boolean
+          description: 'Run build with tmate debugging enabled'
+          required: false
+          default: false
 
 concurrency:
   group: cedana-build-${{ github.event.pull_request.number || github.ref }}
@@ -19,6 +27,11 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: '1.22'
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build }}
 
       - name: Setup CI
         run:  sudo -E make -C scripts/ci setup-build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build }}
+        with:
+          limit-access-to-actor: true
 
       - name: Setup CI
         run:  sudo -E make -C scripts/ci setup-build

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,26 @@
-name: Release 
+name: Release
 
 on:
-  push: 
-    tags: 
+  push:
+    tags:
       - '*'
+  workflow_dispatch:
+      inputs:
+        debug_release:
+          type: boolean
+          description: 'Run release with tmate debugging enabled'
+          required: false
+          default: false
+        debug_build_push_image_to_ghcr:
+          type: boolean
+          description: 'Run build & push (ghcr.io) with tmate debugging enabled'
+          required: false
+          default: false
+        debug_build_push_image_to_dockerhub:
+          type: boolean
+          description: 'Run build & push (dockerhub) with tmate debugging enabled'
+          required: false
+          default: false
 
 permissions:
   contents: write
@@ -27,8 +44,12 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v4
 
-      -
-        name: Install dependencies
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_release }}
+
+      - name: Install dependencies
         run: sudo -E make -C scripts/ci setup-build
       -
         name: Run GoReleaser
@@ -40,11 +61,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GORELEASER_GITHUB_TOKEN }}
 
-  build-and-push-image-to-ghcr: 
-    runs-on: ubuntu-latest 
+  build-and-push-image-to-ghcr:
+    runs-on: ubuntu-latest
     needs: release
 
-    permissions: 
+    permissions:
       contents: read
       packages: write
 
@@ -67,11 +88,16 @@ jobs:
         with:
           images: ghcr.io/cedana/cedana
 
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build_push_image_to_ghcr }}
+
       - name: Get the version
         id: get_version
         run: echo "VERSION=${GITHUB_REF#refs/tags/}" >> $GITHUB_OUTPUT
 
-      - name: Build and push 
+      - name: Build and push
         uses: docker/build-push-action@f2a1d5e99d037542a71f64918e516c093c6f3fc4
         with:
           context: .
@@ -106,6 +132,11 @@ jobs:
         uses: docker/metadata-action@v5
         with:
           images: cedana/cedana-helper
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build_push_image_to_dockerhub }}
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,6 +48,8 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_release }}
+        with:
+          limit-access-to-actor: true
 
       - name: Install dependencies
         run: sudo -E make -C scripts/ci setup-build
@@ -92,6 +94,8 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build_push_image_to_ghcr }}
+        with:
+          limit-access-to-actor: true
 
       - name: Get the version
         id: get_version
@@ -137,6 +141,8 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build_push_image_to_dockerhub }}
+        with:
+          limit-access-to-actor: true
 
       - name: Get the version
         id: get_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,19 @@
 name: Test
 
-on: [push]
+on:
+  push:
+  workflow_dispatch:
+      inputs:
+        debug_smoke_test:
+          type: boolean
+          description: 'Run smoke test with tmate debugging enabled'
+          required: false
+          default: false
+        debug_regression_test:
+          type: boolean
+          description: 'Run regression test with tmate debugging enabled'
+          required: false
+          default: false
 
 concurrency:
   group: cedana-test-${{ github.event.pull_request.number || github.ref }}
@@ -11,6 +24,11 @@ jobs:
     runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v3
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_smoke_test }}
 
       - name: Setup CI
         run:  sudo -E make -C scripts/ci setup-full
@@ -25,6 +43,11 @@ jobs:
     runs-on: ubicloud-standard-8
     steps:
       - uses: actions/checkout@v3
+
+      # Enable tmate debugging of manually-triggered workflows if the input option was provided
+      - name: Setup tmate session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_regression_test }}
 
       - name: Setup CI
         run:  sudo -E make -C scripts/ci setup-full

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_smoke_test }}
+        with:
+          limit-access-to-actor: true
 
       - name: Setup CI
         run:  sudo -E make -C scripts/ci setup-full
@@ -48,6 +50,8 @@ jobs:
       - name: Setup tmate session
         uses: mxschmitt/action-tmate@v3
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_regression_test }}
+        with:
+          limit-access-to-actor: true
 
       - name: Setup CI
         run:  sudo -E make -C scripts/ci setup-full


### PR DESCRIPTION
## Describe your changes
- Add an option to manually launch workflow with a Tmate SSH session. See https://github.com/marketplace/actions/debugging-with-tmate. Only actors who started the workflow can ssh using their private key.
- Upload missing logs to workflow artifacts where possible

## Issue ticket number 
CED-498

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.