### PR TITLE
fix: gpu restore runc

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -349,6 +349,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           submodules: "recursive"
 

--- a/cmd/daemon.go
+++ b/cmd/daemon.go
@@ -185,11 +185,10 @@ func pollForAsrMetricsReporting(ctx context.Context, port uint32) {
 				},
 			})
 			// Get the server-assigned message ID
-			id, err := result.Get(ctx)
+			_, err = result.Get(ctx)
 			if err != nil {
 				log.Error().Msgf("Failed to publish message: %v", err)
 			}
-			log.Info().Msgf("Published message with ID: %v\n", id)
 			time.Sleep(ASR_POLL_INTERVAL)
 		}
 	}()

--- a/pkg/api/gpu.go
+++ b/pkg/api/gpu.go
@@ -240,7 +240,7 @@ func (s *service) WaitGPUController(jid string) error {
 		}
 		log.Info().Int("PID", cmd.Process.Pid).
 			Int("status", cmd.ProcessState.ExitCode()).
-			Str("stdout/stderr", gpuController.Output.String()).
+			// Str("stdout/stderr", gpuController.Output.String()).
 			Msg("GPU controller exited")
 	}
 

--- a/pkg/api/gpu.go
+++ b/pkg/api/gpu.go
@@ -150,9 +150,9 @@ func (s *service) StartGPUController(ctx context.Context, uid, gid int32, groups
 		},
 	}
 
-  if _, err := os.Stat("/run/nvidia/driver"); err == nil {
-    gpuCmd.SysProcAttr.Chroot = "/run/nvidia/driver"
-  }
+	if _, err := os.Stat("/run/nvidia/driver"); err == nil {
+		gpuCmd.SysProcAttr.Chroot = "/run/nvidia/driver"
+	}
 
 	outBuf := &bytes.Buffer{}
 	gpuOut := io.MultiWriter(outBuf)

--- a/pkg/api/restore.go
+++ b/pkg/api/restore.go
@@ -838,11 +838,15 @@ func (s *service) gpuRestore(ctx context.Context, dir string, uid, gid int32, gr
 		return fmt.Errorf("could not get restore stats from context")
 	}
 
-	err := s.StartGPUController(ctx, uid, gid, groups, jid)
-	if err != nil {
-		log.Warn().Msgf("could not start cedana-gpu-controller: %v", err)
-		return err
-	}
+  if _, err := s.getState(ctx, jid); err == nil {
+    log.Info().Msgf("GPU restore requested for managed job %s, assuming gpu controller already started", jid)
+  } else {
+    err := s.StartGPUController(ctx, uid, gid, groups, jid)
+    if err != nil {
+      log.Warn().Msgf("could not start cedana-gpu-controller: %v", err)
+      return err
+    }
+  }
 
 	gpuController := s.GetGPUController(jid)
 

--- a/pkg/api/runc.go
+++ b/pkg/api/runc.go
@@ -246,7 +246,7 @@ func (s *service) RuncRestore(ctx context.Context, args *task.RuncRestoreArgs) (
 		return nil, status.Error(codes.InvalidArgument, "checkpoint path cannot be empty")
 	}
 
-	pid, exitCode, err := s.runcRestore(ctx, args.ImagePath, criuOpts, opts, jid)
+	pid, exitCode, err := s.runcRestore(ctx, args.ImagePath, criuOpts, opts, jid, args.CheckpointID)
 	if err != nil {
 		err = status.Error(codes.Internal, fmt.Sprintf("failed to restore runc container: %v", err))
 		return nil, err

--- a/pkg/api/runc.go
+++ b/pkg/api/runc.go
@@ -223,7 +223,7 @@ func (s *service) RuncRestore(ctx context.Context, args *task.RuncRestoreArgs) (
 	criuOpts := &container.CriuOpts{
 		MntnsCompatMode: false, // XXX: Should instead take value from args
 		TcpEstablished:  args.GetCriuOpts().GetTcpEstablished(),
-		TcpClose:        args.GetCriuOpts().GetTcpClose(),
+		TcpClose:        true,
 		FileLocks:       args.GetCriuOpts().GetFileLocks(),
 	}
 
@@ -246,7 +246,7 @@ func (s *service) RuncRestore(ctx context.Context, args *task.RuncRestoreArgs) (
 		return nil, status.Error(codes.InvalidArgument, "checkpoint path cannot be empty")
 	}
 
-	pid, exitCode, err := s.runcRestore(ctx, args.ImagePath, criuOpts, opts, jid, args.CheckpointID)
+	pid, exitCode, err := s.runcRestore(ctx, args.ImagePath, criuOpts, opts, jid)
 	if err != nil {
 		err = status.Error(codes.Internal, fmt.Sprintf("failed to restore runc container: %v", err))
 		return nil, err

--- a/pkg/api/server.go
+++ b/pkg/api/server.go
@@ -245,10 +245,10 @@ func loggingUnaryInterceptor(serveOpts ServeOpts, machineID string, macAddr stri
 		)
 
 		// log the GetContainerInfo method to trace
-		if strings.Contains(info.FullMethod, "GetContainerInfo") {
+		if strings.Contains(info.FullMethod, "Check") {
 			log.Trace().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")
 		} else {
-			log.Debug().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")
+			log.Info().Str("method", info.FullMethod).Interface("request", req).Msg("gRPC request received")
 		}
 
 		resp, err := handler(ctx, req)
@@ -262,7 +262,11 @@ func loggingUnaryInterceptor(serveOpts ServeOpts, machineID string, macAddr stri
 			span.SetStatus(codes.Error, err.Error())
 			span.RecordError(err)
 		} else {
-			log.Debug().Str("method", info.FullMethod).Interface("response", resp).Msg("gRPC request succeeded")
+      if strings.Contains(info.FullMethod, "Check") {
+        log.Trace().Str("method", info.FullMethod).Interface("response", resp).Msg("gRPC request succeeded")
+      } else {
+        log.Info().Str("method", info.FullMethod).Interface("response", resp).Msg("gRPC request succeeded")
+      }
 		}
 
 		return resp, err

--- a/pkg/container/checkpoint.go
+++ b/pkg/container/checkpoint.go
@@ -1799,7 +1799,7 @@ func (c *RuncContainer) RuncCheckpoint(criuOpts *CriuOpts, pid int32, runcRoot s
 		}
 	}
 
-	err = c.criuSwrk(nil, req, criuOpts, nil)
+	err = c.criuSwrk(nil, req, criuOpts, nil, 0)
 	if err != nil {
 		logCriuErrors(criuOpts.ImagesDirectory, "dump.log")
 		return err
@@ -1807,7 +1807,7 @@ func (c *RuncContainer) RuncCheckpoint(criuOpts *CriuOpts, pid int32, runcRoot s
 	return nil
 }
 
-func (c *RuncContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *CriuOpts, extraFiles []*os.File) error {
+func (c *RuncContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *CriuOpts, extraFiles []*os.File, netPid int) error {
 	fds, err := unix.Socketpair(unix.AF_LOCAL, unix.SOCK_SEQPACKET|unix.SOCK_CLOEXEC, 0)
 	if err != nil {
 		return err
@@ -1874,7 +1874,7 @@ func (c *RuncContainer) criuSwrk(process *Process, req *criurpc.CriuReq, opts *C
 		}
 	}()
 
-	if err := c.criuApplyCgroups(criuProcess.Pid, req); err != nil {
+	if err := c.criuApplyCgroups(criuProcess.Pid, netPid, req); err != nil {
 		return err
 	}
 

--- a/pkg/container/utils_linux.go
+++ b/pkg/container/utils_linux.go
@@ -1507,7 +1507,7 @@ func (c *RuncContainer) Restore(process *Process, criuOpts *CriuOpts, runcRoot s
 			req.Opts.InheritFd = append(req.Opts.InheritFd, inheritFd)
 		}
 	}
-	err = c.criuSwrk(process, req, criuOpts, extraFiles)
+	err = c.criuSwrk(process, req, criuOpts, extraFiles, netPid)
 	if err != nil {
 		logCriuErrors(logDir, logFile)
 	}

--- a/setup-host.sh
+++ b/setup-host.sh
@@ -112,6 +112,12 @@ END_CHROOT
         PATH_CONTAINERD_CONFIG=/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
         echo "k3s detected. Creating default config file at $PATH_CONTAINERD_CONFIG"
         echo '{{ template "base" . }}' > $PATH_CONTAINERD_CONFIG
+        cat >> $PATH_CONTAINERD_CONFIG <<'END_CAT'
+
+        [plugins."io.containerd.grpc.v1.cri".containerd.runtimes."cedana"]
+          runtime_type = "io.containerd.runc.v2"
+          runtime_path = '/usr/local/cedana/bin/containerd-shim-runc-v2'
+END_CAT
     fi
 
     PATH_CONTAINERD_CONFIG=${CONTAINERD_CONFIG_PATH:-"/etc/containerd/config.toml"}

--- a/setup-host.sh
+++ b/setup-host.sh
@@ -95,9 +95,9 @@ END_CHROOT
     echo "Downloading cedana's nvidia interception utilities..."
     mkdir -p /cedana/bin /cedana/lib
 
-    wget --header="Authorization: Bearer $CEDANA_AUTH_TOKEN" -O /cedana/bin/cedana-gpu-controlller $CEDANA_URL/k8s/gpu/gpucontroller
-    chmod +x /cedana/bin/cedana-gpu-controlller
-    install /cedana/bin/cedana-gpu-controlller /usr/local/bin/cedana-gpu-controlller
+    wget --header="Authorization: Bearer $CEDANA_AUTH_TOKEN" -O /cedana/bin/cedana-gpu-controller $CEDANA_URL/k8s/gpu/gpucontroller
+    chmod +x /cedana/bin/cedana-gpu-controller
+    install /cedana/bin/cedana-gpu-controller /usr/local/bin/cedana-gpu-controller
 
     wget --header="Authorization: Bearer $CEDANA_AUTH_TOKEN" -O /cedana/lib/libcedana-gpu.so $CEDANA_URL/k8s/gpu/libcedana
     install /cedana/lib/libcedana-gpu.so /usr/local/lib/libcedana-gpu.so
@@ -108,28 +108,13 @@ END_CHROOT
     mkdir -p /usr/local/cedana/bin
     install /cedana/bin/containerd-shim-runc-v2 /usr/local/cedana/bin/containerd-shim-runc-v2
 
-    PATH_CONTAINERD_CONFIG=${CONTAINERD_CONFIG_PATH:-"/etc/containerd/config.toml"}
-    if [ ! -f $PATH_CONTAINERD_CONFIG ]; then
-        echo "Containerd config file not found at $PATH_CONTAINERD_CONFIG"
-        if [ $SEARCH_CONTAINERD_CONFIG -eq 1 ]; then
-            echo "Searching for containerd config file..."
-            PATH_CONTAINERD_CONFIG=$(find / -fullname **/containerd/config.toml | head -n 1)
-            if [ ! -f $PATH_CONTAINERD_CONFIG ]; then
-                echo "Containerd config file not found. Exiting..."
-                exit 1
-            fi
-            echo "Found containerd config file at $PATH_CONTAINERD_CONFIG"
-        else
-            echo "Containerd config file not found. Creating default config file at $PATH_CONTAINERD_CONFIG"
-            if [[ $PATH_CONTAINERD_CONFIG == *"k3s"* ]]; then
-                echo "k3s detected. Creating default config file at $PATH_CONTAINERD_CONFIG"
-                echo '{{ template "base" . }}' > $PATH_CONTAINERD_CONFIG
-            else
-                echo "" > $PATH_CONTAINERD_CONFIG
-            fi
-        fi
+    if [ -f /var/lib/rancher/k3s/agent/etc/containerd/config.toml ]; then
+        PATH_CONTAINERD_CONFIG=/var/lib/rancher/k3s/agent/etc/containerd/config.toml.tmpl
+        echo "k3s detected. Creating default config file at $PATH_CONTAINERD_CONFIG"
+        echo '{{ template "base" . }}' > $PATH_CONTAINERD_CONFIG
     fi
 
+    PATH_CONTAINERD_CONFIG=${CONTAINERD_CONFIG_PATH:-"/etc/containerd/config.toml"}
     if ! grep -q 'cedana' "$PATH_CONTAINERD_CONFIG"; then
         echo "Writing containerd config to $PATH_CONTAINERD_CONFIG"
         cat >> $PATH_CONTAINERD_CONFIG <<'END_CAT'


### PR DESCRIPTION
### Motivation

Bug with gpu runc restore.

Technically it still works, but we start an extra gpu controller and use more shared memory, not desirable, breaks on systems with not large enough dev shm.

This is also the cause for ghost processes.

### Changes

If jid already exists we know it's a managed process which means we can ignore starting another gpu controller.

Fixes CED-889