### PR TITLE
Add `--leave-running` flag for runc

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -4,6 +4,8 @@ package cmd
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"strconv"
 	"strings"
 
@@ -15,8 +17,6 @@ import (
 	"google.golang.org/grpc/status"
 
 	"github.com/mdlayher/vsock"
-	"os"
-	"io"
 )
 
 var dumpCmd = &cobra.Command{
@@ -372,6 +372,7 @@ var dumpRuncCmd = &cobra.Command{
 		wdPath, _ := cmd.Flags().GetString(wdFlag)
 		tcpEstablished, _ := cmd.Flags().GetBool(tcpEstablishedFlag)
 		pid, _ := cmd.Flags().GetInt(pidFlag)
+		leaveRunning, _ := cmd.Flags().GetBool(leaveRunningFlag)
 
 		external, _ := cmd.Flags().GetString(externalFlag)
 
@@ -392,7 +393,7 @@ var dumpRuncCmd = &cobra.Command{
 		criuOpts := &task.CriuOpts{
 			ImagesDirectory: dir,
 			WorkDirectory:   wdPath,
-			LeaveRunning:    true,
+			LeaveRunning:    leaveRunning,
 			TcpEstablished:  tcpEstablished,
 			External:        externalNamespaces,
 		}
@@ -497,6 +498,7 @@ func init() {
 	dumpRuncCmd.Flags().BoolP(gpuEnabledFlag, "g", false, "gpu enabled")
 	dumpRuncCmd.Flags().IntP(pidFlag, "p", 0, "pid")
 	dumpRuncCmd.Flags().String(externalFlag, "", "external")
+	dumpRuncCmd.Flags().Bool(leaveRunningFlag, false, "leave running")
 
 	dumpCmd.AddCommand(dumpCRIORootfs)
 	dumpCRIORootfs.Flags().StringP(idFlag, "i", "", "container id")

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -35,4 +35,5 @@ const (
 	typeFlag             = "type"
 	attachFlag           = "attach"
 	streamFlag           = "stream"
+	leaveRunningFlag     = "leave-running"
 )

--- a/pkg/api/runc.go
+++ b/pkg/api/runc.go
@@ -72,7 +72,7 @@ func (s *service) RuncDump(ctx context.Context, args *task.RuncDumpArgs) (*task.
 	criuOpts := &container.CriuOpts{
 		ImagesDirectory: args.CriuOpts.ImagesDirectory,
 		WorkDirectory:   args.CriuOpts.WorkDirectory,
-		LeaveRunning:    true,
+		LeaveRunning:    args.CriuOpts.LeaveRunning,
 		TcpEstablished:  isUsingTCP,
 		TcpClose:        isUsingTCP,
 		MntnsCompatMode: false,

--- a/test/regression/helper.bash
+++ b/test/regression/helper.bash
@@ -89,7 +89,8 @@ function rootfs_restore() {
 function runc_checkpoint() {
     local dir="$1"
     local job_id="$2"
-    cedana dump runc --dir "$dir" --id "$job_id"
+    shift 2
+    cedana dump runc --dir "$dir" --id "$job_id" $@
 }
 # Bundle for jupyter notebook restore
 # /run/containerd/io.containerd.runtime.v2.task/default/jupyter-notebook-restore

--- a/test/regression/main.bats
+++ b/test/regression/main.bats
@@ -249,7 +249,7 @@ teardown() {
     [ $nlines_after -gt $nlines_before ]
 
     # checkpoint the container
-    runc_checkpoint $dumpdir $job_id
+    runc_checkpoint $dumpdir $job_id --leave-running
     [ -d $dumpdir ]
 
     # clean up


### PR DESCRIPTION
## Describe your changes
Currently, a default value (true) is used for this CRIU option. We need an option to override from CLI.

BREAKING: The new default will be, thus, false. And this flag must be explicitly passed.

## Issue ticket number
CED-639

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
> The new default will be, thus, false. And this flag must be explicitly passed.
