### PR TITLE
Add a CLI config section

### DIFF
--- a/api/services/cts.go
+++ b/api/services/cts.go
@@ -284,7 +284,7 @@ func (c *ServiceClient) GetConfig(ctx context.Context, args *task.GetConfigReque
 
 func getDefaultCallOptions() []grpc.CallOption {
 	opts := []grpc.CallOption{}
-	if viper.GetBool("wait_for_ready") {
+	if viper.GetBool("cli.wait_for_ready") {
 		opts = append(opts, grpc.WaitForReady(true))
 	}
 	return opts

--- a/cmd/config.go
+++ b/cmd/config.go
@@ -20,7 +20,7 @@ var configCmd = &cobra.Command{
 
 var showCmd = &cobra.Command{
 	Use:   "show",
-	Short: "show currently set configuration",
+	Short: "show config that the daemon is running with",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		ctx := cmd.Context()
 		logger := cmd.Context().Value("logger").(*zerolog.Logger)

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -167,8 +167,6 @@ func init() {
 	daemonCmd.AddCommand(checkDaemonCmd)
 	startDaemonCmd.Flags().BoolP(gpuEnabledFlag, "g", false, "start daemon with GPU support")
 	startDaemonCmd.Flags().String(cudaVersionFlag, "11.8", "cuda version to use")
-	startDaemonCmd.Flags().String(configFlag, "", "custom config JSON string (will merge with existing/default config, and not saved")
-	startDaemonCmd.Flags().String(configDirFlag, "", "custom config directory")
 }
 
 type pullGPUBinaryRequest struct {

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cedana/cedana/api"
 	"github.com/cedana/cedana/api/services"
 	"github.com/cedana/cedana/api/services/task"
-	"github.com/cedana/cedana/types"
 	"github.com/cedana/cedana/utils"
 	"github.com/rs/zerolog"
 	"github.com/spf13/cobra"
@@ -39,16 +38,6 @@ var startDaemonCmd = &cobra.Command{
 	RunE: func(cmd *cobra.Command, args []string) error {
 		ctx := cmd.Context()
 		logger := ctx.Value("logger").(*zerolog.Logger)
-
-		config, _ := cmd.Flags().GetString(configFlag)
-		configDir, _ := cmd.Flags().GetString(configDirFlag)
-		if err := utils.InitConfig(types.InitConfigArgs{
-			Config:    config,
-			ConfigDir: configDir,
-		}); err != nil {
-			logger.Error().Err(err).Msg("failed to initialize config")
-			return err
-		}
 
 		if os.Getuid() != 0 {
 			return fmt.Errorf("daemon must be run as root")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -51,5 +51,8 @@ func Execute(ctx context.Context, version string) error {
 		return nil
 	}
 
+	rootCmd.PersistentFlags().String(configFlag, "", "one-time config JSON string (will merge with existing config)")
+	rootCmd.PersistentFlags().String(configDirFlag, "", "custom config directory")
+
 	return rootCmd.ExecuteContext(ctx)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -5,6 +5,7 @@ package cmd
 import (
 	"context"
 
+	"github.com/cedana/cedana/types"
 	"github.com/cedana/cedana/utils"
 	"github.com/spf13/cobra"
 )
@@ -13,7 +14,7 @@ var rootCmd = &cobra.Command{
 	Use:   "cedana",
 	Short: "simple criu dump/restore client",
 	Long: `
-________  _______   ________  ________  ________   ________
+ ________  _______   ________  ________  ________   ________
 |\   ____\|\  ___ \ |\   ___ \|\   __  \|\   ___  \|\   __  \
 \ \  \___|\ \   __/|\ \  \_|\ \ \  \|\  \ \  \\ \  \ \  \|\  \
  \ \  \    \ \  \_|/_\ \  \ \\ \ \   __  \ \  \\ \  \ \   __  \
@@ -37,9 +38,17 @@ func Execute(ctx context.Context, version string) error {
 	// only show usage when true usage error
 	rootCmd.SilenceUsage = true
 
-	if err := utils.InitConfigCLI(); err != nil {
-		logger.Error().Err(err).Msg("failed to initialize config")
-		return err
+	rootCmd.PersistentPreRunE = func(cmd *cobra.Command, args []string) error {
+		config, _ := cmd.Flags().GetString(configFlag)
+		configDir, _ := cmd.Flags().GetString(configDirFlag)
+		if err := utils.InitConfig(types.InitConfigArgs{
+			Config:    config,
+			ConfigDir: configDir,
+		}); err != nil {
+			logger.Error().Err(err).Msg("failed to initialize config")
+			return err
+		}
+		return nil
 	}
 
 	return rootCmd.ExecuteContext(ctx)

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -32,11 +32,15 @@ func Execute(ctx context.Context, version string) error {
 	ctx = context.WithValue(ctx, "logger", logger)
 
 	rootCmd.Version = version
-
 	rootCmd.Long = rootCmd.Long + "\n " + version
 
 	// only show usage when true usage error
 	rootCmd.SilenceUsage = true
+
+	if err := utils.InitConfigCLI(); err != nil {
+		logger.Error().Err(err).Msg("failed to initialize config")
+		return err
+	}
 
 	return rootCmd.ExecuteContext(ctx)
 }

--- a/types/config.go
+++ b/types/config.go
@@ -4,28 +4,28 @@ package types
 type (
 	// Daemon config
 	Config struct {
-		Client        Client        `json:"client" mapstructure:"client"`
-		Connection    Connection    `json:"connection" mapstructure:"connection"`
-		SharedStorage SharedStorage `json:"shared_storage" mapstructure:"shared_storage"`
+		Client        Client        `key:"client" json:"client" mapstructure:"client"`
+		Connection    Connection    `key:"connection" json:"connection" mapstructure:"connection"`
+		SharedStorage SharedStorage `key:"sharedStorage" json:"shared_storage" mapstructure:"shared_storage"`
 	}
 	Client struct {
 		// job to run
-		Task         string `json:"task" mapstructure:"task"`
-		LeaveRunning bool   `json:"leave_running" mapstructure:"leave_running"`
-		ForwardLogs  bool   `json:"forward_logs" mapstructure:"forward_logs"`
+		Task         string `key:"task" json:"task" mapstructure:"task"`
+		LeaveRunning bool   `key:"leaveRunning" json:"leave_running" mapstructure:"leave_running"`
+		ForwardLogs  bool   `key:"forwardLogs" json:"forward_logs" mapstructure:"forward_logs"`
 	}
 	Connection struct {
 		// for cedana managed systems
-		CedanaUrl       string `json:"cedana_url" mapstructure:"cedana_url"`
-		CedanaAuthToken string `json:"cedana_auth_token" mapstructure:"cedana_auth_token"`
+		CedanaUrl       string `key:"cedanaUrl" json:"cedana_url" mapstructure:"cedana_url"`
+		CedanaAuthToken string `key:"cedanaAuthToken" json:"cedana_auth_token" mapstructure:"cedana_auth_token"`
 	}
 	SharedStorage struct {
-		DumpStorageDir string `json:"dump_storage_dir" mapstructure:"dump_storage_dir"`
+		DumpStorageDir string `key:"dumpStorageDir" json:"dump_storage_dir" mapstructure:"dump_storage_dir"`
 	}
 
 	// CLI config
 	ConfigCLI struct {
-		WaitForReady bool `json:"wait_for_ready" mapstructure:"wait_for_ready"`
+		WaitForReady bool `key:"waitForReady" json:"wait_for_ready" mapstructure:"wait_for_ready"`
 	}
 
 	// Misc

--- a/types/config.go
+++ b/types/config.go
@@ -2,6 +2,7 @@ package types
 
 // XXX: Config file should have a version field to manage future changes to schema
 type (
+	// Daemon config
 	Config struct {
 		Client        Client        `json:"client" mapstructure:"client"`
 		Connection    Connection    `json:"connection" mapstructure:"connection"`
@@ -21,6 +22,13 @@ type (
 	SharedStorage struct {
 		DumpStorageDir string `json:"dump_storage_dir" mapstructure:"dump_storage_dir"`
 	}
+
+	// CLI config
+	ConfigCLI struct {
+		WaitForReady bool `json:"wait_for_ready" mapstructure:"wait_for_ready"`
+	}
+
+	// Misc
 	InitConfigArgs struct {
 		Config    string
 		ConfigDir string

--- a/types/config.go
+++ b/types/config.go
@@ -7,6 +7,7 @@ type (
 		Client        Client        `key:"client" json:"client" mapstructure:"client"`
 		Connection    Connection    `key:"connection" json:"connection" mapstructure:"connection"`
 		SharedStorage SharedStorage `key:"sharedStorage" json:"shared_storage" mapstructure:"shared_storage"`
+		CLI           CLI           `key:"cli" json:"cli" mapstructure:"cli"`
 	}
 	Client struct {
 		// job to run
@@ -23,8 +24,7 @@ type (
 		DumpStorageDir string `key:"dumpStorageDir" json:"dump_storage_dir" mapstructure:"dump_storage_dir"`
 	}
 
-	// CLI config
-	ConfigCLI struct {
+	CLI struct {
 		WaitForReady bool `key:"waitForReady" json:"wait_for_ready" mapstructure:"wait_for_ready"`
 	}
 

--- a/utils/config.go
+++ b/utils/config.go
@@ -47,11 +47,6 @@ func InitConfig(args types.InitConfigArgs) error {
 	viper.SetConfigName(configFileName)
 	viper.SetEnvPrefix(envVarPrefix)
 
-	// Allow environment variables to be accesses through viper *if* bound.
-	// For e.g. CEDANA_SECRET will be accessible as viper.Get("secret")
-	// However, viper.Get() always first checks the config file
-	viper.AutomaticEnv()
-
 	// Create config directory if it does not exist
 	_, err = os.Stat(configDir)
 	if os.IsNotExist(err) {
@@ -66,6 +61,11 @@ func InitConfig(args types.InitConfigArgs) error {
 
 	setDefaults() // Only sets defaults for when no value is found in config
 	bindEnvVars()
+
+	// Allow environment variables to be accesses through viper *if* bound.
+	// For e.g. CEDANA_SECRET will be accessible as viper.Get("secret")
+	// However, viper.Get() always first checks the config file
+	viper.AutomaticEnv()
 	viper.SetTypeByDefaultValue(true)
 	viper.ReadInConfig()
 
@@ -74,7 +74,7 @@ func InitConfig(args types.InitConfigArgs) error {
 		reader := strings.NewReader(args.Config)
 		err = viper.MergeConfig(reader)
 	} else {
-		viper.SafeWriteConfig() // Will only overwrite if file does not exist
+		viper.SafeWriteConfig() // Will only overwrite if file does not exist, ignore error
 	}
 
 	return err
@@ -103,7 +103,7 @@ func setDefaults() {
 
 	viper.SetDefault("connection.cedana_user", "random-user")
 
-	viper.SetDefault("wait_for_ready", false)
+	viper.SetDefault("cli.wait_for_ready", false)
 }
 
 // Add bindings for env vars so env vars can be used as backup
@@ -128,7 +128,8 @@ func bindEnvVars() {
 	viper.BindEnv("is_k8s", "CEDANA_IS_K8S")
 	viper.BindEnv("remote", "CEDANA_REMOTE")
 
-	viper.BindEnv("wait_for_ready", "CEDANA_CLI_WAIT_FOR_READY")
+  // CLI-specific
+	viper.BindEnv("cli.wait_for_ready", "CEDANA_CLI_WAIT_FOR_READY")
 }
 
 func getUser() (*user.User, error) {

--- a/utils/config.go
+++ b/utils/config.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/cedana/cedana/types"
@@ -11,12 +12,14 @@ import (
 )
 
 const (
-	configDirName  = ".cedana"
-	configFileName = "client_config"
-	configFileType = "json"
-	envVarPrefix   = "CEDANA"
-	configDirPerm  = 0755
-	configFilePerm = 0644
+	configDirName     = ".cedana"
+	configFileName    = "client_config"
+	configFileNameCLI = "cli_config"
+	configFileType    = "json"
+	envVarPrefix      = "CEDANA"
+	envVarPrefixCLI   = "CEDANA_CLI"
+	configDirPerm     = 0755
+	configFilePerm    = 0644
 )
 
 const (
@@ -59,9 +62,13 @@ func InitConfig(args types.InitConfigArgs) error {
 			return err
 		}
 	}
+	uid, _ := strconv.Atoi(user.Uid)
+	gid, _ := strconv.Atoi(user.Gid)
+	os.Chown(configDir, uid, gid)
 
 	setDefaults() // Only sets defaults for when no value is found in config
 	bindEnvVars()
+	viper.SetTypeByDefaultValue(true)
 	viper.ReadInConfig()
 
 	if args.Config != "" {
@@ -75,6 +82,49 @@ func InitConfig(args types.InitConfigArgs) error {
 	return err
 }
 
+func InitConfigCLI() error {
+	user, err := getUser()
+	if err != nil {
+		return err
+	}
+
+	homeDir := user.HomeDir
+	configDir := filepath.Join(homeDir, configDirName)
+
+	viper.AddConfigPath(configDir)
+	viper.SetConfigPermissions(configFilePerm)
+	viper.SetConfigType(configFileType)
+	viper.SetConfigName(configFileNameCLI)
+	viper.SetEnvPrefix(envVarPrefixCLI)
+
+	// Allow environment variables to be accesses through viper *if* bound.
+	// For e.g. CEDANA_SECRET will be accessible as viper.Get("secret")
+	// However, viper.Get() always first checks the config file
+	viper.AutomaticEnv()
+
+	// Create config directory if it does not exist
+	_, err = os.Stat(configDir)
+	if os.IsNotExist(err) {
+		err = os.MkdirAll(configDir, configDirPerm)
+		if err != nil {
+			return err
+		}
+	}
+	uid, _ := strconv.Atoi(user.Uid)
+	gid, _ := strconv.Atoi(user.Gid)
+	os.Chown(configDir, uid, gid)
+
+	setDefaultsCLI() // Only sets defaults for when no value is found in config
+	bindEnvVarsCLI()
+	viper.SetTypeByDefaultValue(true)
+	viper.ReadInConfig()
+
+	viper.SafeWriteConfig() // Will only overwrite if file does not exist
+	os.Chown(filepath.Join(configDir, configFileNameCLI+"."+configFileType), uid, gid)
+
+	return err
+}
+
 func GetConfig() (*types.Config, error) {
 	var config types.Config
 	err := viper.Unmarshal(&config)
@@ -83,6 +133,10 @@ func GetConfig() (*types.Config, error) {
 	}
 	return &config, err
 }
+
+///////////////////
+//    Helpers    //
+///////////////////
 
 // Set defaults that are used when no value is found in config/env vars
 func setDefaults() {
@@ -93,6 +147,10 @@ func setDefaults() {
 	viper.SetDefault("shared_storage.dump_storage_dir", "/tmp")
 
 	viper.SetDefault("connection.cedana_user", "random-user")
+}
+
+func setDefaultsCLI() {
+	viper.SetDefault("wait_for_ready", false)
 }
 
 // Add bindings for env vars so env vars can be used as backup
@@ -116,6 +174,10 @@ func bindEnvVars() {
 	viper.BindEnv("profiling_enabled", "CEDANA_PROFILING_ENABLED")
 	viper.BindEnv("is_k8s", "CEDANA_IS_K8S")
 	viper.BindEnv("remote", "CEDANA_REMOTE")
+}
+
+func bindEnvVarsCLI() {
+	viper.BindEnv("wait_for_ready", "CEDANA_CLI_WAIT_FOR_READY")
 }
 
 func getUser() (*user.User, error) {

--- a/utils/config.go
+++ b/utils/config.go
@@ -12,14 +12,12 @@ import (
 )
 
 const (
-	configDirName     = ".cedana"
-	configFileName    = "client_config"
-	configFileNameCLI = "cli_config"
-	configFileType    = "json"
-	envVarPrefix      = "CEDANA"
-	envVarPrefixCLI   = "CEDANA_CLI"
-	configDirPerm     = 0755
-	configFilePerm    = 0644
+	configDirName  = ".cedana"
+	configFileName = "client_config"
+	configFileType = "json"
+	envVarPrefix   = "CEDANA"
+	configDirPerm  = 0755
+	configFilePerm = 0644
 )
 
 const (
@@ -82,49 +80,6 @@ func InitConfig(args types.InitConfigArgs) error {
 	return err
 }
 
-func InitConfigCLI() error {
-	user, err := getUser()
-	if err != nil {
-		return err
-	}
-
-	homeDir := user.HomeDir
-	configDir := filepath.Join(homeDir, configDirName)
-
-	viper.AddConfigPath(configDir)
-	viper.SetConfigPermissions(configFilePerm)
-	viper.SetConfigType(configFileType)
-	viper.SetConfigName(configFileNameCLI)
-	viper.SetEnvPrefix(envVarPrefixCLI)
-
-	// Allow environment variables to be accesses through viper *if* bound.
-	// For e.g. CEDANA_SECRET will be accessible as viper.Get("secret")
-	// However, viper.Get() always first checks the config file
-	viper.AutomaticEnv()
-
-	// Create config directory if it does not exist
-	_, err = os.Stat(configDir)
-	if os.IsNotExist(err) {
-		err = os.MkdirAll(configDir, configDirPerm)
-		if err != nil {
-			return err
-		}
-	}
-	uid, _ := strconv.Atoi(user.Uid)
-	gid, _ := strconv.Atoi(user.Gid)
-	os.Chown(configDir, uid, gid)
-
-	setDefaultsCLI() // Only sets defaults for when no value is found in config
-	bindEnvVarsCLI()
-	viper.SetTypeByDefaultValue(true)
-	viper.ReadInConfig()
-
-	viper.SafeWriteConfig() // Will only overwrite if file does not exist
-	os.Chown(filepath.Join(configDir, configFileNameCLI+"."+configFileType), uid, gid)
-
-	return err
-}
-
 func GetConfig() (*types.Config, error) {
 	var config types.Config
 	err := viper.Unmarshal(&config)
@@ -147,9 +102,7 @@ func setDefaults() {
 	viper.SetDefault("shared_storage.dump_storage_dir", "/tmp")
 
 	viper.SetDefault("connection.cedana_user", "random-user")
-}
 
-func setDefaultsCLI() {
 	viper.SetDefault("wait_for_ready", false)
 }
 
@@ -174,9 +127,7 @@ func bindEnvVars() {
 	viper.BindEnv("profiling_enabled", "CEDANA_PROFILING_ENABLED")
 	viper.BindEnv("is_k8s", "CEDANA_IS_K8S")
 	viper.BindEnv("remote", "CEDANA_REMOTE")
-}
 
-func bindEnvVarsCLI() {
 	viper.BindEnv("wait_for_ready", "CEDANA_CLI_WAIT_FOR_READY")
 }
 


### PR DESCRIPTION
## Describe your changes
As of this PR: https://github.com/cedana/cedana/pull/256, the config file is now only for the daemon. As the CLI is now independent of daemon stuff, we still need a way to configure CLI options. 

This PR:
- Adds a new section called `cli` in `client_config.json`.
- Loads config during start itself now, instead of when daemon starts, as CLI options need to be available for other CLI commands.
- The `--config` & `--config-dir` options are now flags available to the `cedana ...` cmd instead of `cedana daemon start`.

## Issue ticket number 
CED-595

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.
Does not touch existing daemon config at all, so no.