### PR TITLE
Move correctness tests as a separate CI job

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,10 @@
 ## Describe your changes
 
-## Issue ticket number 
+## Issue ticket number
 
 ## Checklist before requesting a review
 - [ ] Have I performed a self-review?
 - [ ] Have I added regression or unit tests (where it makes sense) for my changes?
 - [ ] Have I updated the README if changes have resulted in it being out of date?
-- [ ]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
+- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
 - [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
-

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -92,7 +92,7 @@ jobs:
           path: ./cedana
 
   smoke-test:
-    name: Smoke
+    name: Smoke Tests
     runs-on: ubicloud-standard-8
     needs: build
     steps:
@@ -127,7 +127,7 @@ jobs:
         run: sudo -E make -C scripts/ci smoke
 
   regression-test:
-    name: Regression
+    name: Regression Tests
     runs-on: ubicloud-standard-8
     needs: build
     steps:
@@ -162,7 +162,7 @@ jobs:
         run: sudo -E make -C scripts/ci regression
 
   correctness-test:
-    name: Correctness
+    name: Correctness Tests
     runs-on: ubicloud-standard-8
     needs: build
     steps:

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -22,6 +22,11 @@ on:
         description: 'Run regression test with debugging enabled'
         required: false
         default: false
+      debug_correctness_test:
+        type: boolean
+        description: 'Run correctness test with debugging enabled'
+        required: false
+        default: false
   workflow_call: # to reuse this workflow in other worflows
     inputs:
       debug_build:
@@ -37,6 +42,11 @@ on:
       debug_regression_test:
         type: boolean
         description: 'Run regression test with debugging enabled'
+        required: false
+        default: false
+      debug_correctness_test:
+        type: boolean
+        description: 'Run correctness test with debugging enabled'
         required: false
         default: false
 
@@ -150,3 +160,38 @@ jobs:
           CI_BRANCH: ${{ github.ref_name }}
           SIGNOZ_ACCESS_TOKEN: ${{ secrets.SIGNOZ_ACCESS_TOKEN }}
         run: sudo -E make -C scripts/ci regression
+
+  correctness-test:
+    name: Correctness
+    runs-on: ubicloud-standard-8
+    needs: build
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: 'recursive'
+
+      - name: Download artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_correctness_test }}
+        with:
+          limit-access-to-actor: true
+
+      - name: Setup CI
+        run: |
+          chmod +x cedana
+          sudo -E make -C scripts/ci setup-full
+        env:
+          SIGNOZ_ACCESS_TOKEN: ${{ secrets.SIGNOZ_ACCESS_TOKEN }}
+
+      - name: Run correctness tests
+        env:
+          CI_BRANCH: ${{ github.ref_name }}
+          SIGNOZ_ACCESS_TOKEN: ${{ secrets.SIGNOZ_ACCESS_TOKEN }}
+        run: sudo -E make -C scripts/ci correctness

--- a/scripts/ci/Makefile
+++ b/scripts/ci/Makefile
@@ -15,6 +15,9 @@ smoke:
 regression:
 	./regression-test.sh || (echo "Regression test failed" && exit 1)
 
+correctness:
+	./correctness-test.sh || (echo "Correctness test failed" && exit 1)
+
 setup-full:
 	./setup-full.sh || (echo "Setup full failed" && exit 1)
 

--- a/scripts/ci/correctness-test.sh
+++ b/scripts/ci/correctness-test.sh
@@ -1,0 +1,26 @@
+#!/bin/bash -e
+# Used to run correctness tests for CI
+
+source ./helpers.sh
+
+start_correctness() {
+    echo "Running correctness test in cwd: $(pwd)"
+    sudo -E python3 test/benchmarks/performance.py --correctness --verbose
+    if [[ $? -ne 0 ]]; then
+        echo "start_correctness failed!"
+        exit 1
+    fi
+}
+
+main() {
+    pushd ../..
+    print_env
+    source_env
+    start_otelcol
+    start_cedana
+    start_correctness
+    stop_cedana
+    popd
+}
+
+main

--- a/test/benchmarks/process_json.py
+++ b/test/benchmarks/process_json.py
@@ -165,10 +165,10 @@ def diff_ckpts(jobID1: str, jobID2: str, filename: str, verbose: bool) -> bool:
     e = os.environ.copy()
     err1 = subprocess.run(["cedana", "perf", "crit", "show", dir1], capture_output=True, text=True, env=e)
     if err1.returncode:
-        print("ERROR: cedana perf crit show {} returned\n{}".format(dir1, err1.stdout))
+        print("ERROR: cedana perf crit show {} returned\n{}".format(dir1, err1.stderr))
     err2 = subprocess.run(["cedana", "perf", "crit", "show", dir2], capture_output=True, text=True, env=e)
     if err2.returncode:
-        print("ERROR: cedana perf crit show {} returned\n{}".format(dir2, err2.stdout))
+        print("ERROR: cedana perf crit show {} returned\n{}".format(dir2, err2.stderr))
     test_files, err_files = diff_files(dir1, dir2)
     test_mm, err_mm = diff_mm(dir1, dir2)
     test_pagemap, err_pagemap = diff_pagemap(dir1, dir2)

--- a/test/benchmarks/requirements
+++ b/test/benchmarks/requirements
@@ -13,6 +13,7 @@ typing_extensions
 protobuf
 google-cloud-bigquery
 google-cloud-storage
-requests 
+requests
 psutil
 pandas-gbq
+crit

--- a/test/benchmarks/requirements
+++ b/test/benchmarks/requirements
@@ -16,3 +16,4 @@ requests
 psutil
 pandas-gbq
 crit
+protobuf==3.20.*

--- a/test/benchmarks/requirements
+++ b/test/benchmarks/requirements
@@ -10,7 +10,7 @@ six==1.16.0
 torch==2.0.1
 torchvision==0.15.2
 typing_extensions
-protobuf
+protobuf==3.20.0
 google-cloud-bigquery
 google-cloud-storage
 requests

--- a/test/benchmarks/requirements
+++ b/test/benchmarks/requirements
@@ -10,7 +10,6 @@ six==1.16.0
 torch==2.0.1
 torchvision==0.15.2
 typing_extensions
-protobuf==3.20.0
 google-cloud-bigquery
 google-cloud-storage
 requests


### PR DESCRIPTION
## Describe your changes
Correctness is more of a test than a benchmark, so should be a separate CI job and should run on each PR alongside the regression tests.

## Issue ticket number 
CED-605

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x]  Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.