### PR TITLE
build: improve layer caching for dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM golang:1.22-bullseye as builder
 
 WORKDIR /app
-ADD . /app
 
 RUN <<EOT
 set -eux
@@ -11,31 +10,36 @@ apt-get install -y wget git make curl libnl-3-dev libnet-dev libbsd-dev runc lib
 apt-get install -y libgpgme-dev btrfs-progs libbtrfs-dev libseccomp-dev libapparmor-dev libprotobuf-dev
 apt-get install -y libprotobuf-c-dev protobuf-c-compiler protobuf-compiler python3-protobuf
 apt-get install -y software-properties-common zip
-
-curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.106.1/otelcol-contrib_0.106.1_linux_amd64.tar.gz
-tar -xvf otelcol-contrib_0.106.1_linux_amd64.tar.gz
-
 EOT
 
+RUN curl --proto '=https' --tlsv1.2 -fOL https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/v0.106.1/otelcol-contrib_0.106.1_linux_amd64.tar.gz && \
+    tar -xvf otelcol-contrib_0.106.1_linux_amd64.tar.gz
+
+ADD ./go.mod /app
+ADD ./go.sum /app
+RUN go mod download && rm -rf go.mod go.sum
+ADD . /app
 RUN /app/build.sh
 
 FROM ubuntu:22.04
 
 RUN <<EOT
 set -eux
+DEBIAN_FRONTEND=noninteractive
 apt-get update
 apt-get install -y software-properties-common git wget zip
 apt-get install -y libgpgme-dev libseccomp-dev libbtrfs-dev btrfs-progs
 rm -rf /var/lib/apt/lists/*
 EOT
 
-COPY --from=builder /app/cedana /usr/local/bin/
-COPY --from=builder /app/build.sh /usr/local/bin/
-COPY --from=builder /app/build-start-daemon.sh /usr/local/bin/
-COPY --from=builder /app/setup-host.sh /usr/local/bin/
-COPY --from=builder /app/stop-daemon.sh /usr/local/bin/
+COPY ./build.sh /usr/local/bin/
+COPY ./build-start-daemon.sh /usr/local/bin/
+COPY ./setup-host.sh /usr/local/bin/
+COPY ./stop-daemon.sh /usr/local/bin/
+COPY ./scripts/otelcol-config.yaml /usr/local/bin/otelcol-config.yaml
+
 COPY --from=builder /app/otelcol-contrib /usr/local/bin/otelcol-contrib
-COPY --from=builder /app/scripts/otelcol-config.yaml /usr/local/bin/otelcol-config.yaml
+COPY --from=builder /app/cedana /usr/local/bin/
 
 ENV USER="root"
 


### PR DESCRIPTION


### Describe your changes

Currently, rebuilding docker image even with layer caches is slow as we still repeat the slow go mod download even if the go mod and sum hasn't been updated