### PR TITLE
Add `criu check` to healthcheck

### DIFF
--- a/api/criu.go
+++ b/api/criu.go
@@ -252,7 +252,7 @@ func (c *Criu) IsCriuAtLeast(version int) (bool, error) {
 func (c *Criu) Check() (string, error) {
 	// return c.doSwrk(rpc.CriuReqType_CHECK, nil, nil, nil)
 
-	// XXX: Since heck is not working with swrk, we directly call
+	// XXX: Since check is not working with swrk, we directly call
 	// call criu check and check exit code and also stderr
 	cmd := exec.Command("criu", "check")
 	out, err := cmd.CombinedOutput()

--- a/api/criu.go
+++ b/api/criu.go
@@ -250,6 +250,9 @@ func (c *Criu) IsCriuAtLeast(version int) (bool, error) {
 }
 
 func (c *Criu) Check() (string, error) {
+	// return c.doSwrk(rpc.CriuReqType_CHECK, nil, nil, nil)
+
+	// XXX: Since heck is not working with swrk, we directly call
 	// call criu check and check exit code and also stderr
 	cmd := exec.Command("criu", "check")
 	out, err := cmd.CombinedOutput()

--- a/api/server.go
+++ b/api/server.go
@@ -371,8 +371,13 @@ func (s *service) DetailedHealthCheck(ctx context.Context, req *task.DetailedHea
 	var unhealthyReasons []string
 	resp := &task.DetailedHealthCheckResponse{}
 
-	// TODO NR - Add CRIU check to output
 	criuVersion, err := s.CRIU.GetCriuVersion()
+	if err != nil {
+		resp.UnhealthyReasons = append(unhealthyReasons, fmt.Sprintf("CRIU: %v", err))
+	}
+
+	check, err := s.CRIU.Check()
+	s.logger.Debug().Str("resp", check).Msg("error checking criu")
 	if err != nil {
 		resp.UnhealthyReasons = append(unhealthyReasons, fmt.Sprintf("CRIU: %v", err))
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -377,7 +377,7 @@ func (s *service) DetailedHealthCheck(ctx context.Context, req *task.DetailedHea
 	}
 
 	check, err := s.CRIU.Check()
-	s.logger.Debug().Str("resp", check).Msg("error checking criu")
+	s.logger.Debug().Str("resp", check).Msg("CRIU check")
 	if err != nil {
 		resp.UnhealthyReasons = append(unhealthyReasons, fmt.Sprintf("CRIU: %v", err))
 	}

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -126,14 +126,15 @@ var checkDaemonCmd = &cobra.Command{
 			return fmt.Errorf("health failed with reasons: %v", resp.UnhealthyReasons)
 		}
 
-		fmt.Println("Daemon is running and healthy.")
+		fmt.Println("All good.")
+		fmt.Println("Cedana version: ", rootCmd.Version)
 		fmt.Println("CRIU version: ", resp.HealthCheckStats.CriuVersion)
 		if resp.HealthCheckStats.GPUHealthCheck != nil {
 			prettyJson, err := json.MarshalIndent(resp.HealthCheckStats.GPUHealthCheck, "", "  ")
 			if err != nil {
 				return err
 			}
-			fmt.Println("GPU health Check: ", string(prettyJson))
+			fmt.Println("GPU support: ", string(prettyJson))
 		}
 
 		return nil

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -3,7 +3,6 @@ package cmd
 // This file contains all the dump-related commands when starting `cedana dump ...`
 
 import (
-	"encoding/json"
 	"fmt"
 	"strconv"
 	"strings"
@@ -63,8 +62,7 @@ var dumpProcessCmd = &cobra.Command{
 			}
 			return err
 		}
-		stats, _ := json.Marshal(resp.DumpStats)
-		logger.Info().Str("message", resp.Message).RawJSON("stats", stats).Msgf("Success")
+		logger.Info().Str("message", resp.Message).Interface("stats", resp.DumpStats).Msgf("Success")
 
 		return nil
 	},
@@ -118,8 +116,7 @@ var dumpJobCmd = &cobra.Command{
 			}
 			return err
 		}
-		stats, _ := json.Marshal(resp.DumpStats)
-		logger.Info().Str("message", resp.Message).RawJSON("stats", stats).Msgf("Success")
+		logger.Info().Str("message", resp.Message).Interface("stats", resp.DumpStats).Msgf("Success")
 
 		return nil
 	},

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -4,7 +4,6 @@ package cmd
 
 import (
 	"bufio"
-	"encoding/json"
 	"fmt"
 	"os"
 
@@ -73,8 +72,7 @@ var restoreProcessCmd = &cobra.Command{
 			}
 			return err
 		}
-		stats, _ := json.Marshal(resp.RestoreStats)
-		logger.Info().Str("message", resp.Message).Int32("PID", resp.NewPID).RawJSON("stats", stats).Msgf("Success")
+		logger.Info().Str("message", resp.Message).Int32("PID", resp.NewPID).Interface("stats", resp.RestoreStats).Msgf("Success")
 
 		return nil
 	},
@@ -181,8 +179,7 @@ var restoreJobCmd = &cobra.Command{
 			}
 			return err
 		}
-		stats, _ := json.Marshal(resp.RestoreStats)
-		logger.Info().Str("message", resp.Message).Int32("PID", resp.NewPID).RawJSON("stats", stats).Msgf("Success")
+		logger.Info().Str("message", resp.Message).Int32("PID", resp.NewPID).Interface("stats", resp.RestoreStats).Msgf("Success")
 
 		return nil
 	},

--- a/test/regression/main.bats
+++ b/test/regression/main.bats
@@ -35,6 +35,10 @@ teardown() {
     cedana --version | grep -q "$(git describe --tags --always)"
 }
 
+@test "Daemon health check" {
+    cedana daemon check
+}
+
 @test "Output file created and has some data" {
     local task="./workload.sh"
     local job_id="workload"


### PR DESCRIPTION
## Describe your changes
The health check must also do a `criu check` as the version check is not enough.

Also, now `cedana daemon check` will exit with a non-zero code if any of the checks fail.

## Issue ticket number 
CED-610

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
> Added healthcheck to regression tests.
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.