### PR TITLE
fix: stop cedana before installing cedana

### DIFF
--- a/cmd/scripts/k8s/setup-host.sh
+++ b/cmd/scripts/k8s/setup-host.sh
@@ -1,6 +1,17 @@
 
 #!/bin/bash
 
+chroot /host /bin/bash <<'EOT'
+APP_NAME="cedana"
+SERVICE_FILE="/etc/systemd/system/$APP_NAME.service"
+
+echo "Stopping $APP_NAME service..."
+$SUDO_USE systemctl stop $APP_NAME.service
+
+# truncate the logs
+echo -n > /var/log/cedana-daemon.log
+EOT
+
 # Copy Cedana binaries to the host
 cp /usr/local/bin/cedana /host/usr/local/bin/cedana
 cp /usr/local/bin/build-start-daemon.sh /host/build-start-daemon.sh


### PR DESCRIPTION
## Describe your changes
- Add a stop cedana service portion before copying cedana binary

The purpose of this is to be able to upgrade cedana on a node that already has cedana just by stopping the service temporarily and copying over a new binary before starting a new systemctl service

## Issue ticket number

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the README if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
