### PR TITLE
fix: gpu restore for runc

### DIFF
--- a/pkg/api/gpu.go
+++ b/pkg/api/gpu.go
@@ -150,9 +150,9 @@ func (s *service) StartGPUController(ctx context.Context, uid, gid int32, groups
 		},
 	}
 
-  if _, err := os.Stat("/run/nvidia/driver"); err == nil {
-    gpuCmd.SysProcAttr.Chroot = "/run/nvidia/driver"
-  }
+	if _, err := os.Stat("/run/nvidia/driver"); err == nil {
+		gpuCmd.SysProcAttr.Chroot = "/run/nvidia/driver"
+	}
 
 	outBuf := &bytes.Buffer{}
 	gpuOut := io.MultiWriter(outBuf)

--- a/pkg/api/restore.go
+++ b/pkg/api/restore.go
@@ -843,11 +843,15 @@ func (s *service) gpuRestore(ctx context.Context, dir string, uid, gid int32, gr
 		return fmt.Errorf("could not get restore stats from context")
 	}
 
-	err := s.StartGPUController(ctx, uid, gid, groups, jid)
-	if err != nil {
-		log.Warn().Msgf("could not start cedana-gpu-controller: %v", err)
-		return err
-	}
+  if _, err := s.getState(ctx, jid); err == nil {
+    log.Info().Msgf("GPU restore requested for managed job %s, assuming gpu controller already started", jid)
+  } else {
+    err := s.StartGPUController(ctx, uid, gid, groups, jid)
+    if err != nil {
+      log.Warn().Msgf("could not start cedana-gpu-controller: %v", err)
+      return err
+    }
+  }
 
 	gpuController := s.GetGPUController(jid)
 


### PR DESCRIPTION
### Motivation

Bug with gpu runc restore.

Technically it still works, but we start an extra gpu controller and use more shared memory, not desirable, breaks on systems with not large enough dev shm.

This is also the cause for ghost processes.

### Changes

If jid already exists we know it's a managed process which means we can ignore starting another gpu controller.