### PR TITLE
Capture more info during release & also post on slack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,5 +365,5 @@ jobs:
           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
         with:
           payload: |
-            ${{ steps.summary-patch.outputs.slack-summary }}
+            ${{ steps.summary.outputs.slack-summary }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -344,8 +344,8 @@ jobs:
       - name: Generate summary
         id: summary
         env:
-          RELEASE_TITLE: 'Release summary'
-          RELEASE_DESCRIPTION: '> **cedana ${{ steps.tag.outputs.tag }}**'
+          RELEASE_TITLE: 'cedana'
+          RELEASE_DESCRIPTION: '**${{ steps.tag.outputs.tag }}**'
           RELEASE_NOTES_URL: https://github.com/${{ github.repository }}/releases/${{ steps.tag.outputs.tag }}
           RELEASE_BODY: '${{ steps.release-info.outputs.description }}'
           TAG: ${{ steps.tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -303,22 +303,27 @@ jobs:
           submodules: recursive
           fetch-tags: true
 
-      - name: Get release info
-        id: release-info
-        uses: jossef/action-latest-release-info@v1.2.1
-        env:
-          GITHUB_TOKEN: ${{ github.token }}
+      - name: Get tag
+        id: tag
+        run: |
+          echo ::set-output name=tag::$(git tag --sort=-creatordate | sed -n '1p')
 
       - name: Get previous tag
         id: previous-tag
         run: |
           echo ::set-output name=tag::$(git tag --sort=-creatordate | sed -n '2p')
 
+      - name: Get release info
+        id: release-info
+        uses: thedaviddias/publish-release-info-action@v3.3.0
+        with:
+          github_token: ${{ github.token }}
+
       - name: Download binary
         uses: robinraju/release-downloader@v1
         id: download
         with:
-          tag: ${{ steps.release-info.outputs.tag_name }}
+          tag: ${{ steps.tag.outputs.tag }}
           fileName: '*amd64.tar.gz'
           extract: true
           token: ${{ github.token }}
@@ -338,10 +343,10 @@ jobs:
         id: summary
         env:
           RELEASE_TITLE: 'Release summary'
-          RELEASE_DESCRIPTION: '> **cedana ${{ steps.release-info.outputs.tag_name }}**'
-          RELEASE_NOTES_URL: https://github.com/cedana/cedana-gpu/releases/${{ steps.release-info.outputs.tag_name }}
-          RELEASE_BODY: '${{ steps.release-info.outputs.draft }}'
-          TAG: ${{ steps.release-info.outputs.tag_name }}
+          RELEASE_DESCRIPTION: '> **${{ steps.release-info.outputs.repo }} ${{ steps.tag.outputs.tag }}**'
+          RELEASE_NOTES_URL: ${{ steps.release-info.outputs.repoLink }}/releases/${{ steps.tag.outputs.tag }}
+          RELEASE_BODY: '${{ steps.release-info.outputs.prList }}'
+          TAG: ${{ steps.tag.outputs.tag }}
           BINARY: current/cedana
           PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}
           PREVIOUS_BINARY: previous/cedana

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -315,9 +315,11 @@ jobs:
 
       - name: Get release info
         id: release-info
-        uses: thedaviddias/publish-release-info-action@v3.3.0
+        uses: pozetroninc/github-action-get-latest-release@master
         with:
-          github_token: ${{ github.token }}
+          token: ${{ github.token }}
+          excludes: draft # TODO: exclude prerelease
+          repository: ${{ github.repository }}
 
       - name: Download binary
         uses: robinraju/release-downloader@v1
@@ -343,9 +345,9 @@ jobs:
         id: summary
         env:
           RELEASE_TITLE: 'Release summary'
-          RELEASE_DESCRIPTION: '> **${{ steps.release-info.outputs.repo }} ${{ steps.tag.outputs.tag }}**'
-          RELEASE_NOTES_URL: ${{ steps.release-info.outputs.repoLink }}/releases/${{ steps.tag.outputs.tag }}
-          RELEASE_BODY: '${{ steps.release-info.outputs.prList }}'
+          RELEASE_DESCRIPTION: '> **cedana ${{ steps.tag.outputs.tag }}**'
+          RELEASE_NOTES_URL: ${{ github.repositoryUrl }}/releases/${{ steps.tag.outputs.tag }}
+          RELEASE_BODY: '${{ steps.release-info.outputs.description }}'
           TAG: ${{ steps.tag.outputs.tag }}
           BINARY: current/cedana
           PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,11 +337,11 @@ jobs:
       - name: Generate summary
         id: summary
         env:
-          RELEASE_TITLE: cedana ${{ steps.release-info.outputs.tag_name }}
-          RELEASE_DESCRIPTION: ${{ steps.release-info.outputs.created_at }}
+          RELEASE_TITLE: 'Release summary'
+          RELEASE_DESCRIPTION: '> **cedana ${{ steps.release-info.outputs.tag_name }}**'
           RELEASE_NOTES_URL: https://github.com/cedana/cedana-gpu/releases/${{ steps.release-info.outputs.tag_name }}
-          RELEASE_BODY: ${{ steps.release-info.outputs.draft }}
-          TAG: ${{ github.ref }}
+          RELEASE_BODY: '${{ steps.release-info.outputs.draft }}'
+          TAG: ${{ steps.release-info.outputs.tag_name }}
           BINARY: current/cedana
           PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}
           PREVIOUS_BINARY: previous/cedana

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,7 @@ jobs:
         env:
           RELEASE_TITLE: 'Release summary'
           RELEASE_DESCRIPTION: '> **cedana ${{ steps.tag.outputs.tag }}**'
-          RELEASE_NOTES_URL: ${{ github.repositoryUrl }}/releases/${{ steps.tag.outputs.tag }}
+          RELEASE_NOTES_URL: https://github.com/${{ github.repository }}/releases/${{ steps.tag.outputs.tag }}
           RELEASE_BODY: '${{ steps.release-info.outputs.description }}'
           TAG: ${{ steps.tag.outputs.tag }}
           BINARY: current/cedana

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -337,7 +337,7 @@ jobs:
       - name: Generate summary
         id: summary
         env:
-          RELEASE_TITLE: cedana ${{ github.ref }}
+          RELEASE_TITLE: cedana ${{ steps.release-info.outputs.tag_name }}
           RELEASE_DESCRIPTION: ${{ steps.release-info.outputs.created_at }}
           RELEASE_NOTES_URL: https://github.com/cedana/cedana-gpu/releases/${{ steps.release-info.outputs.tag_name }}
           RELEASE_BODY: ${{ steps.release-info.outputs.draft }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -316,7 +316,7 @@ jobs:
 
       - name: Download binary
         uses: robinraju/release-downloader@v1
-        id: download-previous
+        id: download
         with:
           tag: ${{ steps.release-info.outputs.tag_name }}
           fileName: '*amd64.tar.gz'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -353,17 +353,17 @@ jobs:
           PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}
           PREVIOUS_BINARY: previous/cedana
         run: |
-          scripts/ci/release-summary-slack > $GITHUB_STEP_SUMMARY
+          echo $RELEASE_BODY > $GITHUB_STEP_SUMMARY
           echo ::set-output name=slack-summary::$(scripts/ci/release-summary-slack)
 
-#       - name: Post summary
-#         if: ${{ (github.event_name != 'workflow_dispatch') || (inputs.post_summary) }}
-#         id: slack-patch
-#         uses: slackapi/slack-github-action@v1.26.0
-#         env:
-#           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RELEASE }}
-#           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
-#         with:
-#           payload: |
-#             ${{ steps.summary-patch.outputs.slack-summary }}
+      - name: Post summary
+        if: ${{ (github.event_name != 'workflow_dispatch') || (inputs.post_summary) }}
+        id: slack-patch
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RELEASE }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            ${{ steps.summary-patch.outputs.slack-summary }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  test:
-    name: Test
-    uses: ./.github/workflows/pr.yml
-    with:
-      debug_build: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
-      debug_smoke_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
-      debug_regression_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+  # test:
+  #   name: Test
+  #   uses: ./.github/workflows/pr.yml
+  #   with:
+  #     debug_build: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+  #     debug_smoke_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+  #     debug_regression_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
 
   build-publish-amd64:
     name: Build & Publish (amd64)
     runs-on: ubuntu-latest
-    needs: test
+    # needs: test
     container:
       image: golang:1.22-bullseye
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ on:
         description: "Run build & push (arm64 image) with debugging enabled"
         required: false
         default: false
+      post_summary:
+        type: boolean
+        description: "Post summary to slack"
+        required: false
+        default: false
 
 permissions:
   contents: write
@@ -282,3 +287,76 @@ jobs:
           # check if commit sha matches with the latest commit sha
           # we only match docker hub image as both images should be the same
           echo $(docker run -i --rm cedana/cedana-helper:${{ steps.meta.outputs.version }} -c "cedana -v")
+
+  post-summary:
+    name: Post Summary
+    runs-on: ubuntu-latest
+    needs: ["build-publish-amd64"]
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          submodules: recursive
+          fetch-tags: true
+
+      - name: Get release info
+        id: release-info
+        uses: jossef/action-latest-release-info@v1.2.1
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+
+      - name: Get previous tag
+        id: previous-tag
+        run: |
+          echo ::set-output name=tag::$(git tag --sort=-creatordate | sed -n '2p')
+
+      - name: Download binary
+        uses: robinraju/release-downloader@v1
+        id: download-previous
+        with:
+          tag: ${{ steps.release-info.outputs.tag_name }}
+          fileName: '*amd64.tar.gz'
+          extract: true
+          token: ${{ github.token }}
+          out-file-path: current
+
+      - name: Download previous binary
+        uses: robinraju/release-downloader@v1
+        id: download-previous
+        with:
+          tag: ${{ steps.previous-tag.outputs.tag }}
+          fileName: '*amd64.tar.gz'
+          extract: true
+          token: ${{ github.token }}
+          out-file-path: previous
+
+      - name: Generate summary
+        id: summary
+        env:
+          RELEASE_TITLE: cedana ${{ github.ref }}
+          RELEASE_DESCRIPTION: ${{ steps.release-info.outputs.created_at }}
+          RELEASE_NOTES_URL: https://github.com/cedana/cedana-gpu/releases/${{ steps.release-info.outputs.tag_name }}
+          RELEASE_BODY: ${{ steps.release-info.outputs.draft }}
+          TAG: ${{ github.ref }}
+          BINARY: current/cedana
+          PREVIOUS_TAG: ${{ steps.previous-tag.outputs.tag }}
+          PREVIOUS_BINARY: previous/cedana
+        run: |
+          scripts/ci/release-summary-slack > $GITHUB_STEP_SUMMARY
+          echo ::set-output name=slack-summary::$(scripts/ci/release-summary-slack)
+
+#       - name: Post summary
+#         if: ${{ (github.event_name != 'workflow_dispatch') || (inputs.post_summary) }}
+#         id: slack-patch
+#         uses: slackapi/slack-github-action@v1.26.0
+#         env:
+#           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_RELEASE }}
+#           SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+#         with:
+#           payload: |
+#             ${{ steps.summary-patch.outputs.slack-summary }}
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,18 +41,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # test:
-  #   name: Test
-  #   uses: ./.github/workflows/pr.yml
-  #   with:
-  #     debug_build: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
-  #     debug_smoke_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
-  #     debug_regression_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+  test:
+    name: Test
+    uses: ./.github/workflows/pr.yml
+    with:
+      debug_build: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+      debug_smoke_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
+      debug_regression_test: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_test }}
 
   build-publish-amd64:
     name: Build & Publish (amd64)
     runs-on: ubuntu-latest
-    # needs: test
+    needs: test
     container:
       image: golang:1.22-bullseye
     steps:
@@ -89,7 +89,7 @@ jobs:
   build-push-image-manifest-amd64:
     name: Build & Push (amd64 image)
     runs-on: ubicloud-standard-2
-    # needs: test
+    needs: test
 
     permissions:
       contents: read
@@ -162,7 +162,7 @@ jobs:
   build-push-image-manifest-arm64:
     name: Build & Push (arm64 image)
     runs-on: ubicloud-standard-2-arm
-    # needs: test
+    needs: test
 
     permissions:
       contents: read
@@ -318,7 +318,7 @@ jobs:
         uses: pozetroninc/github-action-get-latest-release@master
         with:
           token: ${{ github.token }}
-          excludes: draft # TODO: exclude prerelease
+          excludes: draft
           repository: ${{ github.repository }}
 
       - name: Download binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
   build-push-image-manifest-amd64:
     name: Build & Push (amd64 image)
     runs-on: ubicloud-standard-2
-    needs: test
+    # needs: test
 
     permissions:
       contents: read
@@ -162,7 +162,7 @@ jobs:
   build-push-image-manifest-arm64:
     name: Build & Push (arm64 image)
     runs-on: ubicloud-standard-2-arm
-    needs: test
+    # needs: test
 
     permissions:
       contents: read

--- a/scripts/ci/release-summary-slack
+++ b/scripts/ci/release-summary-slack
@@ -55,6 +55,23 @@ if BODY:
     )
     blocks.append({'type': 'divider'})
 
+if PREVIOUS_TAG:
+    blocks.append(
+        {
+            'type': 'context',
+            'elements': [
+                {
+                    'type': 'mrkdwn',
+                    'text': f'Version *{TAG}*',
+                },
+                {
+                    'type': 'mrkdwn',
+                    'text': f'_Previously {PREVIOUS_TAG}_',
+                }
+            ],
+        }
+    )
+
 if TAG and PREVIOUS_TAG and BINARY and PREVIOUS_BINARY:
     binary_size_mib = os.path.getsize(BINARY) / 1024 / 1024
     previous_binary_size_mib = os.path.getsize(PREVIOUS_BINARY) / 1024 / 1024
@@ -64,25 +81,12 @@ if TAG and PREVIOUS_TAG and BINARY and PREVIOUS_BINARY:
             'elements': [
                 {
                     'type': 'mrkdwn',
-                    'text': f'Binary size: *{binary_size_mib:.2f} MiB*',
+                    'text': f'Binary size *{binary_size_mib:.2f} MiB*',
                 },
                 {
                     'type': 'mrkdwn',
-                    'text': f'Previous size: *{previous_binary_size_mib:.2f} MiB*',
+                    'text': f'_Previously *{previous_binary_size_mib:.2f} MiB_',
                 },
-            ],
-        }
-    )
-
-if PREVIOUS_TAG:
-    blocks.append(
-        {
-            'type': 'context',
-            'elements': [
-                {
-                    'type': 'mrkdwn',
-                    'text': f'Previous patch: *{PREVIOUS_TAG}*',
-                }
             ],
         }
     )

--- a/scripts/ci/release-summary-slack
+++ b/scripts/ci/release-summary-slack
@@ -64,12 +64,25 @@ if TAG and PREVIOUS_TAG and BINARY and PREVIOUS_BINARY:
             'elements': [
                 {
                     'type': 'mrkdwn',
-                    'text': f'Binary size *{binary_size_mib:.2f} MiB*',
+                    'text': f'Binary size: *{binary_size_mib:.2f} MiB*',
                 },
                 {
                     'type': 'mrkdwn',
-                    'text': f'Previous size *{previous_binary_size_mib:.2f} MiB*',
+                    'text': f'Previous size: *{previous_binary_size_mib:.2f} MiB*',
                 },
+            ],
+        }
+    )
+
+if PREVIOUS_TAG:
+    blocks.append(
+        {
+            'type': 'context',
+            'elements': [
+                {
+                    'type': 'mrkdwn',
+                    'text': f'Previous patch: *{PREVIOUS_TAG}*',
+                }
             ],
         }
     )

--- a/scripts/ci/release-summary-slack
+++ b/scripts/ci/release-summary-slack
@@ -85,7 +85,7 @@ if TAG and PREVIOUS_TAG and BINARY and PREVIOUS_BINARY:
                 },
                 {
                     'type': 'mrkdwn',
-                    'text': f'_Previously *{previous_binary_size_mib:.2f} MiB_',
+                    'text': f'_Previously {previous_binary_size_mib:.2f} MiB_',
                 },
             ],
         }

--- a/scripts/ci/release-summary-slack
+++ b/scripts/ci/release-summary-slack
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""
+Release summary JSON for Slack using Block Kit
+"""
+
+import json
+import os
+
+TITLE = os.getenv('RELEASE_TITLE') or 'Release summary'
+DESCRIPTION = os.getenv('RELEASE_DESCRIPTION') or os.getenv('TAG') or '...'
+RELEASE_NOTES_URL = (
+    os.getenv('RELEASE_NOTES_URL')
+    or 'https://github.com/cedana/cedana/releases'
+)
+BODY = os.getenv('RELEASE_BODY')
+TAG = os.getenv('TAG')
+BINARY = os.getenv('BINARY')
+PREVIOUS_TAG = os.getenv('PREVIOUS_TAG')
+PREVIOUS_BINARY = os.getenv('PREVIOUS_BINARY')
+
+TITLE = TITLE.replace('**', '*')
+DESCRIPTION = DESCRIPTION.replace('**', '*')
+
+blocks = []
+blocks.append(
+    {
+        'type': 'header',
+        'text': {'type': 'plain_text', 'text': TITLE, 'emoji': True},
+    }
+)
+blocks.append(
+    {
+        'type': 'section',
+        'text': {'type': 'mrkdwn', 'text': DESCRIPTION},
+        'accessory': {
+            'type': 'button',
+            'text': {
+                'type': 'plain_text',
+                'text': 'Release notes',
+                'emoji': True,
+            },
+            'url': RELEASE_NOTES_URL,
+            'action_id': 'button-action',
+        },
+    }
+)
+blocks.append({'type': 'divider'})
+
+if BODY:
+    blocks.append(
+        {
+            'type': 'section',
+            'text': {'type': 'mrkdwn', 'text': BODY},
+        }
+    )
+    blocks.append({'type': 'divider'})
+
+if TAG and PREVIOUS_TAG and BINARY and PREVIOUS_BINARY:
+    binary_size_mib = os.path.getsize(BINARY) / 1024 / 1024
+    previous_binary_size_mib = os.path.getsize(PREVIOUS_BINARY) / 1024 / 1024
+    blocks.append(
+        {
+            'type': 'context',
+            'elements': [
+                {
+                    'type': 'mrkdwn',
+                    'text': f'Binary size *{binary_size_mib:.2f} MiB*',
+                },
+                {
+                    'type': 'mrkdwn',
+                    'text': f'Previous size *{previous_binary_size_mib:.2f} MiB*',
+                },
+            ],
+        }
+    )
+
+summary = {'blocks': blocks}
+print(json.dumps(summary))


### PR DESCRIPTION
## Describe your changes
Would make sense to capture binary size changes from last, at least.

On release, a notification on slack using our CI bot would be nice so we are sure to keep an eye. Drafts a custom Slack message using the [Block Kit](https://api.slack.com/block-kit), so we can modify it as per need. For e.g., we could add a deps diff later on. 

Similar script is used for GPU benchmark Slack summaries as well, so it would make sense to create our own github action at some point, so it can be easily added to all repos. No action out there provides all the exact stuff we need.

## Issue ticket number 
CED-592

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 

