### PR TITLE
Log on GPU controller startup poll error

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -329,6 +329,9 @@ func (s *service) StartGPUController(ctx context.Context, uid, gid int32, groups
 	timeout := time.Now().Add(GPU_CONTROLLER_WAIT_TIMEOUT)
 	for {
 		resp, err := gpuServiceConn.StartupPoll(ctx, &args)
+		if err != nil {
+			log.Debug().Err(err).Msg("gpu controller not started yet")
+		}
 		if time.Now().After(timeout) {
 			return nil, fmt.Errorf("gpu controller did not start in time")
 		}


### PR DESCRIPTION
## Describe your changes
### Current behavior/issue

Currently, even if the startup poll RPC call fails, we continue to wait for timeout without printing the status of the RPC poll.

### Proposed solution

Should still be same, but with debug msg including any error msgs.

## Issue ticket number
CED-692

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.