### PR TITLE
fix: stop returning errors that are non-errors in runcquery

### DIFF
--- a/pkg/api/kube/kube.go
+++ b/pkg/api/kube/kube.go
@@ -2,6 +2,7 @@ package kube
 
 import (
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -38,6 +39,8 @@ const CONTAINER_TYPE_CONTAINER = "container"
 
 const CONTAINER_TYPE_SANDBOX = "sandbox"
 
+var ErrDirectoryDoesNotExist = errors.New("directory does not exist")
+
 type Container struct {
 	containerName string
 	sandboxId     string
@@ -54,7 +57,7 @@ func StateList(root string) ([]RuncContainer, error) {
 
 	dirs, err := os.ReadDir(root)
 	if err != nil {
-		return nil, err
+		return nil, ErrDirectoryDoesNotExist
 	}
 
 	for _, dir := range dirs {

--- a/pkg/api/runc.go
+++ b/pkg/api/runc.go
@@ -5,6 +5,7 @@ package api
 import (
 	"bufio"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"github.com/cedana/cedana/pkg/api/services/task"
 	container "github.com/cedana/cedana/pkg/container"
 	"github.com/cedana/cedana/pkg/utils"
+	"github.com/rs/zerolog/log"
 	"github.com/spf13/viper"
 	"google.golang.org/genproto/googleapis/rpc/errdetails"
 	"google.golang.org/grpc/codes"
@@ -195,7 +197,7 @@ func (s *service) RuncQuery(ctx context.Context, args *task.RuncQueryArgs) (*tas
 
 		runcContainers, err := runc.RuncGetAll(args.Root, args.Namespace)
 		if err != nil {
-			return nil, status.Error(codes.NotFound, fmt.Sprint("Container not found"))
+			return nil, status.Error(codes.NotFound, err.Error())
 		}
 
 		for _, c := range runcContainers {
@@ -213,9 +215,14 @@ func (s *service) RuncQuery(ctx context.Context, args *task.RuncQueryArgs) (*tas
 	}
 	for i, name := range args.ContainerNames {
 		runcId, bundle, err := runc.GetContainerIdByName(name, args.SandboxNames[i], args.Root)
-		if err != nil {
-			return nil, status.Error(codes.NotFound, fmt.Sprintf("Container \"%s\" not found", name))
+		if errors.Is(err, runc.ErrContainerNotFound) {
+			log.Info().Msgf("container %s not found", name)
 		}
+
+		if !errors.Is(err, runc.ErrContainerNotFound) && err != nil {
+			return nil, err
+		}
+
 		containers = append(containers, &task.RuncContainer{
 			ID:         runcId,
 			BundlePath: bundle,

--- a/pkg/api/runc/runc.go
+++ b/pkg/api/runc/runc.go
@@ -2,7 +2,7 @@ package runc
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -19,6 +19,8 @@ const (
 	crioContainerName       = "io.kubernetes.container.name"
 	crioSandboxName         = "io.kubernetes.pod.name"
 )
+
+var ErrContainerNotFound = errors.New("container id not found")
 
 type runcContainer struct {
 	ContainerId      string
@@ -186,7 +188,7 @@ func GetContainerIdByName(containerName, sandboxName, root string) (string, stri
 		}
 
 	}
-	return "", "", fmt.Errorf("Container id not found")
+	return "", "", ErrContainerNotFound
 }
 
 func GetPausePid(bundlePath string) (int, error) {


### PR DESCRIPTION
## Describe your changes
- Stop returning errors when runcquery doesn't find a container.

## Issue ticket number
[CED-709](https://linear.app/cedana/issue/CED-709/move-failed-runc-queries-to-info-statements)

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
