### PR TITLE
Adds ability to login to ECR registries to push rootfs changes

### DIFF
--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -415,7 +415,13 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 		decodedAuthString := string(decodedAuthBytes)
 
+		logger.Debug().Msgf("decoded string: %s", decodedAuthString)
+
 		parts := strings.Split(decodedAuthString, ":")
+
+		if len(parts) != 2 {
+			return fmt.Errorf("decoded auth string is not correctly formatted")
+		}
 
 		loginOpts.Username = parts[0]
 		loginOpts.Password = parts[1]

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -417,7 +417,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 		logger.Debug().Msgf("decoded string: %s", decodedAuthString)
 
-		parts := strings.Split(decodedAuthString, ":")
+		parts := strings.Split(":", decodedAuthString)
 
 		if len(parts) != 2 {
 			return fmt.Errorf("decoded auth string is not correctly formatted")

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -2,6 +2,7 @@ package crio
 
 import (
 	"context"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -408,7 +409,9 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		}
 
 		loginOpts.Username = "AWS"
-		loginOpts.Password = *authData.AuthorizationToken
+		data := []byte(*authData.AuthorizationToken)
+		encodedStr := base64.StdEncoding.EncodeToString(data)
+		loginOpts.Password = encodedStr
 		// loginOpts.Stdin = strings.NewReader(proxyEndpoint)
 		loginArgs = append(loginArgs, proxyEndpoint)
 

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -409,6 +409,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 		loginOpts.Username = "AWS"
 		loginOpts.Password = *authData.AuthorizationToken
+		loginOpts.Stdin = strings.NewReader(proxyEndpoint)
 
 		if err := auth.Login(ctx, systemContext, loginOpts, loginArgs); err != nil {
 			return err

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -423,8 +423,11 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 			return fmt.Errorf("decoded auth string is not correctly formatted, %v", len(parts))
 		}
 
+		var stdoutBuilder strings.Builder
+
 		loginOpts.Username = parts[0]
 		loginOpts.Password = parts[1]
+		loginOpts.Stdout = &stdoutBuilder
 
 		loginArgs = append(loginArgs, proxyEndpoint)
 

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -364,7 +364,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 		logger.Debug().Msgf("auth token output: %v", authTokenOutput)
 	} else {
-		logger.Debug().Msgf("did not detect ecr registry: %v", strings.Contains(newImageRef, ".ecr.") && strings.HasSuffix(newImageRef, ".amazonaws.com"))
+		logger.Debug().Msgf("did not detect ecr registry: %v", strings.Contains(newImageRef, ".ecr.") && strings.Contains(newImageRef, ".amazonaws.com"))
 	}
 	//buildah push
 	cmd := exec.Command("buildah", "push", newImageRef)

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
 	ecr "github.com/aws/aws-sdk-go/service/ecr"
 	"github.com/cedana/cedana/api/runc"
@@ -349,7 +350,9 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 	}
 
 	if isECRRepo(newImageRef) {
-		session, err := session.NewSession()
+		session, err := session.NewSession(&aws.Config{
+			Region: aws.String("us-west-2"),
+		})
 		if err != nil {
 			return err
 		}

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -409,14 +409,16 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		}
 
 		loginOpts.Username = "AWS"
-		data := []byte(*authData.AuthorizationToken)
-		encodedStr := base64.StdEncoding.EncodeToString(data)
+		authBytes, err := json.Marshal(authData)
+		if err != nil {
+			return err
+		}
+		encodedStr := base64.StdEncoding.EncodeToString(authBytes)
 		loginOpts.Password = encodedStr
-		// loginOpts.Stdin = strings.NewReader(proxyEndpoint)
 		loginArgs = append(loginArgs, proxyEndpoint)
 
 		if err := auth.Login(ctx, systemContext, loginOpts, loginArgs); err != nil {
-			logger.Debug().Msgf("auth token: %s", *authData.AuthorizationToken)
+			logger.Debug().Msgf("auth token: %s", encodedStr)
 			return err
 		}
 

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -413,7 +413,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		// loginOpts.Stdin = strings.NewReader(proxyEndpoint)
 		loginArgs = append(loginArgs, proxyEndpoint)
 
-		if err := docker.CheckAuth(ctx, systemContext, loginOpts.Username, loginOpts.Password, *authData.ProxyEndpoint); err != nil {
+		if err := docker.CheckAuth(ctx, systemContext, loginOpts.Username, loginOpts.Password, proxyEndpoint); err != nil {
 			return err
 		}
 

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -351,6 +351,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 	if isECRRepo(newImageRef) {
 		session, err := session.NewSession(&aws.Config{
+			// TODO BS this needs to come from the user
 			Region: aws.String("us-west-2"),
 		})
 		if err != nil {
@@ -360,15 +361,14 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		input := &ecr.GetAuthorizationTokenInput{}
 
 		ecrRegistry := ecr.New(session)
-		authTokenOutput, err := ecrRegistry.GetAuthorizationToken(input)
+		_, err = ecrRegistry.GetAuthorizationToken(input)
 		if err != nil {
 			return err
 		}
-
-		logger.Debug().Msgf("auth token output: %v", authTokenOutput)
 	} else {
-		logger.Debug().Msgf("did not detect ecr registry: %v", strings.Contains(newImageRef, ".ecr.") && strings.Contains(newImageRef, ".amazonaws.com"))
+		logger.Debug().Msg("did not detect ecr registry")
 	}
+
 	//buildah push
 	cmd := exec.Command("buildah", "push", newImageRef)
 	out, err := cmd.CombinedOutput()

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -363,6 +363,8 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		}
 
 		logger.Debug().Msgf("auth token output: %v", authTokenOutput)
+	} else {
+		logger.Debug().Msgf("did not detect ecr registry: %v", strings.Contains(newImageRef, ".ecr.") && strings.HasSuffix(newImageRef, ".amazonaws.com"))
 	}
 	//buildah push
 	cmd := exec.Command("buildah", "push", newImageRef)

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -339,7 +339,7 @@ func RootfsMerge(ctx context.Context, originalImageRef, newImageRef, rootfsDiffP
 
 // checks if the given image name is an ECR repository
 func isECRRepo(imageName string) bool {
-	return strings.Contains(imageName, ".ecr.") && strings.HasSuffix(imageName, ".amazonaws.com")
+	return strings.Contains(imageName, ".ecr.") && strings.Contains(imageName, ".amazonaws.com")
 }
 
 func ImagePush(ctx context.Context, newImageRef string) error {

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -413,6 +413,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		loginArgs = append(loginArgs, proxyEndpoint)
 
 		if err := auth.Login(ctx, systemContext, loginOpts, loginArgs); err != nil {
+			logger.Debug().Msgf("auth token: %s", *authData.AuthorizationToken)
 			return err
 		}
 

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -417,7 +417,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 		logger.Debug().Msgf("decoded string: %s", decodedAuthString)
 
-		parts := strings.Split(":", decodedAuthString)
+		parts := strings.Split(decodedAuthString, ":")
 
 		if len(parts) != 2 {
 			return fmt.Errorf("decoded auth string is not correctly formatted, %v", len(parts))

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -408,13 +408,13 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 			return fmt.Errorf("not able to find ecr proxy endpoint %s authentication data", proxyEndpoint)
 		}
 
-		decodedAuthBytes := []byte{}
-		_, err = base64.StdEncoding.Decode([]byte(*authData.AuthorizationToken), decodedAuthBytes)
+		decodedAuthBytes, err := base64.StdEncoding.DecodeString(*authData.AuthorizationToken)
 		if err != nil {
 			return err
 		}
 
 		decodedAuthString := string(decodedAuthBytes)
+
 		parts := strings.Split(decodedAuthString, ":")
 
 		loginOpts.Username = parts[0]

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -19,7 +19,6 @@ import (
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/crutils"
-	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	archive "github.com/containers/storage/pkg/archive"
@@ -412,10 +411,6 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		loginOpts.Password = *authData.AuthorizationToken
 		// loginOpts.Stdin = strings.NewReader(proxyEndpoint)
 		loginArgs = append(loginArgs, proxyEndpoint)
-
-		if err := docker.CheckAuth(ctx, systemContext, loginOpts.Username, loginOpts.Password, proxyEndpoint); err != nil {
-			return err
-		}
 
 		if err := auth.Login(ctx, systemContext, loginOpts, loginArgs); err != nil {
 			logger.Debug().Msgf("auth token: %s", *authData.AuthorizationToken)

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -343,6 +343,11 @@ func isECRRepo(imageName string) bool {
 }
 
 func ImagePush(ctx context.Context, newImageRef string) error {
+	logger, err := utils.GetLoggerFromContext(ctx)
+	if err != nil {
+		fmt.Printf(err.Error())
+	}
+
 	if isECRRepo(newImageRef) {
 		session, err := session.NewSession()
 		if err != nil {
@@ -357,7 +362,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 			return err
 		}
 
-		authTokenOutput.AuthorizationData
+		logger.Debug().Msgf("auth token output: %v", authTokenOutput)
 	}
 	//buildah push
 	cmd := exec.Command("buildah", "push", newImageRef)

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -409,7 +409,8 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 		loginOpts.Username = "AWS"
 		loginOpts.Password = *authData.AuthorizationToken
-		loginOpts.Stdin = strings.NewReader(proxyEndpoint)
+		// loginOpts.Stdin = strings.NewReader(proxyEndpoint)
+		loginArgs = append(loginArgs, proxyEndpoint)
 
 		if err := auth.Login(ctx, systemContext, loginOpts, loginArgs); err != nil {
 			return err

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -19,6 +19,7 @@ import (
 	metadata "github.com/checkpoint-restore/checkpointctl/lib"
 	"github.com/containers/common/pkg/auth"
 	"github.com/containers/common/pkg/crutils"
+	"github.com/containers/image/v5/docker"
 	"github.com/containers/image/v5/types"
 	"github.com/containers/storage"
 	archive "github.com/containers/storage/pkg/archive"
@@ -411,6 +412,10 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		loginOpts.Password = *authData.AuthorizationToken
 		// loginOpts.Stdin = strings.NewReader(proxyEndpoint)
 		loginArgs = append(loginArgs, proxyEndpoint)
+
+		if err := docker.CheckAuth(ctx, systemContext, loginOpts.Username, loginOpts.Password, *authData.ProxyEndpoint); err != nil {
+			return err
+		}
 
 		if err := auth.Login(ctx, systemContext, loginOpts, loginArgs); err != nil {
 			logger.Debug().Msgf("auth token: %s", *authData.AuthorizationToken)

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -420,7 +420,7 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		parts := strings.Split(":", decodedAuthString)
 
 		if len(parts) != 2 {
-			return fmt.Errorf("decoded auth string is not correctly formatted")
+			return fmt.Errorf("decoded auth string is not correctly formatted, %v", len(parts))
 		}
 
 		loginOpts.Username = parts[0]

--- a/api/crio/crio.go
+++ b/api/crio/crio.go
@@ -415,8 +415,6 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 
 		decodedAuthString := string(decodedAuthBytes)
 
-		logger.Debug().Msgf("decoded string: %s", decodedAuthString)
-
 		parts := strings.Split(decodedAuthString, ":")
 
 		if len(parts) != 2 {
@@ -432,7 +430,6 @@ func ImagePush(ctx context.Context, newImageRef string) error {
 		loginArgs = append(loginArgs, proxyEndpoint)
 
 		if err := auth.Login(ctx, systemContext, loginOpts, loginArgs); err != nil {
-			logger.Debug().Msgf("auth token: %s", decodedAuthString)
 			return err
 		}
 

--- a/go.mod
+++ b/go.mod
@@ -62,6 +62,7 @@ require (
 	github.com/VividCortex/ewma v1.2.0 // indirect
 	github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d // indirect
 	github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 // indirect
+	github.com/aws/aws-sdk-go v1.54.19 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/blang/semver/v4 v4.0.0 // indirect
 	github.com/cenkalti/backoff/v4 v4.3.0 // indirect
@@ -123,6 +124,7 @@ require (
 	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect
 	github.com/intel/goresctrl v0.7.0 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/klauspost/compress v1.17.8 // indirect
 	github.com/klauspost/pgzip v1.2.6 // indirect

--- a/go.sum
+++ b/go.sum
@@ -634,6 +634,8 @@ github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5 h1:0CwZNZbxp69SHPd
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2 h1:DklsrG3dyBCFEj5IhUbnKptjxatkF07cF2ak3yi77so=
 github.com/asaskevich/govalidator v0.0.0-20230301143203-a9d515a09cc2/go.mod h1:WaHUgvxTVq04UNunO+XhnAqY/wQc+bxr74GqbsZ/Jqw=
+github.com/aws/aws-sdk-go v1.54.19 h1:tyWV+07jagrNiCcGRzRhdtVjQs7Vy41NwsuOcl0IbVI=
+github.com/aws/aws-sdk-go v1.54.19/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
 github.com/blang/semver/v4 v4.0.0 h1:1PFHFE6yCCTv8C1TeyNNarDzntLi7wMI5i/pzqYIsAM=
@@ -998,6 +1000,9 @@ github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/intel/goresctrl v0.7.0 h1:x6RclP6LiJc24t9mf47BRbjf06B8oVisZMBv31x3rKc=
 github.com/intel/goresctrl v0.7.0/go.mod h1:T3ZZnuHSNouwELB5wvOoUJaB7l/4Rm23rJy/wuWJlr0=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmhodges/clock v1.2.0 h1:eq4kys+NI0PLngzaHEe7AmPT90XMGIEySD1JfV1PDIs=
 github.com/jmhodges/clock v1.2.0/go.mod h1:qKjhA7x7u/lQpPB1XAqX1b1lCI/w3/fNuYpI/ZjLynI=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=


### PR DESCRIPTION
## Describe your changes
- use auth.Login from containers repo to login to ecr registries
- auto detect ecr registry from image name
- decode and parse iam credentials from working node

## Issue ticket number
[CED-515](https://linear.app/cedana/issue/CED-515/add-auth-login-steps-for-ecr)

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 

