### PR TITLE
CLI should ignore GPU if GPU not enabled in daemon

### DIFF
--- a/api/process.go
+++ b/api/process.go
@@ -38,6 +38,10 @@ func (s *service) Start(ctx context.Context, args *task.StartArgs) (*task.StartR
 		args.Task = viper.GetString("client.task")
 	}
 
+	if args.GPU && s.gpuEnabled == false {
+		return nil, status.Error(codes.FailedPrecondition, "GPU support is not enabled in daemon")
+	}
+
 	state := &task.ProcessState{}
 
 	state.JobState = task.JobState_JOB_RUNNING
@@ -87,6 +91,15 @@ func (s *service) Start(ctx context.Context, args *task.StartArgs) (*task.StartR
 
 func (s *service) Dump(ctx context.Context, args *task.DumpArgs) (*task.DumpResp, error) {
 	var err error
+
+	if args.GPU {
+		if s.gpuEnabled == false {
+			return nil, status.Error(codes.FailedPrecondition, "GPU support is not enabled in daemon")
+		}
+		if args.JID == "" {
+			return nil, status.Error(codes.InvalidArgument, "GPU dump is only supported for managed jobs")
+		}
+	}
 
 	dumpStats := task.DumpStats{
 		DumpType: task.DumpType_PROCESS,

--- a/api/server.go
+++ b/api/server.go
@@ -1,10 +1,13 @@
 package api
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"reflect"
@@ -42,13 +45,15 @@ const (
 )
 
 type service struct {
-	CRIU      *Criu
-	fs        *afero.Afero // for dependency-injection of filesystems (useful for testing)
-	db        db.DB
-	logger    *zerolog.Logger
-	store     *utils.CedanaStore
-	serverCtx context.Context // context alive for the duration of the server
-	wg        sync.WaitGroup  // for waiting for all background tasks to finish
+	CRIU        *Criu
+	fs          *afero.Afero // for dependency-injection of filesystems (useful for testing)
+	db          db.DB
+	logger      *zerolog.Logger
+	store       *utils.CedanaStore
+	serverCtx   context.Context // context alive for the duration of the server
+	wg          sync.WaitGroup  // for waiting for all background tasks to finish
+	gpuEnabled  bool
+	cudaVersion string
 
 	task.UnimplementedTaskServiceServer
 }
@@ -59,7 +64,16 @@ type Server struct {
 	listener   net.Listener
 }
 
-func NewServer(ctx context.Context) (*Server, error) {
+type ServeOpts struct {
+	GPUEnabled  bool
+	CUDAVersion string
+}
+
+type pullGPUBinaryRequest struct {
+	CudaVersion string `json:"cuda_version"`
+}
+
+func NewServer(ctx context.Context, opts *ServeOpts) (*Server, error) {
 	logger := ctx.Value("logger").(*zerolog.Logger)
 
 	server := &Server{
@@ -76,12 +90,14 @@ func NewServer(ctx context.Context) (*Server, error) {
 	service := &service{
 		// criu instantiated as empty, because all criu functions run criu swrk (starting the criu rpc server)
 		// instead of leaving one running forever.
-		CRIU:      &Criu{},
-		fs:        &afero.Afero{Fs: afero.NewOsFs()},
-		db:        db.NewLocalDB(ctx),
-		logger:    logger,
-		store:     utils.NewCedanaStore(logger),
-		serverCtx: ctx,
+		CRIU:        &Criu{},
+		fs:          &afero.Afero{Fs: afero.NewOsFs()},
+		db:          db.NewLocalDB(ctx),
+		logger:      logger,
+		store:       utils.NewCedanaStore(logger),
+		serverCtx:   ctx,
+		gpuEnabled:  opts.GPUEnabled,
+		cudaVersion: opts.CUDAVersion,
 	}
 
 	task.RegisterTaskServiceServer(server.grpcServer, service)
@@ -108,14 +124,14 @@ func (s *Server) stop() error {
 }
 
 // Takes in a context that allows for cancellation from the cmdline
-func StartServer(cmdCtx context.Context) error {
+func StartServer(cmdCtx context.Context, opts *ServeOpts) error {
 	logger := cmdCtx.Value("logger").(*zerolog.Logger)
 
 	// Create a child context for the server
 	srvCtx, cancel := context.WithCancelCause(cmdCtx)
 	defer cancel(nil)
 
-	server, err := NewServer(srvCtx)
+	server, err := NewServer(srvCtx, opts)
 	if err != nil {
 		return err
 	}
@@ -150,7 +166,32 @@ func StartServer(cmdCtx context.Context) error {
 			}
 		}
 
-		logger.Debug().Str("Address", ADDRESS).Msgf("server listening")
+		if opts.GPUEnabled {
+			if viper.GetString("gpu_controller_path") == "" {
+				err = pullGPUBinary(cmdCtx, utils.GpuControllerBinaryName, utils.GpuControllerBinaryPath, opts.CUDAVersion)
+				if err != nil {
+					logger.Error().Err(err).Msg("could not pull gpu controller")
+					cancel(err)
+					return
+				}
+			} else {
+				logger.Debug().Str("path", viper.GetString("gpu_controller_path")).Msg("using gpu controller")
+			}
+
+			if viper.GetString("gpu_shared_lib_path") == "" {
+				err = pullGPUBinary(cmdCtx, utils.GpuSharedLibName, utils.GpuSharedLibPath, opts.CUDAVersion)
+				if err != nil {
+					logger.Error().Err(err).Msg("could not pull gpu shared lib")
+					cancel(err)
+					return
+				}
+			} else {
+				logger.Debug().Str("path", viper.GetString("gpu_shared_lib_path")).Msg("using gpu shared lib")
+			}
+		}
+
+		logger.Info().Str("address", ADDRESS).Msgf("server listening")
+
 		err := server.start()
 		if err != nil {
 			cancel(err)
@@ -330,6 +371,7 @@ func (s *service) DetailedHealthCheck(ctx context.Context, req *task.DetailedHea
 	var unhealthyReasons []string
 	resp := &task.DetailedHealthCheckResponse{}
 
+	// TODO NR - Add CRIU check to output
 	criuVersion, err := s.CRIU.GetCriuVersion()
 	if err != nil {
 		resp.UnhealthyReasons = append(unhealthyReasons, fmt.Sprintf("CRIU: %v", err))
@@ -338,10 +380,11 @@ func (s *service) DetailedHealthCheck(ctx context.Context, req *task.DetailedHea
 	resp.HealthCheckStats = &task.HealthCheckStats{}
 	resp.HealthCheckStats.CriuVersion = strconv.Itoa(criuVersion)
 
-	// TODO NR - Add CRIU check to output
-	err = s.GPUHealthCheck(ctx, req, resp)
-	if err != nil {
-		resp.UnhealthyReasons = append(unhealthyReasons, fmt.Sprintf("Error checking gpu health: %v", err))
+	if s.gpuEnabled {
+		err = s.GPUHealthCheck(ctx, req, resp)
+		if err != nil {
+			resp.UnhealthyReasons = append(unhealthyReasons, fmt.Sprintf("Error checking gpu health: %v", err))
+		}
 	}
 
 	return resp, nil
@@ -380,7 +423,13 @@ func (s *service) GPUHealthCheck(
 		return nil
 	}
 
-	defer cmd.Process.Kill()
+	defer func() {
+		err = cmd.Process.Kill()
+		if err != nil {
+			s.logger.Fatal().Err(err)
+		}
+		s.logger.Info().Int("PID", cmd.Process.Pid).Msgf("GPU controller killed")
+	}()
 
 	var opts []grpc.DialOption
 	opts = append(opts, grpc.WithTransportCredentials(insecure.NewCredentials()))
@@ -422,4 +471,59 @@ func (s *service) GetConfig(ctx context.Context, req *task.GetConfigRequest) (*t
 	}
 	resp.JSON = string(bytes)
 	return resp, nil
+}
+
+func pullGPUBinary(ctx context.Context, binary string, filePath string, version string) error {
+	logger := ctx.Value("logger").(*zerolog.Logger)
+	_, err := os.Stat(filePath)
+	if err == nil {
+		logger.Debug().Str("Path", filePath).Msgf("GPU binary exists. Delete existing binary to download another supported cuda version.")
+		// TODO NR - check version and checksum of binary?
+		return nil
+	}
+	logger.Debug().Msgf("pulling gpu binary %s for cuda version %s", binary, version)
+
+	url := viper.GetString("connection.cedana_url") + "/checkpoint/gpu/" + binary
+	logger.Debug().Msgf("pulling %s from %s", binary, url)
+
+	httpClient := &http.Client{}
+
+	body := pullGPUBinaryRequest{
+		CudaVersion: version,
+	}
+
+	jsonBody, err := json.Marshal(body)
+	if err != nil {
+		logger.Err(err).Msg("could not marshal request body")
+		return err
+	}
+
+	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", viper.GetString("connection.cedana_auth_token")))
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := httpClient.Do(req)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		logger.Err(err).Msg("gpu binary get request failed")
+		return err
+	}
+	defer resp.Body.Close()
+
+	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0755)
+	if err == nil {
+		err = os.Chmod(filePath, 0755)
+	}
+	if err != nil {
+		logger.Err(err).Msg("could not create file")
+		return err
+	}
+	defer file.Close()
+
+	_, err = io.Copy(file, resp.Body)
+	if err != nil {
+		logger.Err(err).Msg("could not read file from response")
+		return err
+	}
+	logger.Debug().Msgf("%s downloaded to %s", binary, filePath)
+	return err
 }

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -3,12 +3,7 @@ package cmd
 // This file contains all the daemon-related commands when starting `cedana daemon ...`
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
 	"fmt"
-	"io"
-	"net/http"
 	"os"
 
 	"github.com/cedana/cedana/api"
@@ -55,39 +50,17 @@ var startDaemonCmd = &cobra.Command{
 			go startProfiler()
 		}
 		gpuEnabled, _ := cmd.Flags().GetBool(gpuEnabledFlag)
-		if gpuEnabled {
-			// defaults to 11_8, this continues if --cuda is not specified
-			cudaVersion, _ := cmd.Flags().GetString(cudaVersionFlag)
-			if _, ok := cudaVersions[cudaVersion]; !ok {
-				err = fmt.Errorf("invalid cuda version %s, must be one of %v", cudaVersion, cudaVersions)
-				logger.Error().Err(err).Msg("invalid cuda version")
-				return err
-			}
-
-			if viper.GetString("gpu_controller_path") == "" {
-				err = pullGPUBinary(ctx, utils.GpuControllerBinaryName, utils.GpuControllerBinaryPath, cudaVersions[cudaVersion])
-				if err != nil {
-					logger.Error().Err(err).Msg("could not pull gpu controller")
-					return err
-				}
-			} else {
-				logger.Debug().Msgf("using gpu controller at %s", viper.GetString("gpu_controller_path"))
-			}
-
-			if viper.GetString("gpu_shared_lib_path") == "" {
-				err = pullGPUBinary(ctx, utils.GpuSharedLibName, utils.GpuSharedLibPath, cudaVersions[cudaVersion])
-				if err != nil {
-					logger.Error().Err(err).Msg("could not pull libcedana")
-					return err
-				}
-			} else {
-				logger.Debug().Msgf("using gpu shared lib at %s", viper.GetString("gpu_shared_lib_path"))
-			}
+		// defaults to 11_8, this continues if --cuda is not specified
+		cudaVersion, _ := cmd.Flags().GetString(cudaVersionFlag)
+		if _, ok := cudaVersions[cudaVersion]; !ok {
+			err = fmt.Errorf("invalid cuda version %s, must be one of %v", cudaVersion, cudaVersions)
+			logger.Error().Err(err).Msg("invalid cuda version")
+			return err
 		}
 
 		logger.Info().Msgf("starting daemon version %s", rootCmd.Version)
 
-		err = api.StartServer(ctx)
+		err = api.StartServer(ctx, &api.ServeOpts{GPUEnabled: gpuEnabled, CUDAVersion: cudaVersions[cudaVersion]})
 		if err != nil {
 			logger.Error().Err(err).Msgf("stopping daemon")
 			return err
@@ -167,63 +140,4 @@ func init() {
 	daemonCmd.AddCommand(checkDaemonCmd)
 	startDaemonCmd.Flags().BoolP(gpuEnabledFlag, "g", false, "start daemon with GPU support")
 	startDaemonCmd.Flags().String(cudaVersionFlag, "11.8", "cuda version to use")
-}
-
-type pullGPUBinaryRequest struct {
-	CudaVersion string `json:"cuda_version"`
-}
-
-func pullGPUBinary(ctx context.Context, binary string, filePath string, version string) error {
-	logger := ctx.Value("logger").(*zerolog.Logger)
-	_, err := os.Stat(filePath)
-	if err == nil {
-		logger.Debug().Str("Path", filePath).Msgf("GPU binary exists. Delete existing binary to download another supported cuda version.")
-		// TODO NR - check version and checksum of binary?
-		return nil
-	}
-	logger.Debug().Msgf("pulling gpu binary %s for cuda version %s", binary, version)
-
-	url := viper.GetString("connection.cedana_url") + "/checkpoint/gpu/" + binary
-	logger.Debug().Msgf("pulling %s from %s", binary, url)
-
-	httpClient := &http.Client{}
-
-	body := pullGPUBinaryRequest{
-		CudaVersion: version,
-	}
-
-	jsonBody, err := json.Marshal(body)
-	if err != nil {
-		logger.Err(err).Msg("could not marshal request body")
-		return err
-	}
-
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonBody))
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", viper.GetString("connection.cedana_auth_token")))
-	req.Header.Set("Content-Type", "application/json")
-
-	resp, err := httpClient.Do(req)
-	if err != nil || resp.StatusCode != http.StatusOK {
-		logger.Err(err).Msg("gpu binary get request failed")
-		return err
-	}
-	defer resp.Body.Close()
-
-	file, err := os.OpenFile(filePath, os.O_CREATE|os.O_WRONLY, 0755)
-	if err == nil {
-		err = os.Chmod(filePath, 0755)
-	}
-	if err != nil {
-		logger.Err(err).Msg("could not create file")
-		return err
-	}
-	defer file.Close()
-
-	_, err = io.Copy(file, resp.Body)
-	if err != nil {
-		logger.Err(err).Msg("could not read file from response")
-		return err
-	}
-	logger.Debug().Msgf("%s downloaded to %s", binary, filePath)
-	return err
 }

--- a/test/regression/helper.bash
+++ b/test/regression/helper.bash
@@ -13,7 +13,8 @@ function stop_cedana() {
 function exec_task() {
     local task="$1"
     local job_id="$2"
-    cedana exec -w "$DIR" "$task" -i "$job_id"
+    shift 2
+    cedana exec -w "$DIR" "$task" -i "$job_id" $@
 }
 
 function checkpoint_task() {

--- a/test/regression/helper.bash
+++ b/test/regression/helper.bash
@@ -18,7 +18,8 @@ function exec_task() {
 
 function checkpoint_task() {
     local job_id="$1"
-    cedana dump job "$job_id" -d /tmp
+    shift 1
+    cedana dump job "$job_id" -d /tmp $@
 }
 
 function restore_task() {

--- a/test/regression/main.bats
+++ b/test/regression/main.bats
@@ -124,6 +124,21 @@ teardown() {
     cedana config show | grep leave_running | grep true
 }
 
+@test "Complain if GPU not enabled in daemon and using GPU flags" {
+    local task="./workload.sh"
+    local job_id="workload-no-gpu"
+
+    # try to run a job with GPU flags
+    run exec_task $task $job_id --gpu-enabled
+    [ "$status" -ne 0 ]
+
+    # try to dump unmanaged process with GPU flags
+    run exec_task $task $job_id
+    [ "$status" -eq 0 ]
+    run dump_task $job_id --gpu-enabled
+    [ "$status" -ne 0 ]
+}
+
 @test "Rootfs snapshot of containerd container" {
     local container_id="busybox-test"
     local image_ref="checkpoint/test:latest"


### PR DESCRIPTION
## Describe your changes
Currently, the healthcheck does a GPU health check regardless of whether the daemon was start with
`--gpu-enabled`. This was fixed.

Now, if GPU-support is not enabled in daemon, `cedana exec -g` will complain. Also, `cedana dump -g` will complain if trying to dump a job that is not 'managed' by the daemon, as the GPU-support is only possible for managed jobs.

## Issue ticket number 
CED-609

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
> New tests added.
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
> Move the GPU binary download logic to server. Now `StartServer` takes a `ServerOpts`, and `sevice` has persistent state flags `gpuEnabled` and `cudaVersion`.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.