### PR TITLE
Show rest of the H/W specs within benchmark plots

### DIFF
--- a/.github/workflows/manual.yml
+++ b/.github/workflows/manual.yml
@@ -157,7 +157,9 @@ jobs:
         run: ./bench results push --overwrite
 
       - name: Plot
-        run: ./bench plot --runtime cedana --save
+        env:
+          FLAGS: ${{ vars.BENCH_PLOT_FLAGS }}
+        run: ./bench plot --runtime cedana --save $FLAGS
 
       - name: Upload plots
         id: upload-plots

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -394,7 +394,9 @@ jobs:
             /src/*.log
 
       - name: Plot comparison
-        run: ./bench plot --runtime cedana:2 --save
+        env:
+          FLAGS: ${{ vars.BENCH_PLOT_FLAGS }}
+        run: ./bench plot --runtime cedana:2 --save $FLAGS
 
       - name: Upload plots
         id: upload-plots

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -405,11 +405,12 @@ jobs:
       - name: Plot comparison w/ last patch
         env:
           COLOR_PALETTE: ${{ vars.BENCH_PALETTE_COMPARISON_LAST_PATCH }}
+          FLAGS: ${{ vars.BENCH_PLOT_FLAGS }}
         run: |
           rm -rf results/*.png
           jq '.plots.color_palette = "'$COLOR_PALETTE'"' bench.json > temp.json
           mv temp.json bench.json
-          ./bench plot --runtime cedana:2 --save
+          ./bench plot --runtime cedana:2 --save $FLAGS
 
       - name: Upload plots (comparison w/ last patch)
         id: upload-plots-patch


### PR DESCRIPTION
## Describe your changes
### Current behavior/issue
The legend only shows specs/tags that differ b/w results under comparison for brevity. 

### Proposed solution
Same as title. So that a plot image generated by the CI becomes standalone, and can be shared around without needing to share specs separately.

Plot flags can now be configured via the CI variable `BENCH_PLOT_FLAGS`.

## Issue ticket number
CED-756

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.