### PR TITLE
Remove daemon log redirection embedded in daemon

### DIFF
--- a/api/streaming.go
+++ b/api/streaming.go
@@ -3,6 +3,7 @@ package api
 import (
 	"context"
 	"fmt"
+	"os"
 	"time"
 
 	"github.com/cedana/cedana/api/services/task"
@@ -28,7 +29,7 @@ func (s *service) LogStreaming(stream task.TaskService_LogStreamingServer) error
 		case <-stream.Context().Done():
 			return nil // Client disconnected
 		default:
-			n, err := s.logFile.Read(buf)
+			n, err := os.Stdout.Read(buf)
 			if err != nil {
 				break
 			}
@@ -36,7 +37,7 @@ func (s *service) LogStreaming(stream task.TaskService_LogStreamingServer) error
 				// TODO BS Needs implementation
 				response := &task.LogStreamingArgs{
 					Timestamp: time.Now().Local().Format(time.RFC3339),
-					Source:    SERVER_LOG_PATH,
+					Source:    "stdout",
 					Level:     "INFO",
 					Msg:       string(buf[:n]),
 				}

--- a/build-start-daemon.sh
+++ b/build-start-daemon.sh
@@ -101,6 +101,7 @@ WantedBy=multi-user.target
 
 [Service]
 StandardError=append:/var/log/cedana-daemon.log
+StandardOutput=append:/var/log/cedana-daemon.log
 EOF
 
     echo "Reloading systemd..."


### PR DESCRIPTION
## Describe your changes
The daemon was hardcoded to print logs at `/var/log/cedana-daemon.log`. This should handled by redirection by whoever's spawning the daemon instead.

## Issue ticket number 
CED-579

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.