### PR TITLE
fix: GPU controller Attach called too quickly leading to race

### DIFF
--- a/internal/server/gpu/manager_simple.go
+++ b/internal/server/gpu/manager_simple.go
@@ -84,7 +84,7 @@ func (m *ManagerSimple) Detach(jid string) error {
 }
 
 func (m *ManagerSimple) IsAttached(jid string) bool {
-	return m.controllers.get(jid) != nil
+	return m.controllers.Get(jid) != nil
 }
 
 func (m *ManagerSimple) Checks() types.Checks {
@@ -114,7 +114,7 @@ func (m *ManagerSimple) Checks() types.Checks {
 			return []*daemon.HealthCheckComponent{statusComponent}
 		}
 
-		controller := m.controllers.get(jid)
+		controller := m.controllers.Get(jid)
 		components, err := controller.waitForHealthCheck(ctx, m.wg)
 		defer m.controllers.kill(jid)
 		if components == nil && err != nil {
@@ -148,7 +148,7 @@ func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string) *criu
 		waitCtx, cancel := context.WithTimeout(ctx, DUMP_TIMEOUT)
 		defer cancel()
 
-		controller := m.controllers.get(jid)
+		controller := m.controllers.Get(jid)
 		if controller == nil {
 			return fmt.Errorf("GPU controller not found, is the task still running?")
 		}
@@ -183,7 +183,7 @@ func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string) *criu
 			waitCtx, cancel := context.WithTimeout(ctx, RESTORE_TIMEOUT)
 			defer cancel()
 
-			controller := m.controllers.get(jid)
+			controller := m.controllers.Get(jid)
 			if controller == nil {
 				restoreErr <- fmt.Errorf("GPU controller not found, is the task still running?")
 			}


### PR DESCRIPTION
## Describe your changes
This race is caused when a restore is called immediately after a dump. Since for dump, the request
is returned as soon as dump is completed, while in the background the daemon cleans up the GPU
controller. If a restore is called immediately after the dump, a GPU controller might still appear
as attached to the job.

This fix fails restore request that happens too quickly, instead of segfaulting on the internal controller
map.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.