### PR TITLE
fix: GPU restore barrier deadlock

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,8 +6,8 @@ toolchain go1.22.2
 
 require (
 	buf.build/gen/go/cedana/criu/protocolbuffers/go v1.35.2-20241120213244-d99a43b0c85e.1
-	buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-20241120213244-06763032c670.1
-	buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-20241120213244-06763032c670.1
+	buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-20241126224120-f71196128a6a.1
+	buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-20241126224120-f71196128a6a.1
 	buf.build/gen/go/cedana/img-streamer/protocolbuffers/go v1.34.2-20241004172122-02bf93858080.2
 	buf.build/gen/go/cedana/task/grpc/go v1.5.1-20241120213244-f9aa09c7b23a.1
 	buf.build/gen/go/cedana/task/protocolbuffers/go v1.35.2-20241120213244-f9aa09c7b23a.1

--- a/go.sum
+++ b/go.sum
@@ -10,10 +10,14 @@ buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-00000000000000-3ee9a9b2e1a6.1 h1:WPu6
 buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-00000000000000-3ee9a9b2e1a6.1/go.mod h1:PS+uTBH3Bk7T2RGFge6Nk39TzmN6uhm77OWXLYVqCf4=
 buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-20241120213244-06763032c670.1 h1:fW0Pf9Xqa8zwA/f24lG+cNCUsItq27Vk0B9IFy/VwPA=
 buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-20241120213244-06763032c670.1/go.mod h1:gUkkKjYHTLQFc5Mar8CdEq9TUqa1TiJ4g7Bvmf2IYlE=
+buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-20241126224120-f71196128a6a.1 h1:+VUSy7zACBmNsdm2rYx+/NkE9bmN23IOoHIGC/ya/ZM=
+buf.build/gen/go/cedana/gpu/grpc/go v1.5.1-20241126224120-f71196128a6a.1/go.mod h1:PaznPifUSiYmQbRCJOEila/3z3Tt8wAKJXvx2qQAznw=
 buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-00000000000000-3ee9a9b2e1a6.1 h1:l0dyX51oiXAdPyNetvnTznmPlQn19eGLFnngi2yIVLM=
 buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-00000000000000-3ee9a9b2e1a6.1/go.mod h1:14P29lBGPpmKBTOhetR/D806Xraxf+f7Zw9nwaWSOmo=
 buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-20241120213244-06763032c670.1 h1:8mJImDs0Q83s61/MN4V3aPJnip6YJRU2IneghwohXyw=
 buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-20241120213244-06763032c670.1/go.mod h1:14P29lBGPpmKBTOhetR/D806Xraxf+f7Zw9nwaWSOmo=
+buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-20241126224120-f71196128a6a.1 h1:7gpC+AAH6RLTP6Q27Iqrfx33SXBxz5KutSawjJQuIlQ=
+buf.build/gen/go/cedana/gpu/protocolbuffers/go v1.35.2-20241126224120-f71196128a6a.1/go.mod h1:14P29lBGPpmKBTOhetR/D806Xraxf+f7Zw9nwaWSOmo=
 buf.build/gen/go/cedana/img-streamer/protocolbuffers/go v1.34.2-20241004172122-02bf93858080.2 h1:kwXHtlUqAOBK5y8cE7PJdH3aVCqQ6MvH4bWAL1XCkFs=
 buf.build/gen/go/cedana/img-streamer/protocolbuffers/go v1.34.2-20241004172122-02bf93858080.2/go.mod h1:oPrkbz2tVi+fhZbClTT2M5jJaNJhRtrAv8Ef/j/kwwc=
 buf.build/gen/go/cedana/task/grpc/go v1.5.1-00000000000000-1c06d68a2426.1 h1:s9F3sDkmPcWk77ijmQLg2taxF6Bf0lbkvtwrVczHZGg=

--- a/pkg/api/gpu.go
+++ b/pkg/api/gpu.go
@@ -246,6 +246,22 @@ func (s *service) WaitGPUController(jid string) error {
 	return nil
 }
 
+func (s *service) UnblockGPUController(ctx context.Context, jid string) error {
+	controller, ok := gpuControllers[jid]
+	if !ok {
+		return fmt.Errorf("no gpu controller found for jid %s", jid)
+	}
+
+	resp, err := controller.Client.UnblockBarrier(ctx, &gpu.UnblockBarrierRequest{})
+	if err != nil {
+		return fmt.Errorf("failed to unblock gpu controller: %v", err)
+	}
+	if !resp.Success {
+		return fmt.Errorf("failed to unblock gpu controller")
+	}
+	return nil
+}
+
 func (s *service) GetGPUController(jid string) *GPUController {
 	controller, ok := gpuControllers[jid]
 	if !ok {

--- a/pkg/api/restore.go
+++ b/pkg/api/restore.go
@@ -640,6 +640,13 @@ func (s *service) restore(ctx context.Context, args *task.RestoreArgs, stream gr
 		if err != nil {
 			return 0, nil, err
 		}
+
+		nfy.PreResumeFunc = NotifyFunc{
+			Avail: true,
+			Callback: func() error {
+				return s.UnblockGPUController(ctx, state.JID)
+			},
+		}
 	}
 
 	pid, err := s.criuRestore(ctx, opts, nfy, dir, extraFiles)


### PR DESCRIPTION
## Describe your changes

**NOTE**: This will still not fix for runc GPU restores, as we don't have a CRIU notify hook for it. In the new unified design, it should be fixed.

#### Current behavior/issue

If a checkpoint is taken during execution where the barrier flag is set, it breaks during the restore as it blocks gpu-controller from executing. 

This probably was introduced by moving the restore before the criu restore, which changed gpu-controller conking the flag over the head and unsetting it.

#### Proposed solution

Add a new RPC function that unsets the barrier that gets called during a PreResume() hook, before the process starts.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.