### PR TITLE
fix: add back arm64 support

### DIFF
--- a/cmd/scripts/k8s/setup-host.sh
+++ b/cmd/scripts/k8s/setup-host.sh
@@ -57,8 +57,17 @@ install_yum_packages() {
 
 # Function to install CRIU on Ubuntu 22.04
 install_criu_ubuntu_2204() {
-    PACKAGE_URL="https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_22.04/amd64/criu_3.19-4_amd64.deb"
-    OUTPUT_FILE="criu_3.19-4_amd64.deb"
+    case $(uname -m) in
+        x86_64 | amd64)
+            PACKAGE_URL="https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_22.04/amd64/criu_3.19-4_amd64.deb"
+            OUTPUT_FILE="criu_3.19-4_amd64.deb"
+        aarch64 | arm64)
+            PACKAGE_URL="https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_22.04/arm64/criu_3.19-4_amd64.deb"
+            OUTPUT_FILE="criu_3.19-4_amd64.deb"
+        *)
+            echo "Unknown platform architecture $(uname -m)"
+            exit 1
+    esac
 
     wget $PACKAGE_URL -O $OUTPUT_FILE
     dpkg -i $OUTPUT_FILE


### PR DESCRIPTION
Forgot to add back arm support after the previous revert due to setup bug elsewhere.