### PR TITLE
Remove daemon log redirection embedded in daemon

### DIFF
--- a/build-start-daemon.sh
+++ b/build-start-daemon.sh
@@ -101,6 +101,7 @@ WantedBy=multi-user.target
 
 [Service]
 StandardError=append:/var/log/cedana-daemon.log
+StandardOutput=append:/var/log/cedana-daemon.log
 EOF
 
     echo "Reloading systemd..."

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -41,15 +41,6 @@ var dumpProcessCmd = &cobra.Command{
 		}
 
 		dir, _ := cmd.Flags().GetString(dirFlag)
-		if dir == "" {
-			// TODO NR - should we default to /tmp?
-			dir = viper.GetString("shared_storage.dump_storage_dir")
-			if dir == "" {
-				logger.Error().Msgf("no dump directory specified")
-				return err
-			}
-			logger.Info().Msgf("no directory specified as input, using %s from config", dir)
-		}
 
 		// always self serve when invoked from CLI
 		gpuEnabled, _ := cmd.Flags().GetBool(gpuEnabledFlag)
@@ -107,28 +98,12 @@ var dumpJobCmd = &cobra.Command{
 		}
 
 		dir, _ := cmd.Flags().GetString(dirFlag)
-		if dir == "" {
-			dir = viper.GetString("shared_storage.dump_storage_dir")
-			if dir == "" {
-				logger.Error().Msgf("no dump directory specified")
-				return err
-			}
-			logger.Info().Msgf("no directory specified as input, using %s from config", dir)
-		}
-
-		var taskType task.CRType
-		if viper.GetBool("remote") {
-			taskType = task.CRType_REMOTE
-		} else {
-			taskType = task.CRType_LOCAL
-		}
 
 		gpuEnabled, _ := cmd.Flags().GetBool(gpuEnabledFlag)
 		tcpEstablished, _ := cmd.Flags().GetBool(tcpEstablishedFlag)
 		dumpArgs := task.DumpArgs{
 			JID:            id,
 			Dir:            dir,
-			Type:           taskType,
 			GPU:            gpuEnabled,
 			TcpEstablished: tcpEstablished,
 		}

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cedana/cedana/api/services/task"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc/status"
 )
 

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -31,4 +31,5 @@ const (
 	containerStorageFlag = "container-storage"
 	configFlag           = "config"
 	configDirFlag        = "config-dir"
+  typeFlag             = "type"
 )

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -111,18 +111,6 @@ var restoreJobCmd = &cobra.Command{
 			}
 		}
 
-		// Query job state
-		query := task.QueryArgs{
-			JIDs: []string{jid},
-		}
-
-		res, err := cts.Query(ctx, &query)
-		if err != nil {
-			logger.Error().Msgf("Error querying job: %v", err)
-			return err
-		}
-		state := res.Processes[0]
-
 		tcpEstablished, _ := cmd.Flags().GetBool(tcpEstablishedFlag)
 		restoreArgs := task.RestoreArgs{
 			JID:            jid,
@@ -130,23 +118,6 @@ var restoreJobCmd = &cobra.Command{
 			GID:            gid,
 			Groups:         groups,
 			TcpEstablished: tcpEstablished,
-		}
-		if viper.GetBool("remote") {
-			remoteState := state.GetRemoteState()
-			if remoteState == nil {
-				logger.Error().Msgf("No remote state found for id %s", jid)
-				return err
-			}
-			// For now just grab latest checkpoint
-			if remoteState[len(remoteState)-1].CheckpointID == "" {
-				logger.Error().Msgf("No checkpoint found for id %s", jid)
-				return err
-			}
-			restoreArgs.CheckpointID = remoteState[len(remoteState)-1].CheckpointID
-			restoreArgs.Type = task.CRType_REMOTE
-		} else {
-			restoreArgs.CheckpointPath = state.GetCheckpointPath()
-			restoreArgs.Type = task.CRType_LOCAL
 		}
 
 		resp, err := cts.Restore(ctx, &restoreArgs)

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cedana/cedana/api/services/task"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 	"google.golang.org/grpc/status"
 )
 


### PR DESCRIPTION
## Describe your changes
The daemon was hardcoded to print logs at /var/log/cedana-daemon.log. This should handled by redirection by whoever's spawning the daemon instead.

## Issue ticket number 
CED-579

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.