### PR TITLE
refactor: gpu binary downloads

### DIFF
--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -243,7 +243,7 @@ func StartServer(cmdCtx context.Context, opts *ServeOpts) error {
 					gpuSharedLibPath = s
 				}
 				log.Info().Str("gpu_shared_lib_path", gpuSharedLibPath).Msg("Ensuring LibCedana library exists.")
-				err = pullGPUBinary(cmdCtx, utils.GpuControllerBinaryName, gpuSharedLibPath)
+				err = pullGPUBinary(cmdCtx, utils.GpuSharedLibName, gpuSharedLibPath)
 				if err != nil {
 					log.Error().Err(err).Msg("could not download libcedana")
 					cancel(err)

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -218,28 +218,40 @@ func StartServer(cmdCtx context.Context, opts *ServeOpts) error {
 			}
 		}
 
+		var wg sync.WaitGroup
 		if opts.GPUEnabled {
-			if viper.GetString("gpu_controller_path") == "" {
-				err = pullGPUBinary(cmdCtx, utils.GpuControllerBinaryName, utils.GpuControllerBinaryPath)
+			wg.Add(2)
+			go func() {
+				defer wg.Done()
+				gpuControllerPath := utils.GpuControllerBinaryPath
+				if s := viper.GetString("gpu_controller_path"); s != "" {
+					gpuControllerPath = s
+				}
+				log.Info().Str("gpu_controller_path", gpuControllerPath).Msg("Ensuring GPU Controller exists.")
+				err = pullGPUBinary(cmdCtx, utils.GpuControllerBinaryName, gpuControllerPath)
 				if err != nil {
 					log.Error().Err(err).Msg("could not pull gpu controller")
 					cancel(err)
 					return
 				}
-			} else {
-				log.Debug().Str("path", viper.GetString("gpu_controller_path")).Msg("using gpu controller")
-			}
+			}()
 
-			if viper.GetString("gpu_shared_lib_path") == "" {
-				err = pullGPUBinary(cmdCtx, utils.GpuSharedLibName, utils.GpuSharedLibPath)
+			go func() {
+				defer wg.Done()
+				gpuSharedLibPath := utils.GpuSharedLibPath
+				if s := viper.GetString("gpu_shared_lib_path"); s != "" {
+					gpuSharedLibPath = s
+				}
+				log.Info().Str("gpu_shared_lib_path", gpuSharedLibPath).Msg("Ensuring LibCedana library exists.")
+				err = pullGPUBinary(cmdCtx, utils.GpuControllerBinaryName, gpuSharedLibPath)
 				if err != nil {
-					log.Error().Err(err).Msg("could not pull gpu shared lib")
+					log.Error().Err(err).Msg("could not download libcedana")
 					cancel(err)
 					return
 				}
-			} else {
-				log.Debug().Str("path", viper.GetString("gpu_shared_lib_path")).Msg("using gpu shared lib")
-			}
+			}()
+
+			wg.Wait()
 		}
 
 		log.Info().Str("host", DEFAULT_HOST).Uint32("port", opts.Port).Msg("server listening")
@@ -518,14 +530,12 @@ func (s *service) GetConfig(ctx context.Context, req *task.GetConfigRequest) (*t
 func pullGPUBinary(ctx context.Context, binary string, filePath string) error {
 	_, err := os.Stat(filePath)
 	if err == nil {
-		log.Info().Str("Path", filePath).Msgf("GPU binary exists. Delete existing binary to download latest version.")
+		log.Info().Str("Path", filePath).Msgf("%s binary found, skipping download.", binary)
 		// TODO NR - check version and checksum of binary?
 		return nil
 	}
-	log.Debug().Msgf("pulling gpu binary %s", binary)
-
 	url := viper.GetString("connection.cedana_url") + "/k8s/gpu/" + binary
-	log.Debug().Msgf("pulling %s from %s", binary, url)
+	log.Info().Msgf("Downloading %s from %s", binary, url)
 
 	httpClient := &http.Client{}
 
@@ -563,7 +573,7 @@ func pullGPUBinary(ctx context.Context, binary string, filePath string) error {
 		log.Err(err).Msg("could not read file from response")
 		return err
 	}
-	log.Debug().Msgf("%s downloaded to %s", binary, filePath)
+	log.Info().Msgf("%s downloaded to %s", binary, filePath)
 	return err
 }
 

--- a/setup-host.sh
+++ b/setup-host.sh
@@ -14,7 +14,7 @@ YUM_PACKAGES=(
 
 APT_PACKAGES=(
     wget libgpgme11-dev libseccomp-dev libbtrfs-dev git make libnl-3-dev libnet-dev libbsd-dev libcap-dev pkg-config libprotobuf-dev python3-protobuf build-essential
-    libprotobuf-c1 buildah libnftables1
+    libprotobuf-c1 buildah libnftables1 libelf-dev
 )
 
 # Function to install APT packages
@@ -76,6 +76,13 @@ else
     exit 1
 fi
 
+# if gpu driver present enable it!
+GPU=""
+if command -v nvidia-smi &>/dev/null; then
+    echo "nvidia-smi found! CUDA Version: $(nvidia-smi --version | grep CUDA | cut -d ':' -f 2)"
+    GPU="--gpu"
+fi
+
 # Run the Cedana daemon setup script
 cd /
-./build-start-daemon.sh --systemctl --no-build --k8s
+./build-start-daemon.sh --systemctl --no-build --k8s ${GPU}


### PR DESCRIPTION
### Describe your changes
Downloads were broken if you added the path, now it will ensure the download happens even if the path is specified. Also does them in parallel for perf & adds gpu flag if on nvidia supported node.

Ideally we will do all the setup in setup host but this improves the user experience for the end user. Also makes the logs for download "info" so it will be outputted to the user stdout by default.

Fixes CED-730