### PR TITLE
fix: noisy stdout asr output

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -87,7 +87,7 @@ var startDaemonCmd = &cobra.Command{
 						return
 					}
 					_ = conts
-					time.Sleep(1 * time.Second)
+					time.Sleep(60 * time.Second)
 				}
 			}()
 		}

--- a/pkg/api/crio.go
+++ b/pkg/api/crio.go
@@ -14,16 +14,13 @@ import (
 
 func (s *service) CRIORootfsDump(ctx context.Context, args *task.CRIORootfsDumpArgs) (resp *task.CRIORootfsDumpResp, err error) {
 	var spec *rspec.Spec
-
 	resp = &task.CRIORootfsDumpResp{}
-
 	root := filepath.Join("/var/lib/containers/storage/overlay-containers/", args.ContainerID, "userdata/config.json")
 
 	configFile, err := os.ReadFile(filepath.Join(root))
 	if err != nil {
 		return resp, err
 	}
-
 	if err := json.Unmarshal(configFile, &spec); err != nil {
 		return resp, err
 	}
@@ -55,9 +52,3 @@ func (s *service) CRIOImagePush(ctx context.Context, args *task.CRIOImagePushArg
 
 	return resp, nil
 }
-
-// func (s *service) CRIOSysboxPatch(ctx context.Context, args *task.CRIOSysboxPatchArgs) (resp *task.CRIOSysboxPatchResp, err error) {
-// 	ctx = utils.WithLogger(ctx, s.logger)
-
-// 	return resp, nil
-// }

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -377,7 +377,12 @@ func loggingUnaryInterceptor(serveOpts ServeOpts, machineID string) grpc.UnarySe
 			attribute.Bool("server.opts.gpuenabled", serveOpts.GPUEnabled),
 		)
 
-		log.Debug().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")
+		// log the GetContainerInfo method to trace
+		if !strings.Contains(info.FullMethod, "TaskService/GetContainerInfo") {
+			log.Trace().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")
+		} else {
+			log.Debug().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")
+		}
 
 		resp, err := handler(ctx, req)
 

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -378,7 +378,7 @@ func loggingUnaryInterceptor(serveOpts ServeOpts, machineID string) grpc.UnarySe
 		)
 
 		// log the GetContainerInfo method to trace
-		if !strings.Contains(info.FullMethod, "TaskService/GetContainerInfo") {
+		if strings.Contains(info.FullMethod, "TaskService/GetContainerInfo") {
 			log.Trace().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")
 		} else {
 			log.Debug().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")


### PR DESCRIPTION
### motivation
very noisy stdout of pod after asr on k8s.

### goal
- makes asr less frequent now down to 60 seconds from 1 second.
- makes GetContainerInfo method trace log rather than debug log. As by default log level is debug, we don't get trace logs in stdout. use "CEDANA_LOG_LEVEL=trace" to adjust this. 