### PR TITLE
Fix job state update on early exit

### DIFF
--- a/api/process.go
+++ b/api/process.go
@@ -213,10 +213,8 @@ func (s *service) startHelper(ctx context.Context, args *task.StartArgs, stream 
 
 	state := &task.ProcessState{}
 
-	state.JobState = task.JobState_JOB_RUNNING
 	if args.JID == "" {
 		state.JID = xid.New().String()
-		args.JID = state.JID
 	} else {
 		existingState, _ := s.getState(ctx, args.JID)
 		if existingState != nil {
@@ -224,35 +222,48 @@ func (s *service) startHelper(ctx context.Context, args *task.StartArgs, stream 
 		}
 		state.JID = args.JID
 	}
-	err := s.updateState(ctx, state.JID, state)
-	if err != nil {
-		return nil, status.Error(codes.Internal, fmt.Sprintf("failed to update state: %s", err.Error()))
-	}
+	args.JID = state.JID
 
-	pid, done, err := s.run(ctx, args, stream)
-	state.PID = pid
+	pid, exitCode, err := s.run(ctx, args, stream)
 	if err != nil {
-		// TODO BS: this should be at market level
-		s.logger.Error().Err(err).Msgf("failed to run task, attempt %d", 1)
-		state.JobState = task.JobState_JOB_STARTUP_FAILED
-		s.updateState(ctx, state.JID, state) // because it's a managed job
+		s.logger.Error().Err(err).Msg("failed to run task")
 		return nil, status.Error(codes.Internal, "failed to run task")
-		// TODO BS: replace doom loop with just retrying from market
 	}
+	s.logger.Info().Int32("PID", pid).Str("JID", state.JID).Msgf("managing process")
+	state.PID = pid
+	state.JobState = task.JobState_JOB_RUNNING
 	err = s.updateState(ctx, state.JID, state)
 	if err != nil {
-		s.logger.Warn().Err(err).Msg("failed to update state after starting job")
+		s.logger.Fatal().Err(err).Msg("failed to update state after run")
+		syscall.Kill(int(pid), syscall.SIGKILL) // kill cuz inconsistent state
+		return nil, status.Error(codes.Internal, "failed to update state after run")
 	}
 
-	s.logger.Info().Int32("PID", pid).Str("JID", state.JID).Msgf("managing process")
-
-	if state.JobState == task.JobState_JOB_STARTUP_FAILED {
-		err = status.Error(codes.Internal, "Task startup failed")
-		return nil, err
-	}
-
-	if stream != nil && done != nil {
-		<-done
+	if stream != nil && exitCode != nil {
+		code := <-exitCode // if streaming, wait for process to finish
+		if stream != nil {
+			stream.Send(&task.StartAttachResp{
+				ExitCode: int32(code),
+			})
+		}
+		state.JobState = task.JobState_JOB_DONE
+		err = s.updateState(context.WithoutCancel(ctx), state.JID, state)
+		if err != nil {
+			s.logger.Fatal().Err(err).Msg("failed to update state after done")
+			return nil, status.Error(codes.Internal, "failed to update state after done")
+		}
+	} else {
+		s.wg.Add(1)
+		go func() {
+			defer s.wg.Done()
+			<-exitCode
+			state.JobState = task.JobState_JOB_DONE
+			err = s.updateState(context.WithoutCancel(ctx), state.JID, state)
+			if err != nil {
+				s.logger.Fatal().Err(err).Msg("failed to update state after done")
+				return
+			}
+		}()
 	}
 
 	return &task.StartResp{
@@ -264,7 +275,7 @@ func (s *service) startHelper(ctx context.Context, args *task.StartArgs, stream 
 
 func (s *service) restoreHelper(ctx context.Context, args *task.RestoreArgs, stream task.TaskService_RestoreAttachServer) (*task.RestoreResp, error) {
 	var resp task.RestoreResp
-	var pid *int32
+	var pid int32
 	var err error
 
 	restoreStats := task.RestoreStats{
@@ -320,45 +331,71 @@ func (s *service) restoreHelper(ctx context.Context, args *task.RestoreArgs, str
 		args.CheckpointPath = *zipFile
 	}
 
-	pid, done, err := s.restore(ctx, args, stream)
+	pid, exitCode, err := s.restore(ctx, args, stream)
 	if err != nil {
 		staterr := status.Error(codes.Internal, fmt.Sprintf("failed to restore process: %v", err))
 		return nil, staterr
 	}
-
-	resp = task.RestoreResp{
-		Message: fmt.Sprintf("successfully restored process: %v", *pid),
-		NewPID:  *pid,
-	}
-
-	// TODO NR - watch PID for a couple seconds after exec to ensure no failure
-	// We could be restoring on a new machine, so we update the state
-
-	state, err := s.generateState(ctx, *pid)
-	if err != nil {
-		s.logger.Warn().Err(err).Msg("failed to generate state after restore")
-	}
-
+	state := &task.ProcessState{}
 	// Only update state if it was a managed job
-	if args.JID != "" && state != nil {
+	if args.JID != "" {
+		state, err = s.generateState(ctx, pid)
+		if err != nil {
+			s.logger.Warn().Err(err).Msg("failed to generate state after restore, using fallback")
+			state, err = s.getState(ctx, args.JID)
+			if err != nil {
+				s.logger.Warn().Err(err).Msg("failed to get state existing after restore")
+			}
+		}
+		s.logger.Info().Int32("PID", pid).Str("JID", state.JID).Msgf("managing restored process")
+		state.PID = pid
 		state.JobState = task.JobState_JOB_RUNNING
 		err = s.updateState(ctx, state.JID, state)
 		if err != nil {
-			s.logger.Warn().Err(err).Msg("failed to update managed job state after restore")
+			s.logger.Fatal().Err(err).Msg("failed to update state after restore")
+			syscall.Kill(int(pid), syscall.SIGKILL) // kill cuz inconsistent state
+			return nil, status.Error(codes.Internal, "failed to update state after restore")
+		}
+
+		if stream != nil && exitCode != nil {
+			code := <-exitCode // if streaming, wait for process to finish
+			if stream != nil {
+				stream.Send(&task.RestoreAttachResp{
+					ExitCode: int32(code),
+				})
+			}
+			state.JobState = task.JobState_JOB_DONE
+			err = s.updateState(context.WithoutCancel(ctx), state.JID, state)
+			if err != nil {
+				s.logger.Fatal().Err(err).Msg("failed to update state after done")
+				return nil, status.Error(codes.Internal, "failed to update state after done")
+			}
+		} else {
+			s.wg.Add(1)
+			go func() {
+				defer s.wg.Done()
+				<-exitCode
+				state.JobState = task.JobState_JOB_DONE
+				err = s.updateState(context.WithoutCancel(ctx), state.JID, state)
+				if err != nil {
+					s.logger.Fatal().Err(err).Msg("failed to update state after done")
+					return
+				}
+			}()
 		}
 	}
 
-	if stream != nil && done != nil {
-		<-done
+	resp = task.RestoreResp{
+		Message:      fmt.Sprintf("successfully restored process: %v", pid),
+		NewPID:       pid,
+		State:        state,
+		RestoreStats: &restoreStats,
 	}
-
-	resp.State = state
-	resp.RestoreStats = &restoreStats
 
 	return &resp, nil
 }
 
-func (s *service) run(ctx context.Context, args *task.StartArgs, stream task.TaskService_StartAttachServer) (int32, chan error, error) {
+func (s *service) run(ctx context.Context, args *task.StartArgs, stream task.TaskService_StartAttachServer) (int32, chan int, error) {
 	var pid int32
 	if args.Task == "" {
 		return 0, nil, fmt.Errorf("could not find task")
@@ -502,8 +539,12 @@ func (s *service) run(ctx context.Context, args *task.StartArgs, stream task.Tas
 		return 0, nil, err
 	}
 
+	ppid := int32(os.Getpid())
+	pid = int32(cmd.Process.Pid)
+	closeCommonFds(ppid, pid)
+
 	s.wg.Add(1)
-	done := make(chan error)
+	exitCode := make(chan int)
 	go func() {
 		defer s.wg.Done()
 		err := cmd.Wait()
@@ -517,33 +558,11 @@ func (s *service) run(ctx context.Context, args *task.StartArgs, stream task.Tas
 			s.logger.Debug().Str("stderr", gpuerrbuf.String()).Msgf("GPU controller log")
 		}
 		s.logger.Info().Int("status", cmd.ProcessState.ExitCode()).Int32("PID", pid).Msg("process exited")
-		if stream != nil {
-			stream.Send(&task.StartAttachResp{
-				ExitCode: int32(cmd.ProcessState.ExitCode()),
-			})
-			done <- err
-		}
-
-		// Update state as it's a managed job
-		childCtx := context.WithoutCancel(cmdCtx) // since this routine can outlive the parent
-		state, err := s.getState(childCtx, args.JID)
-		if err != nil {
-			s.logger.Warn().Err(err).Msg("failed to get state after job done")
-			return
-		}
-		state.JobState = task.JobState_JOB_DONE
-		state.PID = pid
-		err = s.updateState(childCtx, args.JID, state)
-		if err != nil {
-			s.logger.Warn().Err(err).Msg("failed to update state after job done")
-		}
+		code := cmd.ProcessState.ExitCode()
+		exitCode <- code
 	}()
 
-	ppid := int32(os.Getpid())
-	pid = int32(cmd.Process.Pid)
-
-	closeCommonFds(ppid, pid)
-	return pid, done, err
+	return pid, exitCode, err
 }
 
 func closeCommonFds(parentPID, childPID int32) error {

--- a/api/restore.go
+++ b/api/restore.go
@@ -560,7 +560,7 @@ func rsyncDirectories(source, destination string) error {
 	return nil
 }
 
-func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream task.TaskService_RestoreAttachServer) (*int32, chan error, error) {
+func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream task.TaskService_RestoreAttachServer) (int32, chan int, error) {
 	var dir *string
 	var pid *int32
 
@@ -571,14 +571,14 @@ func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream ta
 
 	dir, state, extraFiles, ioFiles, err := s.prepareRestore(ctx, opts, args, stream)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 
 	var gpuCmd *exec.Cmd
 	// No GPU flag passed in args - if state.GPUCheckpointed = true, always restore using gpu-controller
 	if state.GPUCheckpointed {
 		if !s.gpuEnabled {
-			return nil, nil, fmt.Errorf("dump has GPU state but GPU support is not enabled in daemon")
+			return 0, nil, fmt.Errorf("dump has GPU state but GPU support is not enabled in daemon")
 		}
 		nfy.PreResumeFunc = NotifyFunc{
 			Avail: true,
@@ -597,11 +597,11 @@ func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream ta
 
 	pid, err = s.criuRestore(ctx, opts, nfy, *dir, extraFiles)
 	if err != nil {
-		return nil, nil, err
+		return 0, nil, err
 	}
 
 	// If it's a managed restored job
-	done := make(chan error)
+	exitCode := make(chan int)
 	if args.JID != "" {
 		if stream != nil {
 			// last 3 files of ioFiles are stdin, stdout, stderr
@@ -667,12 +667,8 @@ func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream ta
 			defer s.wg.Done()
 			var status syscall.WaitStatus
 			syscall.Wait4(int(*pid), &status, 0, nil) // since managed jobs are restored as children of the daemon
-			s.logger.Debug().Int32("PID", *pid).Str("JID", args.JID).Int("status", status.ExitStatus()).Msgf("process exited")
-
-			if stream != nil {
-				stream.Send(&task.RestoreAttachResp{ExitCode: int32(status.ExitStatus())})
-				done <- nil
-			}
+			code := status.ExitStatus()
+			s.logger.Debug().Int32("PID", *pid).Str("JID", args.JID).Int("status", code).Msgf("process exited")
 
 			if gpuCmd != nil {
 				err = gpuCmd.Process.Kill()
@@ -684,19 +680,7 @@ func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream ta
 				s.logger.Debug().Str("stderr", gpuerrbuf.String()).Msgf("GPU controller log")
 			}
 
-			// Update state
-			childCtx := context.WithoutCancel(ctx) // since this routine can outlive the parent
-			state, err := s.getState(childCtx, args.JID)
-			if err != nil {
-				s.logger.Warn().Err(err).Msg("failed to get state after job done")
-				return
-			}
-			state.JobState = task.JobState_JOB_DONE
-			state.PID = *pid
-			err = s.updateState(childCtx, args.JID, state)
-			if err != nil {
-				s.logger.Warn().Err(err).Msg("failed to update state after job done")
-			}
+			exitCode <- code
 		}()
 
 		// Kill on server/stream shutdown
@@ -724,7 +708,7 @@ func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream ta
 		}()
 	}
 
-	return pid, done, nil
+	return *pid, exitCode, nil
 }
 
 func (s *service) gpuRestore(ctx context.Context, dir string, uid, gid int32, groups []int32) (*exec.Cmd, error) {


### PR DESCRIPTION
## Describe your changes
There's a race condition where the daemon does not update the job state, if the program exits too early:

```bash
10:57AM INF process exited PID=29533 status=127
10:57AM INF managing process JID=ced PID=29533
10:57AM DBG gRPC request succeeded method
```
## Issue ticket number 
CED-620

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
> Simplifies the updation of state for both after `exec`ing and `restore`ing the job, so that the state is updated consistently. Also, ensures that the state is only updated in `process.go` and not touched by any of the internal functions.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.