### PR TITLE
Revert "update: match bin commit sha in image"

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -271,9 +271,5 @@ jobs:
 
       - name: Inspect image
         run: |
-          # check if push was successful
           docker buildx imagetools inspect cedana/cedana-helper:${{ steps.meta.outputs.version }}
           docker buildx imagetools inspect ghcr.io/cedana/cedana:${{ steps.meta.outputs.version }}
-          # check if commit sha matches with the latest commit sha
-          # we only match docker hub image as both images should be the same
-          echo $(docker run -i --rm cedana/cedana-helper:${{ steps.meta.outputs.version }} -c "cedana -v") | grep -qF ${{ github.sha }}


### PR DESCRIPTION
Just checked, we now plan to use `git describe --tags` which doesn't add the commit hash to version field. If that is merge, it will fail all release actions after they have successfully pushed the images.

The relevant PR #272 

Not a breaking change.