### PR TITLE
hotfix: GPU controller leak + increase timeout

### DIFF
--- a/pkg/api/gpu.go
+++ b/pkg/api/gpu.go
@@ -27,7 +27,7 @@ import (
 )
 
 const (
-	GPU_CONTROLLER_WAIT_TIMEOUT       = 20 * time.Second
+	GPU_CONTROLLER_WAIT_TIMEOUT       = 30 * time.Second
 	GPU_CONTROLLER_DEFAULT_HOST       = "localhost" // and port is dynamic
 	GPU_CONTROLLER_LOG_PATH_FORMATTER = "/tmp/cedana-gpu-controller-%s.log"
 )
@@ -185,6 +185,8 @@ func (s *service) StartGPUController(ctx context.Context, uid, gid int32, groups
 	waitCtx, _ := context.WithTimeout(ctx, GPU_CONTROLLER_WAIT_TIMEOUT)
 	resp, err := gpuServiceConn.StartupPoll(waitCtx, &args, grpc.WaitForReady(true))
 	if err != nil || !resp.Success {
+    gpuCmd.Process.Signal(syscall.SIGTERM)
+    gpuConn.Close()
 		log.Error().Err(err).Str("stdout/stderr", outBuf.String()).Msg("failed to start GPU controller")
 		return fmt.Errorf("gpu controller did not start: %v", err)
 	}


### PR DESCRIPTION
## Describe your changes
If the timeout expires, a GPU controller instance might keep running as an orphan. This fixes it, and also increases the timeout for slower systems.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.