### PR TITLE
fix: GPU shared memory segment migration issue

### DIFF
--- a/pkg/api/dump.go
+++ b/pkg/api/dump.go
@@ -363,8 +363,6 @@ func (s *service) dump(ctx context.Context, state *task.ProcessState, args *task
 		return err
 	}
 
-	log.Info().Int32("stream", args.Stream).Msg("")
-
 	if state.GPU {
 		err = s.gpuDump(ctx, dumpdir, args.Stream > 0, state.JID)
 		if err != nil {

--- a/pkg/api/dump.go
+++ b/pkg/api/dump.go
@@ -323,7 +323,7 @@ func (s *service) containerdDump(ctx context.Context, imagePath, containerID str
 
 func (s *service) setupStreamerCapture(dumpdir string, num_pipes int32) (*exec.Cmd, error) {
 	buf := new(bytes.Buffer)
-	cmd := exec.Command("sudo", "cedana-image-streamer", "--dir", dumpdir, "--num-pipes", fmt.Sprint(num_pipes), "capture")
+	cmd := exec.Command("cedana-image-streamer", "--dir", dumpdir, "--num-pipes", fmt.Sprint(num_pipes), "capture")
 	cmd.Stderr = buf
 	var err error
 	/*stdout, err := cmd.StdoutPipe()

--- a/pkg/api/gpu.go
+++ b/pkg/api/gpu.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	GPU_CONTROLLER_WAIT_TIMEOUT       = 10 * time.Second
+	GPU_CONTROLLER_WAIT_TIMEOUT       = 20 * time.Second
 	GPU_CONTROLLER_DEFAULT_HOST       = "localhost" // and port is dynamic
 	GPU_CONTROLLER_LOG_PATH_FORMATTER = "/tmp/cedana-gpu-controller-%s.log"
 )


### PR DESCRIPTION
## Current behavior/issue

If the shared memory file at /dev/shm/cedana-gpu.* is deleted after a dump. Or the restore happens on a new machine, the restore fails.

## Proposed solution

Do GPU restore before CRIU restore so GPU controller ensures that file is recreated. For now, this is fine as this file is of fixed size anyways.

For log files such as cedana-so-<jid>.log, uses a hack where gpuRestore simply creates an empty file before CRIU restore using the JID.

## Possible other solutions?

When the segment becomes dynamic in size, this won't work as CRIU will still complain about size mismatch. Also, if there are multiple segments. Ideally, GPU controller should return all such files info in RPC response to GPU restore, so we can just --inherit-fd them to CRIU.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.