### PR TITLE
Run all tests on push

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -6,22 +6,39 @@ on:
     branches:
       - main
   workflow_dispatch:
-      inputs:
-        debug_build:
-          type: boolean
-          description: 'Run build with debugging enabled'
-          required: false
-          default: false
-        debug_smoke_test:
-          type: boolean
-          description: 'Run smoke test with debugging enabled'
-          required: false
-          default: false
-        debug_regression_test:
-          type: boolean
-          description: 'Run regression test with debugging enabled'
-          required: false
-          default: false
+    inputs:
+      debug_build:
+        type: boolean
+        description: 'Run build with debugging enabled'
+        required: false
+        default: false
+      debug_smoke_test:
+        type: boolean
+        description: 'Run smoke test with debugging enabled'
+        required: false
+        default: false
+      debug_regression_test:
+        type: boolean
+        description: 'Run regression test with debugging enabled'
+        required: false
+        default: false
+  workflow_call: # to reuse this workflow in other worflows
+    inputs:
+      debug_build:
+        type: boolean
+        description: 'Run build with debugging enabled'
+        required: false
+        default: false
+      debug_smoke_test:
+        type: boolean
+        description: 'Run smoke test with debugging enabled'
+        required: false
+        default: false
+      debug_regression_test:
+        type: boolean
+        description: 'Run regression test with debugging enabled'
+        required: false
+        default: false
 
 concurrency:
   group: cedana-pr-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -54,7 +54,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: true
           submodules: 'recursive'
 
@@ -88,7 +88,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: true
           submodules: 'recursive'
 
@@ -123,7 +123,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
           fetch-tags: true
           submodules: 'recursive'
 

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,7 +1,9 @@
-name: PR
+name: Push
 
 on:
   push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       debug_test:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -1,0 +1,24 @@
+name: PR
+
+on:
+  push:
+  workflow_dispatch:
+    inputs:
+      debug_test:
+        type: boolean
+        description: 'Run tests with debugging enabled'
+        required: false
+        default: false
+
+concurrency:
+  group: cedana-push-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Test
+    uses: ./.github/workflows/pr.yml
+    with:
+      debug_build: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+      debug_smoke_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+      debug_regression_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,12 +40,12 @@ jobs:
     name: Test
     uses: ./.github/workflows/pr.yml
     with:
-      debug_build: ${{ github.event.inputs.debug_test }}
-      debug_smoke_test: ${{ github.event.inputs.debug_test }}
-      debug_regression_test: ${{ github.event.inputs.debug_test }}
+      debug_build: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+      debug_smoke_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+      debug_regression_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
 
   build-publish-amd64:
-    name: Publish (amd64)
+    name: Build & Publish (amd64)
     runs-on: ubuntu-latest
     needs: test
     container:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,11 @@ on:
       - "*"
   workflow_dispatch:
     inputs:
+      debug_test:
+        type: boolean
+        description: "Run tests with debugging enabled"
+        required: false
+        default: false
       debug_build_publish_amd64:
         type: boolean
         description: "Run build & publish (amd64 binary) with debugging enabled"
@@ -31,9 +36,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  test:
+    name: Test
+    uses: ./.github/workflows/pr.yml
+    with:
+      debug_build: ${{ github.event.inputs.debug_test }}
+      debug_smoke_test: ${{ github.event.inputs.debug_test }}
+      debug_regression_test: ${{ github.event.inputs.debug_test }}
+
   build-publish-amd64:
-    name: Build & Publish (amd64)
+    name: Publish (amd64)
     runs-on: ubuntu-latest
+    needs: test
     container:
       image: golang:1.22-bullseye
     steps:
@@ -70,6 +84,7 @@ jobs:
   build-push-image-manifest-amd64:
     name: Build & Push (amd64 image)
     runs-on: ubicloud-standard-2
+    needs: test
 
     permissions:
       contents: read
@@ -142,6 +157,7 @@ jobs:
   build-push-image-manifest-arm64:
     name: Build & Push (arm64 image)
     runs-on: ubicloud-standard-2-arm
+    needs: test
 
     permissions:
       contents: read


### PR DESCRIPTION
## Describe your changes
Currently, tests are only run on a PR. An issue that only occures after merging to main will be missed. Before creating a release, we should be able to see that the tests pass on the main branch.

As show below, the 'green check mark' is missing on main branch:

![image](https://github.com/user-attachments/assets/427bdb11-9212-4f58-986d-a5c757c4b6c6)

Release workflow will now look like:

![image](https://github.com/user-attachments/assets/8857c81b-48dc-40c5-a75f-06dba536c18c)

Creates a new 'Push' workflow that only runs on the main branch. Also runs the tests as part of the release workflow before publishing. Both simply reuse the existing PR workflow.

## Issue ticket number 
CED-615

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
> Manually tested by creating a tag. Thus, you will see a release workflow in the checks below.
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.