### PR TITLE
Remove otel binary start from daemonset

### DIFF
--- a/cmd/scripts/k8s/start-otelcol.sh
+++ b/cmd/scripts/k8s/start-otelcol.sh
@@ -15,5 +15,4 @@ if [ -z "$SIGNOZ_ACCESS_TOKEN" ]; then
     exit 1
 fi
 
-/usr/local/bin/otelcol-contrib --config /usr/local/bin/otelcol-config.yaml > /dev/null 2>&1 &
 '


### PR DESCRIPTION
## Describe your changes
This removes the otel binary from daemonset during k8 setup. This is being added now that otel helm charts have been added to run the same binary. Once this is tested, I will leave a comment.
## Issue ticket number

## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the README if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
