### PR TITLE
feat: Allow setting custom precision for printing profiling data

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"time"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	"github.com/cedana/cedana/pkg/client"
@@ -12,11 +11,7 @@ import (
 	"github.com/cedana/cedana/pkg/features"
 	"github.com/cedana/cedana/pkg/flags"
 	"github.com/cedana/cedana/pkg/keys"
-	"github.com/cedana/cedana/pkg/profiling"
-	"github.com/cedana/cedana/pkg/style"
 	"github.com/cedana/cedana/pkg/utils"
-	"github.com/jedib0t/go-pretty/v6/table"
-	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 )
 
@@ -177,65 +172,4 @@ var processRunCmd = &cobra.Command{
 
 		return nil
 	},
-}
-
-////////////////////
-/// Helper Funcs ///
-////////////////////
-
-// PrintProfilingData prints the profiling data in a very readable format.
-func printProfilingData(data *profiling.Data) {
-	var total time.Duration
-
-	fmt.Print("Profiling data received from daemon:\n\n")
-
-	tableWriter := table.NewWriter()
-	tableWriter.SetStyle(style.TableStyle)
-	tableWriter.SetOutputMirror(os.Stdout)
-
-	categoryMap := make(map[string]time.Duration)
-
-	for _, p := range data.Components {
-		if p.Duration == 0 {
-			continue
-		}
-		categoryName, name := utils.SimplifyFuncName(p.Name)
-
-		category := style.WarningColors.Sprint(categoryName)
-		features.CmdTheme.IfAvailable(func(name string, theme text.Colors) error {
-			category = theme.Sprint(categoryName)
-			return nil
-		}, categoryName)
-
-		duration := time.Duration(p.Duration)
-		total += duration
-
-		if categoryName != "" {
-			categoryMap[category] += duration
-		} else {
-			categoryMap[style.DisabledColors.Sprint("other")] += duration
-		}
-
-		tableWriter.AppendRow([]interface{}{duration, category, style.DisabledColors.Sprint(name)})
-	}
-
-	tableWriter.AppendFooter([]interface{}{total, "", fmt.Sprintf("%s (total)", data.Name)})
-	tableWriter.Render()
-
-	if len(categoryMap) > 1 {
-		fmt.Println()
-		tableWriter = table.NewWriter()
-		tableWriter.SetStyle(style.TableStyle)
-		tableWriter.SetOutputMirror(os.Stdout)
-
-		for category, duration := range categoryMap {
-			percentage := (float64(duration) / float64(total)) * 100
-			tableWriter.AppendRow([]interface{}{duration, fmt.Sprintf("%.2f%%", percentage), category})
-		}
-
-		tableWriter.AppendFooter([]interface{}{total, "", fmt.Sprintf("%s (total)", data.Name)})
-		tableWriter.Render()
-	}
-
-	fmt.Println()
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1,0 +1,73 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/features"
+	"github.com/cedana/cedana/pkg/profiling"
+	"github.com/cedana/cedana/pkg/style"
+	"github.com/cedana/cedana/pkg/utils"
+	"github.com/jedib0t/go-pretty/v6/table"
+	"github.com/jedib0t/go-pretty/v6/text"
+)
+
+// PrintProfilingData prints the profiling data in a very readable format.
+func printProfilingData(data *profiling.Data) {
+	var total time.Duration
+
+	fmt.Print("Profiling data received from daemon:\n\n")
+
+	tableWriter := table.NewWriter()
+	tableWriter.SetStyle(style.TableStyle)
+	tableWriter.SetOutputMirror(os.Stdout)
+
+	categoryMap := make(map[string]time.Duration)
+  precision := config.Global.Profiling.Precision
+
+	for _, p := range data.Components {
+		if p.Duration == 0 {
+			continue
+		}
+		categoryName, name := utils.SimplifyFuncName(p.Name)
+
+		category := style.WarningColors.Sprint(categoryName)
+		features.CmdTheme.IfAvailable(func(name string, theme text.Colors) error {
+			category = theme.Sprint(categoryName)
+			return nil
+		}, categoryName)
+
+		duration := time.Duration(p.Duration)
+		total += duration
+
+		if categoryName != "" {
+			categoryMap[category] += duration
+		} else {
+			categoryMap[style.DisabledColors.Sprint("other")] += duration
+		}
+
+		tableWriter.AppendRow([]interface{}{profiling.DurationStr(duration, precision), category, style.DisabledColors.Sprint(name)})
+	}
+
+	tableWriter.AppendFooter([]interface{}{total, "", fmt.Sprintf("%s (total)", data.Name)})
+	tableWriter.Render()
+
+	if len(categoryMap) > 1 {
+		fmt.Println()
+		tableWriter = table.NewWriter()
+		tableWriter.SetStyle(style.TableStyle)
+		tableWriter.SetOutputMirror(os.Stdout)
+
+		for category, duration := range categoryMap {
+			percentage := (float64(duration) / float64(total)) * 100
+			tableWriter.AppendRow([]interface{}{duration, fmt.Sprintf("%.2f%%", percentage), category})
+		}
+
+		tableWriter.AppendFooter([]interface{}{total, "", fmt.Sprintf("%s (total)", data.Name)})
+		tableWriter.Render()
+	}
+
+	fmt.Println()
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -25,7 +25,7 @@ func printProfilingData(data *profiling.Data) {
 	tableWriter.SetOutputMirror(os.Stdout)
 
 	categoryMap := make(map[string]time.Duration)
-  precision := config.Global.Profiling.Precision
+	precision := config.Global.Profiling.Precision
 
 	for _, p := range data.Components {
 		if p.Duration == 0 {
@@ -51,7 +51,7 @@ func printProfilingData(data *profiling.Data) {
 		tableWriter.AppendRow([]interface{}{profiling.DurationStr(duration, precision), category, style.DisabledColors.Sprint(name)})
 	}
 
-	tableWriter.AppendFooter([]interface{}{total, "", fmt.Sprintf("%s (total)", data.Name)})
+	tableWriter.AppendFooter([]interface{}{profiling.DurationStr(total, precision), "", fmt.Sprintf("%s (total)", data.Name)})
 	tableWriter.Render()
 
 	if len(categoryMap) > 1 {
@@ -62,10 +62,10 @@ func printProfilingData(data *profiling.Data) {
 
 		for category, duration := range categoryMap {
 			percentage := (float64(duration) / float64(total)) * 100
-			tableWriter.AppendRow([]interface{}{duration, fmt.Sprintf("%.2f%%", percentage), category})
+			tableWriter.AppendRow([]interface{}{profiling.DurationStr(duration, precision), fmt.Sprintf("%.2f%%", percentage), category})
 		}
 
-		tableWriter.AppendFooter([]interface{}{total, "", fmt.Sprintf("%s (total)", data.Name)})
+		tableWriter.AppendFooter([]interface{}{profiling.DurationStr(total, precision), "", fmt.Sprintf("%s (total)", data.Name)})
 		tableWriter.Render()
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -48,7 +48,8 @@ var Global Config = Config{
 		Path:   filepath.Join(os.TempDir(), "cedana.db"),
 	},
 	Profiling: Profiling{
-		Enabled: true,
+		Enabled:       true,
+		Precision: "auto",
 	},
 	Metrics: Metrics{
 		ASR:  false,

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -57,6 +57,8 @@ type (
 	Profiling struct {
 		// Enabled sets whether to enable and show profiling information
 		Enabled bool `json:"enabled" mapstructure:"enabled" yaml:"enabled"`
+		// Precision sets the time precision when printing profiling information (auto, ns, us, ms, s)
+		Precision string `json:"time_precision" mapstructure:"time_precision" yaml:"time_precision"`
 	}
 
 	Metrics struct {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -58,7 +58,7 @@ type (
 		// Enabled sets whether to enable and show profiling information
 		Enabled bool `json:"enabled" mapstructure:"enabled" yaml:"enabled"`
 		// Precision sets the time precision when printing profiling information (auto, ns, us, ms, s)
-		Precision string `json:"time_precision" mapstructure:"time_precision" yaml:"time_precision"`
+		Precision string `json:"precision" mapstructure:"precision" yaml:"precision"`
 	}
 
 	Metrics struct {

--- a/pkg/profiling/timing.go
+++ b/pkg/profiling/timing.go
@@ -2,6 +2,7 @@ package profiling
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"runtime"
 	"time"
@@ -199,4 +200,21 @@ func LogDuration(start time.Time, f ...any) {
 
 	name := utils.FunctionName(pc)
 	log.Trace().Str("in", name).Msgf("spent %s", duration)
+}
+
+// DurationStr converts the duration to the specified precision.
+func DurationStr(d time.Duration, precision string) string {
+	switch precision {
+	case "s":
+		return fmt.Sprintf("%gs", float64(d.Nanoseconds())/1e9)
+	case "ms":
+		return fmt.Sprintf("%gms", float64(d.Nanoseconds())/1e6)
+	case "us":
+		return fmt.Sprintf("%gus", float64(d.Nanoseconds())/1e3)
+	case "ns":
+		return fmt.Sprintf("%gns", float64(d.Nanoseconds()))
+	}
+
+	// auto
+	return d.String()
 }


### PR DESCRIPTION
## Describe your changes
This is required by benchmark or other tools that want to read the data directly from stdout. Adds
the precision config item:
https://github.com/cedana/cedana/blob/2d924f8c81c8f7af8545587e3812d6793eeca95d/pkg/config/types.go#L57-L62

Default is "auto", which prints using the most suitable precision for the value.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.