### PR TITLE
fix: containerd pull

### DIFF
--- a/scripts/k8s-install-plugins.sh
+++ b/scripts/k8s-install-plugins.sh
@@ -13,7 +13,7 @@ DIR="$( cd -P "$( dirname "$SOURCE"  )" >/dev/null 2>&1 && pwd  )"
 
 source "$DIR"/utils.sh
 
-PLUGINS="criu runc k8s" # bare minimum plugins required for k8s
+PLUGINS="criu runc k8s containerd" # bare minimum plugins required for k8s
 
 # if gpu driver present then add gpu plugin
 if [ -d /proc/driver/nvidia/gpus/ ]; then


### PR DESCRIPTION
We don't pull containerd by default on k8s side, which is needed. Once we add CRIO we should pull that as well.

cc: @yashanand1910 