### PR TITLE
Remove issue number from PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,7 +1,5 @@
 ## Describe your changes
 
-## Issue ticket number
-
 ## Checklist before requesting a review
 - [ ] Have I performed a self-review?
 - [ ] Have I added regression or unit tests (where it makes sense) for my changes?


### PR DESCRIPTION
Remove issue number from PR template, as it's already fetched from branch name and attached to the PR.