### PR TITLE
chore: add k8s, etc plugins inside image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,7 @@ ADD ./go.sum /app
 RUN go mod download && rm -rf go.mod go.sum
 ADD . /app
 RUN make build
+RUN make plugins
 
 FROM ubuntu:22.04
 
@@ -53,6 +54,7 @@ RUN mkdir -p /usr/local/bin /scripts
 ADD ./Makefile /
 ADD ./scripts/ /scripts
 
+COPY --from=builder /app/libcedana*.so /usr/local/lib/
 COPY --from=builder /app/cedana /usr/local/bin/
 COPY --from=builder /app/buildah/cmd/buildah/buildah /usr/local/bin
 COPY --from=builder /app/netavark/bin/netavark /usr/local/bin

--- a/plugins/k8s/cmd/scripts/setup-host.sh
+++ b/plugins/k8s/cmd/scripts/setup-host.sh
@@ -9,6 +9,7 @@ mkdir -p /host/cedana /host/cedana/bin /host/cedana/scripts /host/cedana/lib
 # We load the binary from docker image for the container
 # Copy Cedana binaries and scripts to the host
 cp /usr/local/bin/cedana /host/usr/local/bin/cedana
+cp /usr/local/lib/libcedana*.so /host/usr/local/lib/
 cp /scripts/* /host/cedana/scripts
 cp /Makefile /host/cedana/Makefile
 


### PR DESCRIPTION
Install all plugins into the container image at the time of release by default, the images can be updated later.

Most importantly, this allows for k8s-helper code to work as it is.