### PR TITLE
hotfix: Don't error if GPU restore stats is nil

### DIFF
--- a/api/restore.go
+++ b/api/restore.go
@@ -666,12 +666,11 @@ func (s *service) gpuRestore(ctx context.Context, dir string, uid, gid int32, gr
 		}
 	}
 
-	if resp.GpuRestoreStats == nil {
-		return nil, fmt.Errorf("gpu controller returned nil stats")
-	}
-	stats.GPURestoreStats = &gpu.GPURestoreStats{
-		CopyMemTime:     resp.GpuRestoreStats.CopyMemTime,
-		ReplayCallsTime: resp.GpuRestoreStats.ReplayCallsTime,
+	if resp.GpuRestoreStats != nil {
+		stats.GPURestoreStats = &gpu.GPURestoreStats{
+			CopyMemTime:     resp.GpuRestoreStats.CopyMemTime,
+			ReplayCallsTime: resp.GpuRestoreStats.ReplayCallsTime,
+		}
 	}
 	s.logger.Info().Msgf("gpu controller returned %v", resp)
 


### PR DESCRIPTION
## Describe your changes
This is needed for better backward compatibility, as it's older versions of `cedana-gpu` to always fail on `cedana restore`.

## Issue ticket number 
NA

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.