### PR TITLE
Deploy `cedana-bench` to CI

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -83,6 +83,13 @@ jobs:
       run:
         working-directory: /src
     steps:
+      # Github actions unfortunately mounts the docker socket, which we don't want
+      - id: Workaround for dind
+        run: |
+          umount /var/run/docker.sock
+          sudo service supervisor start
+          supervisorctl restart dockerd
+
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1
@@ -130,7 +137,9 @@ jobs:
           CLOUDSMITH_CEDANA_BENCH_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_BENCH }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           BENCH_CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
-        run: $BENCH_CMD
+        run: |
+          cd /src
+          $BENCH_CMD
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,46 +28,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build:
-    name: Build
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        working-directory: ${{ github.workspace }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          fetch-tags: true
-          submodules: 'recursive'
+  # build:
+  #   name: Build
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       working-directory: ${{ github.workspace }}
+  #   steps:
+  #     - uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #         fetch-tags: true
+  #         submodules: 'recursive'
 
-      - name: Set up Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: '1.22'
+  #     - name: Set up Go
+  #       uses: actions/setup-go@v4
+  #       with:
+  #         go-version: '1.22'
 
-      - name: Setup debugging session
-        uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build }}
-        with:
-          limit-access-to-actor: true
+  #     - name: Setup debugging session
+  #       uses: mxschmitt/action-tmate@v3
+  #       if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build }}
+  #       with:
+  #         limit-access-to-actor: true
 
-      - name: Setup CI
-        run: sudo -E make -C scripts/ci setup-build
+  #     - name: Setup CI
+  #       run: sudo -E make -C scripts/ci setup-build
 
-      - name: Build
-        run: sudo -E ./build.sh
+  #     - name: Build
+  #       run: sudo -E ./build.sh
 
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v4
-        with:
-          name: build
-          path: ./cedana
+  #     - name: Upload artifacts
+  #       uses: actions/upload-artifact@v4
+  #       with:
+  #         name: build
+  #         path: ./cedana
 
   benchmark:
     name: Benchmark
     # if: github.event.inputs.bench == 'true' TODO: uncomment later
-    needs: build
+    # needs: build
     permissions:
       contents: 'read'
       packages: 'read'
@@ -84,11 +84,17 @@ jobs:
         working-directory: /src
     steps:
       # Github actions unfortunately mounts the docker socket, which we don't want
-      - name: Workaround for dind
-        run: |
-          umount /var/run/docker.sock
-          sudo service supervisor start
-          supervisorctl restart dockerd
+      # - name: Workaround for dind
+      #   run: |
+      #     umount /var/run/docker.sock
+      #     sudo service supervisor start
+      #     supervisorctl restart dockerd
+
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        # if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
+        with:
+          limit-access-to-actor: true
 
       - id: auth
         name: Authenticate to Google Cloud
@@ -125,12 +131,6 @@ jobs:
           mv temp.json bench.json
           jq '.plots.color_palette = "'$COLOR_PALETTE'"' bench.json > temp.json
           mv temp.json bench.json
-
-      - name: Setup debugging session
-        uses: mxschmitt/action-tmate@v3
-        # if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
-        with:
-          limit-access-to-actor: true
 
       - name: Run
         env:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,10 +1,6 @@
 name: Manual
 
 on:
-  pull_request: # TODO: remove later
-    types: [opened, synchronize]
-    branches:
-      - main
   workflow_dispatch:
       inputs:
         bench:
@@ -66,7 +62,7 @@ jobs:
 
   benchmark:
     name: Benchmark
-    # if: github.event.inputs.bench == 'true' TODO: uncomment later
+    if: github.event.inputs.bench == 'true'
     needs: build
     permissions:
       contents: 'read'

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -78,7 +78,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --init --privileged --ipc=host --pid=host --cgroupns=host -v /var/run/docker:/var/run/docker -v /var/lib/docker:/var/lib/docker -v /var/run/containerd:/var/run/containerd
+      options: --init --privileged --ipc=host --pid=host --cgroupns=host -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/docker:/var/run/docker -v /var/lib/docker:/var/lib/docker -v /var/run/containerd:/var/run/containerd
     defaults:
       run:
         working-directory: /src

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -28,46 +28,46 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # build:
-  #   name: Build
-  #   runs-on: ubuntu-latest
-  #   defaults:
-  #     run:
-  #       working-directory: ${{ github.workspace }}
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #         fetch-tags: true
-  #         submodules: 'recursive'
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: 'recursive'
 
-  #     - name: Set up Go
-  #       uses: actions/setup-go@v4
-  #       with:
-  #         go-version: '1.22'
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
 
-  #     - name: Setup debugging session
-  #       uses: mxschmitt/action-tmate@v3
-  #       if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build }}
-  #       with:
-  #         limit-access-to-actor: true
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build }}
+        with:
+          limit-access-to-actor: true
 
-  #     - name: Setup CI
-  #       run: sudo -E make -C scripts/ci setup-build
+      - name: Setup CI
+        run: sudo -E make -C scripts/ci setup-build
 
-  #     - name: Build
-  #       run: sudo -E ./build.sh
+      - name: Build
+        run: sudo -E ./build.sh
 
-  #     - name: Upload artifacts
-  #       uses: actions/upload-artifact@v4
-  #       with:
-  #         name: build
-  #         path: ./cedana
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: ./cedana
 
   benchmark:
     name: Benchmark
     # if: github.event.inputs.bench == 'true' TODO: uncomment later
-    # needs: build
+    needs: build
     permissions:
       contents: 'read'
       packages: 'read'
@@ -84,17 +84,12 @@ jobs:
         working-directory: /src
     steps:
       # Github actions unfortunately mounts the docker socket, which we don't want
-      # - name: Workaround for dind
-      #   run: |
-      #     umount /var/run/docker.sock
-      #     sudo service supervisor start
-      #     supervisorctl restart dockerd
-
-      - name: Setup debugging session
-        uses: mxschmitt/action-tmate@v3
-        # if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
-        with:
-          limit-access-to-actor: true
+      - name: Workaround for dind
+        run: |
+          umount /var/run/docker.sock
+          sudo service supervisor start
+          sleep 1
+          supervisorctl restart dockerd
 
       - id: auth
         name: Authenticate to Google Cloud
@@ -132,6 +127,12 @@ jobs:
           jq '.plots.color_palette = "'$COLOR_PALETTE'"' bench.json > temp.json
           mv temp.json bench.json
 
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        # if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
+        with:
+          limit-access-to-actor: true
+
       - name: Run
         env:
           CLOUDSMITH_CEDANA_BENCH_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_BENCH }}
@@ -139,7 +140,7 @@ jobs:
           BENCH_CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
         run: |
           cd /src
-          $BENCH_CMD
+          bash -c $BENCH_CMD
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -78,12 +78,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      volumes:
-        - /var/run/docker.sock:/var/run/docker.sock
-        - /var/run/docker:/var/run/docker
-        - /var/lib/docker:/var/lib/docker
-        - /var/run/containerd:/var/run/containerd
-      options: --init --privileged --ipc=host --pid=host --cgroupns=host
+      options: --privileged
     defaults:
       run:
         working-directory: /src
@@ -134,11 +129,8 @@ jobs:
         env:
           CLOUDSMITH_CEDANA_BENCH_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_BENCH }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
-        run: |
-          echo Using bench config:
-          cat bench.json
-          $CMD
+          BENCH_CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
+        run: $BENCH_CMD
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Setup debugging session
         uses: mxschmitt/action-tmate@v3
-        # if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,6 +1,10 @@
 name: Manual
 
 on:
+  pull_request: # TODO: remove later
+    types: [opened, synchronize]
+    branches:
+      - main
   workflow_dispatch:
       inputs:
         bench:

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -84,7 +84,7 @@ jobs:
         working-directory: /src
     steps:
       # Github actions unfortunately mounts the docker socket, which we don't want
-      - id: Workaround for dind
+      - name: Workaround for dind
         run: |
           umount /var/run/docker.sock
           sudo service supervisor start

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -1,0 +1,171 @@
+name: Manual
+
+on:
+  workflow_dispatch:
+      inputs:
+        bench:
+          type: boolean
+          description: 'Run the benchmark'
+          required: false
+          default: false
+        push_results:
+          type: boolean
+          description: 'Push the results to database'
+          required: false
+          default: false
+        debug_bench:
+          type: boolean
+          description: 'Run the benchmark with debugging enabled'
+          required: false
+          default: false
+
+concurrency:
+  group: manual-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          submodules: 'recursive'
+
+      - name: Set up Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.22'
+
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_build }}
+        with:
+          limit-access-to-actor: true
+
+      - name: Setup CI
+        run: sudo -E make -C scripts/ci setup-build
+
+      - name: Build
+        run: sudo -E ./build.sh
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: ./cedana
+
+  benchmark:
+    name: Benchmark
+    if: github.event.inputs.bench == 'true'
+    needs: build
+    permissions:
+      contents: 'read'
+      packages: 'read'
+      id-token: 'write'
+    runs-on: ubicloud-standard-8
+    container:
+      image: ghcr.io/cedana/cedana-bench.ubuntu:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --init --privileged --ipc=host --pid=host --cgroupns=host
+    defaults:
+      run:
+        working-directory: /src
+    steps:
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        env:
+          WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROVIDER }}
+          SERVICE_ACCOUNT: ${{ vars.GCLOUD_BENCHMARK_SERVICE_ACCOUNT }}
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Download artifacts
+        id: download-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+
+      - name: Get branch name
+        shell: bash
+        run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
+        id: get_branch
+
+      - name: Configure
+        env:
+          PATH_CEDANA: ${{ steps.download-artifacts.outputs.download-path }}
+          TAG: ${{ steps.get_branch.outputs.branch }}
+          COLOR_PALETTE: ${{ vars.BENCH_PALETTE_COMPARISON_LAST_PATCH }}
+        run: |
+          BINDIR=`jq -r '.crtools.list."cedana".bindir' bench.json`
+          cp $PATH_CEDANA/cedana crtools/cedana/$BINDIR/
+          jq '.crtools.list."cedana".source = "local"' bench.json > temp.json
+          mv temp.json bench.json
+          jq '.crtools.list."cedana".tag = "'$TAG'"' bench.json > temp.json
+          mv temp.json bench.json
+          jq '.plots.color_palette = "'$COLOR_PALETTE'"' bench.json > temp.json
+          mv temp.json bench.json
+
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
+        with:
+          limit-access-to-actor: true
+
+      - name: Run
+        env:
+          CLOUDSMITH_CEDANA_BENCH_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_BENCH }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
+        run: |
+          echo Using bench config:
+          cat bench.json
+          $CMD
+
+      - name: Upload logs
+        if: always()
+        id: upload-logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-logs
+          path: /src/*.log
+
+      - name: Push results
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.push_results }}
+        env:
+          GCLOUD_PROJECT: ${{ steps.auth.outputs.project_id }}
+          BIGQUERY_RESULTS_DATASET: ${{ vars.BIGQUERY_BENCH_RESULTS_DATASET }}
+        run: ./bench results push --overwrite
+
+      - name: Plot
+        run: ./bench plot --runtime cedana --save
+
+      - name: Upload plots
+        id: upload-plots
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          predefinedAcl: publicRead
+          project_id: ${{ steps.auth.outputs.project_id }}
+          path: /src/results
+          destination: cedana/bench-${{ github.ref }}
+          glob: '**/*.png'
+
+      - name: Generate summary
+        env:
+          RESULTS_BASE_URL: https://storage.googleapis.com/cedana/bench-${{ github.ref }}/results
+          RESULTS_DESCRIPTION: "> Manual run (cedana)"
+        run: |
+          utils/results-summary > summary.md
+          cat summary.md > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -66,7 +66,7 @@ jobs:
 
   benchmark:
     name: Benchmark
-    if: github.event.inputs.bench == 'true'
+    # if: github.event.inputs.bench == 'true' TODO: uncomment later
     needs: build
     permissions:
       contents: 'read'

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -137,9 +137,8 @@ jobs:
         env:
           CLOUDSMITH_CEDANA_BENCH_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_BENCH }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          BENCH_CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
-        run: |
-          ./bench run cedana --save --cpu-only
+          CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
+        run: $CMD
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -139,8 +139,7 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           BENCH_CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
         run: |
-          cd /src
-          bash -c $BENCH_CMD
+          ./bench run cedana --save --cpu-only
 
       - name: Upload logs
         if: always()

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -99,9 +99,6 @@ jobs:
         with:
           name: build
 
-      - name: Install dependencies
-        run: pip install -r requirements.txt
-
       - name: Get branch name
         shell: bash
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -78,7 +78,12 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --init --privileged --ipc=host --pid=host --cgroupns=host -v /var/run/docker.sock:/var/run/docker.sock -v /var/run/docker:/var/run/docker -v /var/lib/docker:/var/lib/docker -v /var/run/containerd:/var/run/containerd
+      volumes:
+        - /var/run/docker.sock:/var/run/docker.sock
+        - /var/run/docker:/var/run/docker
+        - /var/lib/docker:/var/lib/docker
+        - /var/run/containerd:/var/run/containerd
+      options: --init --privileged --ipc=host --pid=host --cgroupns=host
     defaults:
       run:
         working-directory: /src

--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -78,7 +78,7 @@ jobs:
       credentials:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-      options: --init --privileged --ipc=host --pid=host --cgroupns=host
+      options: --init --privileged --ipc=host --pid=host --cgroupns=host -v /var/run/docker:/var/run/docker -v /var/lib/docker:/var/lib/docker -v /var/run/containerd:/var/run/containerd
     defaults:
       run:
         working-directory: /src
@@ -121,7 +121,7 @@ jobs:
 
       - name: Setup debugging session
         uses: mxschmitt/action-tmate@v3
-        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
+        # if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench }}
         with:
           limit-access-to-actor: true
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -302,7 +302,7 @@ jobs:
       - name: Configure
         env:
           PATH_CEDANA: ${{ steps.download-artifacts.outputs.download-path }}
-          TAG: ${{ steps.get_branch.outputs.branch }}
+          TAG: ${{ github.event.pull_request.head.ref }}
           COLOR_PALETTE: ${{ vars.BENCH_PALETTE_COMPARISON_LAST_PATCH }}
         run: |
           BINDIR=`jq -r '.crtools.list."cedana".bindir' bench.json`

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -275,6 +275,14 @@ jobs:
       run:
         working-directory: /src
     steps:
+      # Github actions unfortunately mounts the docker socket, which we don't want
+      - name: Workaround for dind
+        run: |
+          umount /var/run/docker.sock
+          sudo service supervisor start
+          sleep 1
+          supervisorctl restart dockerd
+
       - id: auth
         name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v1

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -32,6 +32,11 @@ on:
         description: 'Run unit test with debugging enabled'
         required: false
         default: false
+      debug_bench:
+        type: boolean
+        description: 'Run benchmark with debugging enabled'
+        required: false
+        default: false
   workflow_call: # to reuse this workflow in other worflows
     inputs:
       debug_build:
@@ -57,6 +62,11 @@ on:
       debug_unit_test:
         type: boolean
         description: 'Run unit test with debugging enabled'
+        required: false
+        default: false
+      debug_bench:
+        type: boolean
+        description: 'Run benchmark with debugging enabled'
         required: false
         default: false
 
@@ -245,3 +255,109 @@ jobs:
         env:
           GO111MODULE: "on"
           CI_BRANCH: ${{ github.ref_name }}
+
+  benchmark:
+    name: Benchmark
+    permissions:
+      contents: 'read'
+      packages: 'read'
+      id-token: 'write'
+      pull-requests: 'write'
+    runs-on: ubicloud-standard-8
+    needs: build
+    container:
+      image: ghcr.io/cedana/cedana-bench.ubuntu:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --privileged
+    defaults:
+      run:
+        working-directory: /src
+    steps:
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        env:
+          WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROVIDER }}
+          SERVICE_ACCOUNT: ${{ vars.GCLOUD_BENCHMARK_SERVICE_ACCOUNT }}
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Download artifacts
+        id: download-artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Configure
+        env:
+          PATH_CEDANA: ${{ steps.download-artifacts.outputs.download-path }}
+          TAG: ${{ steps.get_branch.outputs.branch }}
+          COLOR_PALETTE: ${{ vars.BENCH_PALETTE_COMPARISON_LAST_PATCH }}
+        run: |
+          BINDIR=`jq -r '.crtools.list."cedana".bindir' bench.json`
+          cp $PATH_CEDANA/cedana crtools/cedana/$BINDIR/
+          jq '.crtools.list."cedana".source = "local"' bench.json > temp.json
+          mv temp.json bench.json
+          jq '.crtools.list."cedana".tag = "'$TAG'"' bench.json > temp.json
+          mv temp.json bench.json
+          jq '.plots.color_palette = "'$COLOR_PALETTE'"' bench.json > temp.json
+          mv temp.json bench.json
+
+      - name: Pull last result
+        env:
+          GCLOUD_PROJECT: ${{ steps.auth.outputs.project_id }}
+          BIGQUERY_RESULTS_DATASET: ${{ vars.BIGQUERY_BENCH_RESULTS_DATASET }}
+        run: ./bench results pull --runtime cedana:1
+
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench_cuda_11_8 }}
+        with:
+          limit-access-to-actor: true
+
+      - name: Run
+        env:
+          CLOUDSMITH_CEDANA_BENCH_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_BENCH }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          CMD: ${{ vars.BENCH_RUN_CMD_PR }}
+        run: $CMD
+
+      - name: Upload logs
+        if: always()
+        id: upload-logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-logs
+          path: |
+            /src/*.log
+
+      - name: Plot comparison
+        run: ./bench plot --runtime cedana:2 --save
+
+      - name: Upload plots
+        id: upload-plots
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          predefinedAcl: publicRead
+          project_id: ${{ steps.auth.outputs.project_id }}
+          path: /src/results
+          destination: cedana/pr-${{ github.event.pull_request.number }}
+          glob: '**/*.png'
+
+      - name: Generate summary
+        env:
+          RESULTS_BASE_URL: https://storage.googleapis.com/cedana/pr-${{ github.event.pull_request.number }}/results
+          RESULTS_TITLE: "## Benchmark preview"
+          RESULTS_DESCRIPTION: "> **${{ github.event.pull_request.head.ref }}** comparison w/ last patch\n*Updates on every commit to this branch*"
+        run: |
+          utils/results-summary > summary.md
+          cat summary.md > $GITHUB_STEP_SUMMARY
+
+      - name: Post summary
+        uses: thollander/actions-comment-pull-request@v2
+        with:
+          filePath: /src/summary.md
+          comment_tag: execution

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -293,6 +293,146 @@ jobs:
           # we only match docker hub image as both images should be the same
           echo $(docker run -i --rm cedana/cedana-helper:${{ steps.meta.outputs.version }} -c "cedana -v")
 
+  benchmark:
+    name: Benchmark
+    needs: ["build-publish-amd64"]
+    permissions:
+      contents: 'read'
+      packages: 'read'
+      id-token: 'write'
+    runs-on: ubicloud-standard-8
+    needs: test
+    container:
+      image: ghcr.io/cedana/cedana-bench.ubuntu:latest
+      credentials:
+        username: ${{ github.actor }}
+        password: ${{ secrets.GITHUB_TOKEN }}
+      options: --privileged
+    defaults:
+      run:
+        working-directory: /src
+    steps:
+      # Github actions unfortunately mounts the docker socket, which we don't want
+      - name: Workaround for dind
+        run: |
+          umount /var/run/docker.sock
+          sudo service supervisor start
+          sleep 1
+          supervisorctl restart dockerd
+
+      - id: auth
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v1
+        env:
+          WORKLOAD_IDENTITY_PROVIDER: ${{ secrets.WORKLOAD_IDENTITY_POOL_PROVIDER }}
+          SERVICE_ACCOUNT: ${{ vars.GCLOUD_BENCHMARK_SERVICE_ACCOUNT }}
+        with:
+          workload_identity_provider: ${{ env.WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ env.SERVICE_ACCOUNT }}
+
+      - name: Get tag
+        id: get-tag
+        run: echo ::set-output name=TAG::$(echo $GITHUB_REF | cut -d / -f 3)
+
+      - name: Download binary
+        uses: robinraju/release-downloader@v1
+        id: download
+        with:
+          tag: ${{ steps.get-tag.outputs.tag }}
+          fileName: '*amd64.tar.gz'
+          extract: true
+          token: ${{ github.token }}
+          out-file-path: /src
+
+      - name: Configure
+        env:
+          PATH_CEDANA: /src
+          TAG: ${{ steps.get_branch.outputs.branch }}
+          COLOR_PALETTE: ${{ vars.BENCH_PALETTE_COMPARISON_LAST_PATCH }}
+        run: |
+          BINDIR=`jq -r '.crtools.list."cedana".bindir' bench.json`
+          cp $PATH_CEDANA/cedana crtools/cedana/$BINDIR/
+          jq '.crtools.list."cedana".source = "local"' bench.json > temp.json
+          mv temp.json bench.json
+          jq '.crtools.list."cedana".tag = "'$TAG'"' bench.json > temp.json
+          mv temp.json bench.json
+          jq '.plots.color_palette = "'$COLOR_PALETTE'"' bench.json > temp.json
+          mv temp.json bench.json
+
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_bench_cuda_11_8 }}
+        with:
+          limit-access-to-actor: true
+
+      - name: Run
+        env:
+          CLOUDSMITH_CEDANA_BENCH_TOKEN: ${{ secrets.CLOUDSMITH_ENTITLEMENT_TOKEN_BENCH }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          CMD: ${{ vars.BENCH_RUN_CMD_RELEASE }}
+        run: $CMD
+
+      - name: Upload logs
+        if: always()
+        id: upload-logs
+        uses: actions/upload-artifact@v4
+        with:
+          name: bench-logs
+          path: /src/*.log
+
+      - name: Push results
+        env:
+          GCLOUD_PROJECT: ${{ steps.auth.outputs.project_id }}
+          BIGQUERY_RESULTS_DATASET: ${{ vars.BIGQUERY_BENCH_RESULTS_DATASET }}
+        run: ./bench results push --overwrite
+
+      - name: Pull last results
+        env:
+          GCLOUD_PROJECT: ${{ steps.auth.outputs.project_id }}
+          BIGQUERY_RESULTS_DATASET: ${{ vars.BIGQUERY_BENCH_RESULTS_DATASET }}
+        run: ./bench results pull --runtime cedana:2
+
+      - name: Plot comparison w/ last patch
+        env:
+          COLOR_PALETTE: ${{ vars.BENCH_PALETTE_COMPARISON_LAST_PATCH }}
+        run: |
+          rm -rf results/*.png
+          jq '.plots.color_palette = "'$COLOR_PALETTE'"' bench.json > temp.json
+          mv temp.json bench.json
+          ./bench plot --runtime cedana:2 --save
+
+      - name: Upload plots (comparison w/ last patch)
+        id: upload-plots-patch
+        uses: google-github-actions/upload-cloud-storage@v2
+        with:
+          predefinedAcl: publicRead
+          project_id: ${{ steps.auth.outputs.project_id }}
+          path: /src/results
+          destination: cedana/release-${{ steps.get-tag.outputs.TAG }}
+          glob: '**/*.png'
+
+      - name: Generate summary (comparison w/ last patch)
+        id: summary-patch
+        env:
+          RESULTS_BASE_URL: https://storage.googleapis.com/cedana/release-${{ steps.get-tag.outputs.TAG }}/results
+          RESULTS_TITLE: "cedana"
+          RESULTS_DESCRIPTION: "**${{ steps.get-tag.outputs.TAG }}** comparison w/ last patch"
+          RELEASE_NOTES_URL: https://github.com/cedana/cedana/releases/${{ steps.get-tag.outputs.TAG }}
+        run: |
+          utils/results-summary > $GITHUB_STEP_SUMMARY
+          echo ::set-output name=slack_summary::$(utils/results-summary-slack)
+
+      - name: Post summary (comparison w/ last patch)
+        if: ${{ (github.event_name != 'workflow_dispatch') || (inputs.post_summary) }}
+        id: slack-patch
+        uses: slackapi/slack-github-action@v1.26.0
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL_PERFORMANCE }}
+          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+        with:
+          payload: |
+            ${{ steps.summary-patch.outputs.slack_summary }}
+
   post-summary:
     name: Post Summary
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -301,7 +301,6 @@ jobs:
       packages: 'read'
       id-token: 'write'
     runs-on: ubicloud-standard-8
-    needs: test
     container:
       image: ghcr.io/cedana/cedana-bench.ubuntu:latest
       credentials:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -346,7 +346,7 @@ jobs:
       - name: Configure
         env:
           PATH_CEDANA: /src
-          TAG: ${{ steps.get_branch.outputs.branch }}
+          TAG: ${{ steps.get-tag.outputs.TAG }}
           COLOR_PALETTE: ${{ vars.BENCH_PALETTE_COMPARISON_LAST_PATCH }}
         run: |
           BINDIR=`jq -r '.crtools.list."cedana".bindir' bench.json`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,6 +26,11 @@ on:
         description: "Run build & push (arm64 image) with debugging enabled"
         required: false
         default: false
+      debug_bench:
+        type: boolean
+        description: 'Run the benchmark with debugging enabled'
+        required: false
+        default: false
       post_summary:
         type: boolean
         description: "Post summary to slack"


### PR DESCRIPTION
## Describe your changes
- Adds a PR job to run benchmark and post comparison w/ last patch on the PR as well as Slack to help catch performance regressions.
- Adds a release job to run benchmark and publish results to bigquery along with a post on Slack. All similar to the GPU benchmarks.
- Adds a manual workflow to trigger the benchmark manually on any branch, including an option to publish results to bigquery.

## Issue ticket number
CED-646

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
