### PR TITLE
hotfix: hotfix grpc connection issue

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -128,7 +128,10 @@ func NewServer(ctx context.Context, opts *ServeOpts) (*Server, error) {
 	if opts.VSOCKEnabled {
 		listener, err = vsock.Listen(VSOCK_PORT, nil)
 	} else {
-		Address = fmt.Sprintf("localhost:%d", opts.GrpcPort)
+		// NOTE: localhost requires firewall settings to disabled inside kubernetes
+		// this may or may not work without kubernetes based on firewall and network
+		// configuration, should work fine on local system
+		Address = fmt.Sprintf("0.0.0.0:%d", opts.GrpcPort)
 		listener, err = net.Listen(PROTOCOL, Address)
 	}
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -130,7 +130,7 @@ func NewServer(ctx context.Context, opts *ServeOpts) (*Server, error) {
 	} else {
 		// NOTE: localhost requires firewall settings to disabled inside kubernetes
 		// this may or may not work without kubernetes based on firewall and network
-		// configuration, should work fine on local system
+		// configuration, should work fine on local system, hence use 0.0.0.0
 		Address = fmt.Sprintf("0.0.0.0:%d", opts.GrpcPort)
 		listener, err = net.Listen(PROTOCOL, Address)
 	}

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -128,9 +128,9 @@ func NewServer(ctx context.Context, opts *ServeOpts) (*Server, error) {
 	if opts.VSOCKEnabled {
 		listener, err = vsock.Listen(VSOCK_PORT, nil)
 	} else {
-		// NOTE: localhost requires firewall settings to disabled inside kubernetes
-		// this may or may not work without kubernetes based on firewall and network
-		// configuration, should work fine on local system, hence use 0.0.0.0
+		// NOTE: `localhost` server inside kubernetes may or may not work
+		// based on firewall and network configuration, it would only work
+		// on local system, hence for serving use 0.0.0.0
 		Address = fmt.Sprintf("0.0.0.0:%d", opts.GrpcPort)
 		listener, err = net.Listen(PROTOCOL, Address)
 	}


### PR DESCRIPTION
### Describe your changes

**Why it was hard to find yesterday.** 
1. Only broken over firewall'ed networks, which is the case over k8s.
2. As well as protobufs were broken too.

This is why reverting was working, but fixing just protobufs alone was not working.
Both issues raise similar errors.

**How I found it?**
I tried connecting to it while debugging the grpc and saw that it was refusing the connection before validation, so it was fairly easy to resolve.

Also updated the protobufs on controller side. Everything is working now.