### PR TITLE
fix: add back criu deps

### DIFF
--- a/cmd/scripts/k8s/setup-host.sh
+++ b/cmd/scripts/k8s/setup-host.sh
@@ -13,7 +13,7 @@ if [[ $SKIPSETUP -eq 1 ]]; then
 fi
 
 YUM_PACKAGES=(wget libnet-devel libnl3-devel libcap-devel libseccomp-devel gpgme-devel btrfs-progs-devel buildah criu)
-APT_PACKAGES=(wget libnl-3-dev libnet-dev libbsd-dev libcap-dev pkg-config libgpgme-dev libseccomp-dev libbtrfs-dev buildah)
+APT_PACKAGES=(wget libnl-3-dev libnet-dev libbsd-dev libcap-dev pkg-config libgpgme-dev libseccomp-dev libbtrfs-dev buildah libgnutls30 python3:any python3-protobuf libc6 libnftables1 libprotobuf-c1)
 
 install_apt_packages() {
     apt-get update


### PR DESCRIPTION
## Describe your changes

The current images don't work on many host images it used to work on anymore, I have added back all the deps for criu.

```bash
dpkg -I criu.deb
```

## Issue ticket number

Fixes CED-590

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the README if changes have resulted in it being out of date?
- [ ]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 

