### PR TITLE
Add `wait_for_ready` option to CLI config

### DIFF
--- a/api/services/cts.go
+++ b/api/services/cts.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cedana/cedana/api"
 	"github.com/cedana/cedana/api/services/task"
+	"github.com/spf13/viper"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/health/grpc_health_v1"
@@ -54,10 +55,12 @@ func (c *ServiceClient) HealthCheck(ctx context.Context) (bool, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
 
+	opts := getDefaultCallOptions()
+
 	// Health check
 	resp, err := healthClient.Check(ctx, &grpc_health_v1.HealthCheckRequest{
 		Service: "task.TaskService",
-	})
+	}, opts...)
 	if err != nil {
 		return false, err
 	}
@@ -72,7 +75,8 @@ func (c *ServiceClient) HealthCheck(ctx context.Context) (bool, error) {
 func (c *ServiceClient) DetailedHealthCheck(ctx context.Context, args *task.DetailedHealthCheckRequest) (*task.DetailedHealthCheckResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.DetailedHealthCheck(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.DetailedHealthCheck(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -87,7 +91,8 @@ func (c *ServiceClient) DetailedHealthCheck(ctx context.Context, args *task.Deta
 func (c *ServiceClient) Start(ctx context.Context, args *task.StartArgs) (*task.StartResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.Start(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.Start(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -98,7 +103,8 @@ func (c *ServiceClient) Dump(ctx context.Context, args *task.DumpArgs) (*task.Du
 	// TODO NR - timeouts here need to be fixed
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.Dump(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.Dump(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -108,7 +114,8 @@ func (c *ServiceClient) Dump(ctx context.Context, args *task.DumpArgs) (*task.Du
 func (c *ServiceClient) Restore(ctx context.Context, args *task.RestoreArgs) (*task.RestoreResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.Restore(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.Restore(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -118,7 +125,8 @@ func (c *ServiceClient) Restore(ctx context.Context, args *task.RestoreArgs) (*t
 func (c *ServiceClient) Query(ctx context.Context, args *task.QueryArgs) (*task.QueryResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.Query(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.Query(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +141,8 @@ func (c *ServiceClient) CRIORootfsDump(ctx context.Context, args *task.CRIORootf
 	// TODO NR - timeouts here need to be fixed
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.CRIORootfsDump(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.CRIORootfsDump(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -144,7 +153,8 @@ func (c *ServiceClient) CRIOImagePush(ctx context.Context, args *task.CRIOImageP
 	// TODO NR - timeouts here need to be fixed
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.CRIOImagePush(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.CRIOImagePush(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -158,7 +168,8 @@ func (c *ServiceClient) CRIOImagePush(ctx context.Context, args *task.CRIOImageP
 func (c *ServiceClient) ContainerdDump(ctx context.Context, args *task.ContainerdDumpArgs) (*task.ContainerdDumpResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_CONTAINERD_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.ContainerdDump(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.ContainerdDump(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +179,8 @@ func (c *ServiceClient) ContainerdDump(ctx context.Context, args *task.Container
 func (c *ServiceClient) ContainerdRestore(ctx context.Context, args *task.ContainerdRestoreArgs) (*task.ContainerdRestoreResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_CONTAINERD_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.ContainerdRestore(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.ContainerdRestore(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -178,7 +190,8 @@ func (c *ServiceClient) ContainerdRestore(ctx context.Context, args *task.Contai
 func (c *ServiceClient) ContainerdQuery(ctx context.Context, args *task.ContainerdQueryArgs) (*task.ContainerdQueryResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_CONTAINERD_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.ContainerdQuery(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.ContainerdQuery(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -188,7 +201,8 @@ func (c *ServiceClient) ContainerdQuery(ctx context.Context, args *task.Containe
 func (c *ServiceClient) ContainerdRootfsDump(ctx context.Context, args *task.ContainerdRootfsDumpArgs) (*task.ContainerdRootfsDumpResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_CONTAINERD_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.ContainerdRootfsDump(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.ContainerdRootfsDump(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -198,7 +212,8 @@ func (c *ServiceClient) ContainerdRootfsDump(ctx context.Context, args *task.Con
 func (c *ServiceClient) ContainerdRootfsRestore(ctx context.Context, args *task.ContainerdRootfsRestoreArgs) (*task.ContainerdRootfsRestoreResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_CONTAINERD_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.ContainerdRootfsRestore(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.ContainerdRootfsRestore(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -212,7 +227,8 @@ func (c *ServiceClient) ContainerdRootfsRestore(ctx context.Context, args *task.
 func (c *ServiceClient) RuncDump(ctx context.Context, args *task.RuncDumpArgs) (*task.RuncDumpResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_RUNC_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.RuncDump(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.RuncDump(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -222,7 +238,8 @@ func (c *ServiceClient) RuncDump(ctx context.Context, args *task.RuncDumpArgs) (
 func (c *ServiceClient) RuncRestore(ctx context.Context, args *task.RuncRestoreArgs) (*task.RuncRestoreResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_RUNC_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.RuncRestore(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.RuncRestore(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -232,7 +249,8 @@ func (c *ServiceClient) RuncRestore(ctx context.Context, args *task.RuncRestoreA
 func (c *ServiceClient) RuncQuery(ctx context.Context, args *task.RuncQueryArgs) (*task.RuncQueryResp, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_RUNC_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.RuncQuery(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.RuncQuery(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -246,7 +264,8 @@ func (c *ServiceClient) RuncQuery(ctx context.Context, args *task.RuncQueryArgs)
 func (c *ServiceClient) GetConfig(ctx context.Context, args *task.GetConfigRequest) (*task.GetConfigResponse, error) {
 	ctx, cancel := context.WithTimeout(ctx, DEFAULT_PROCESS_DEADLINE)
 	defer cancel()
-	resp, err := c.taskService.GetConfig(ctx, args)
+	opts := getDefaultCallOptions()
+	resp, err := c.taskService.GetConfig(ctx, args, opts...)
 	if err != nil {
 		return nil, err
 	}
@@ -258,3 +277,15 @@ func (c *ServiceClient) GetConfig(ctx context.Context, args *task.GetConfigReque
 /////////////////////////////
 
 // TODO YA add streaming calls (move it from server.go to here)
+
+///////////////////
+//    Helpers    //
+///////////////////
+
+func getDefaultCallOptions() []grpc.CallOption {
+	opts := []grpc.CallOption{}
+	if viper.GetBool("wait_for_ready") {
+		opts = append(opts, grpc.WaitForReady(true))
+	}
+	return opts
+}


### PR DESCRIPTION
## Describe your changes
This would allow cedana commands to be executed while the daemon is not up yet, or has possibly crashed and is restarting. Could be useful in many cases, but currently need it for the design we're using for the Beam integration.

Please also look at #287, as this is based on that. Can be merged in any order, though.

## Issue ticket number 
CED-594

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.
> Nope. This will turned off by default.