### PR TITLE
Update `cedana` for `cedana-gpu` driver API change

### DIFF
--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -22,13 +22,6 @@ var daemonCmd = &cobra.Command{
 	Short: "Start daemon for cedana client. Must be run as root, needed for all other cedana functionality.",
 }
 
-var cudaVersions = map[string]string{
-	"11.8": "cuda11_8",
-	"12.1": "cuda12_1",
-	"12.2": "cuda12_2",
-	"12.4": "cuda12_4",
-}
-
 var DEFAULT_PORT uint32 = 8080
 
 var startDaemonCmd = &cobra.Command{
@@ -47,13 +40,6 @@ var startDaemonCmd = &cobra.Command{
 		var err error
 
 		gpuEnabled, _ := cmd.Flags().GetBool(gpuEnabledFlag)
-		// defaults to 11_8, this continues if --cuda is not specified
-		cudaVersion, _ := cmd.Flags().GetString(cudaVersionFlag)
-		if _, ok := cudaVersions[cudaVersion]; !ok {
-			err = fmt.Errorf("invalid cuda version %s, must be one of %v", cudaVersion, cudaVersions)
-			log.Error().Err(err).Msg("invalid cuda version")
-			return err
-		}
 		vsockEnabled, _ := cmd.Flags().GetBool(vsockEnabledFlag)
 		port, _ := cmd.Flags().GetUint32(portFlag)
 		metricsEnabled, _ := cmd.Flags().GetBool(metricsEnabledFlag)
@@ -100,7 +86,6 @@ var startDaemonCmd = &cobra.Command{
 
 		err = api.StartServer(ctx, &api.ServeOpts{
 			GPUEnabled:        gpuEnabled,
-			CUDAVersion:       cudaVersions[cudaVersion],
 			VSOCKEnabled:      vsockEnabled,
 			CedanaURL:         cedanaURL,
 			MetricsEnabled:    metricsEnabled,
@@ -196,7 +181,6 @@ func init() {
 	daemonCmd.AddCommand(checkDaemonCmd)
 	startDaemonCmd.Flags().BoolP(gpuEnabledFlag, "g", false, "start daemon with GPU support")
 	startDaemonCmd.Flags().Bool(vsockEnabledFlag, false, "start daemon with vsock support")
-	startDaemonCmd.Flags().String(cudaVersionFlag, "11.8", "cuda version to use")
 	startDaemonCmd.Flags().BoolP(metricsEnabledFlag, "m", false, "enable metrics")
 	startDaemonCmd.Flags().Bool(jobServiceFlag, false, "enable job service")
 }

--- a/cmd/flags.go
+++ b/cmd/flags.go
@@ -25,7 +25,6 @@ const (
 	startChrootFlag      = "start-chroot"
 	setupHostFlag        = "setup-host"
 	restartFlag          = "restart"
-	cudaVersionFlag      = "cuda"
 	pidFlag              = "pid"
 	externalFlag         = "external"
 	destFlag             = "dest"

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -83,8 +83,6 @@ type ServeOpts struct {
 	JobServiceEnabled bool
 }
 
-type pullGPUBinaryRequest struct{}
-
 func NewServer(ctx context.Context, opts *ServeOpts) (*Server, error) {
 	var err error
 


### PR DESCRIPTION
## Describe your changes
Also check https://github.com/cedana/cedana-docs/pull/17

### Current behavior/issue
Currently, a flag, --cuda, needs to be passed to specify the GPU binary version to download.

### Proposed solution
Remove this flag and by default download the latest binary as it is now backward compatible.

### Possible other solutions?
NA


## Issue ticket number

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.