### PR TITLE
For `cedana manage`, handle GPU controller startup error properly

### DIFF
--- a/docs/runc/gpu.md
+++ b/docs/runc/gpu.md
@@ -10,11 +10,10 @@ Currently, support is available for NVIDIA GPUs only.
 
 To spawn a runc container with NVIDIA GPU support, NVIDIA ships a runc `prestart` hook that can be used to set up the GPU environment for the container. For instance, when spawning a docker container with `--runtime=nvidia` ([more info](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/install-guide.html#configuring-docker)), the `nvidia-container-runtime-hook` is added to the runc bundle's `config.json` file. 
 
-To enable cedana C/R support, there are 4 additional requirements:
+To enable cedana C/R support, there are 3 additional requirements:
 1. Add/Mount the cedana GPU shared library `libcedana-gpu.so` to the container. This binary can be obtained when you run the daemon with GPU support enabled, i.e., `sudo cedana daemon start --gpu-enabled`.
 2. Set the `LD_PRELOAD=libcedana-gpu.so` environment variable, or prefix to `process.args` in the container's `config.json`.
-3. Bind the container's port 50051 to the host.
-4. Share the container's shared memory (`/dev/shm`) with the host. 
+3. Share the container's shared memory (`/dev/shm`) with the host. 
 
 All these steps can only be done before spawning the container (by modifying the bundle's `config.json`). In future releases, we plan to add a runc hook that will automate these steps, or add an option to spawn a runc container from the daemon itself.
 

--- a/pkg/api/process.go
+++ b/pkg/api/process.go
@@ -80,11 +80,6 @@ func (s *service) Manage(ctx context.Context, args *task.ManageArgs) (*task.Mana
 	state.JobState = task.JobState_JOB_RUNNING
 	state.GPU = args.GPU
 
-	err = s.updateState(ctx, state.JID, state)
-	if err != nil {
-		return nil, status.Error(codes.Internal, "failed to update state after manage")
-	}
-
 	var gpuCmd *exec.Cmd
 	gpuOutBuf := &bytes.Buffer{}
 	if args.GPU {
@@ -97,6 +92,11 @@ func (s *service) Manage(ctx context.Context, args *task.ManageArgs) (*task.Mana
 				return nil, fmt.Errorf("failed to start GPU controller: %v", err)
 			}
 		}
+	}
+
+	err = s.updateState(ctx, state.JID, state)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to update state after manage")
 	}
 
 	// Wait for server shutdown to gracefully exit, since job is now managed

--- a/pkg/api/runc.go
+++ b/pkg/api/runc.go
@@ -63,11 +63,6 @@ func (s *service) RuncManage(ctx context.Context, args *task.RuncManageArgs) (*t
 	state.JobState = task.JobState_JOB_RUNNING
 	state.GPU = args.GPU
 
-	err = s.updateState(ctx, state.JID, state)
-	if err != nil {
-		return nil, status.Error(codes.Internal, "failed to update state after manage")
-	}
-
 	var gpuCmd *exec.Cmd
 	gpuOutBuf := &bytes.Buffer{}
 	if args.GPU {
@@ -80,6 +75,11 @@ func (s *service) RuncManage(ctx context.Context, args *task.RuncManageArgs) (*t
 				return nil, fmt.Errorf("failed to start GPU controller: %v", err)
 			}
 		}
+	}
+
+	err = s.updateState(ctx, state.JID, state)
+	if err != nil {
+		return nil, status.Error(codes.Internal, "failed to update state after manage")
 	}
 
 	// Wait for server shutdown to gracefully exit, since job is now managed


### PR DESCRIPTION
## Describe your changes
Currently, if the GPU controller fails to startup, the job still gets created in the DB.

## Issue ticket number
CED-747

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.