### PR TITLE
Fix binary not built for lower glibc versions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,7 +35,7 @@ jobs:
     name: Build & Publish (amd64)
     runs-on: ubuntu-latest
     container:
-      image: golang:1.22-bookworm
+      image: golang:1.22-bullseye
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,24 +1,29 @@
-FROM golang:1.22-bookworm as builder
+FROM golang:1.22-bullseye as builder
 
 WORKDIR /app
 ADD . /app
 
-RUN apt-get update \
-    && DEBIAN_FRONTEND=noninteractive \
-    apt-get install --no-install-recommends --assume-yes \
-    wget git make curl libnl-3-dev libnet-dev libbsd-dev runc libcap-dev \
-    libgpgme-dev btrfs-progs libbtrfs-dev libseccomp-dev libapparmor-dev libprotobuf-dev \
-    libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf software-properties-common zip
+RUN <<EOT
+set -eux
+DEBIAN_FRONTEND=noninteractive
+apt-get update
+apt-get install -y wget git make curl libnl-3-dev libnet-dev libbsd-dev runc libcap-dev
+apt-get install -y libgpgme-dev btrfs-progs libbtrfs-dev libseccomp-dev libapparmor-dev libprotobuf-dev
+apt-get install -y libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf
+apt-get install -y software-properties-common zip
+EOT
 
 RUN /app/build.sh
 
 FROM ubuntu:22.04
 
-# Install essential packages
-RUN apt-get update && \
-    apt-get install -y software-properties-common git wget zip && \
-    apt-get install -y libgpgme-dev libseccomp-dev libbtrfs-dev && \
-    rm -rf /var/lib/apt/lists/*
+RUN <<EOT
+set -eux
+apt-get update
+apt-get install -y software-properties-common git wget zip
+apt-get install -y libgpgme-dev libseccomp-dev libbtrfs-dev
+rm -rf /var/lib/apt/lists/*
+EOT
 
 COPY --from=builder /app/cedana /usr/local/bin/
 COPY --from=builder /app/build.sh /usr/local/bin/


### PR DESCRIPTION
## Describe your changes
Everywhere in the CI, where we are building the cedana binary, the glibc version is 2.36. To support even just the base image ubuntu 20.04, we need to link with glibc version that is at most 2.30 (since it's forward compatible).

## Issue ticket number 
CED-586

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.