### PR TITLE
hotfix: upgrade cedana k8s broken

### DIFF
--- a/plugins/k8s/cmd/scripts/bump-restart.sh
+++ b/plugins/k8s/cmd/scripts/bump-restart.sh
@@ -1,10 +1,9 @@
 #!/bin/bash
+# NOTE: This script assumes it's executed in the container environment
 
 set -e
 
 chroot /host /bin/bash /cedana/scripts/systemd-reset.sh
-
-# NOTE: This script assumes it's executed in the container environment
 
 # updates the cedana daemon to the latest version
 # and restarts with the same arguments

--- a/plugins/k8s/cmd/scripts/bump-restart.sh
+++ b/plugins/k8s/cmd/scripts/bump-restart.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+chroot /host /bin/bash /cedana/scripts/systemd-reset.sh
+
 # NOTE: This script assumes it's executed in the container environment
 
 # updates the cedana daemon to the latest version
@@ -19,6 +21,5 @@ cp /usr/local/bin/buildah /host/cedana/bin/buildah
 cp /usr/local/bin/netavark /host/cedana/bin/netavark
 cp /usr/local/bin/netavark-dhcp-proxy-client /host/cedana/bin/netavark-dhcp-proxy-client
 
-chroot /host /bin/bash /cedana/scripts/systemd-reset.sh
 chroot /host /bin/bash /cedana/scripts/k8s-install-plugins.sh # updates to latest
 chroot /host /bin/bash /cedana/scripts/systemd-install.sh

--- a/plugins/k8s/cmd/scripts/setup-host.sh
+++ b/plugins/k8s/cmd/scripts/setup-host.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
+# NOTE: This script assumes it's executed in the container environment
 
 set -e
 
 chroot /host /bin/bash /cedana/scripts/systemd-reset.sh
-# NOTE: This script assumes it's executed in the container environment
 
 mkdir -p /host/cedana /host/cedana/bin /host/cedana/scripts /host/cedana/lib
 

--- a/plugins/k8s/cmd/scripts/setup-host.sh
+++ b/plugins/k8s/cmd/scripts/setup-host.sh
@@ -2,21 +2,7 @@
 
 set -e
 
-chroot /host /bin/bash <<'EOT'
-APP_NAME="cedana"
-SERVICE_FILE="/etc/systemd/system/$APP_NAME.service"
-
-if [ -f /var/log/cedana-daemon.log ]; then
-    echo "Stopping $APP_NAME service..."
-    $SUDO_USE systemctl stop $APP_NAME.service
-
-    # truncate the logs
-    echo -n > /var/log/cedana-daemon.log
-else
-    echo "No cedana-daemon.log file found"
-    echo "Skipping $APP_NAME service stop"
-fi
-EOT
+chroot /host /bin/bash /cedana/scripts/systemd-reset.sh
 # NOTE: This script assumes it's executed in the container environment
 
 mkdir -p /host/cedana /host/cedana/bin /host/cedana/scripts /host/cedana/lib
@@ -33,7 +19,6 @@ cp /usr/local/bin/netavark /host/cedana/bin/netavark
 cp /usr/local/bin/netavark-dhcp-proxy-client /host/cedana/bin/netavark-dhcp-proxy-client
 
 # Enter chroot environment on the host
-chroot /host /bin/bash /cedana/scripts/systemd-reset.sh
 env \
     CEDANA_URL="$CEDANA_URL" \
     CEDANA_AUTH_TOKEN="$CEDANA_AUTH_TOKEN" \

--- a/plugins/k8s/cmd/scripts/setup-host.sh
+++ b/plugins/k8s/cmd/scripts/setup-host.sh
@@ -2,6 +2,21 @@
 
 set -e
 
+chroot /host /bin/bash <<'EOT'
+APP_NAME="cedana"
+SERVICE_FILE="/etc/systemd/system/$APP_NAME.service"
+
+if [ -f /var/log/cedana-daemon.log ]; then
+    echo "Stopping $APP_NAME service..."
+    $SUDO_USE systemctl stop $APP_NAME.service
+
+    # truncate the logs
+    echo -n > /var/log/cedana-daemon.log
+else
+    echo "No cedana-daemon.log file found"
+    echo "Skipping $APP_NAME service stop"
+fi
+EOT
 # NOTE: This script assumes it's executed in the container environment
 
 mkdir -p /host/cedana /host/cedana/bin /host/cedana/scripts /host/cedana/lib


### PR DESCRIPTION
cedana upgrade fails to copy cedana file, as it's running, keep this in case until we can provide a separate upgrade utility and binary