### PR TITLE
fix: resolve full path in CLI for exec/run

### DIFF
--- a/cmd/run.go
+++ b/cmd/run.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"os/exec"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	"github.com/cedana/cedana/pkg/client"
@@ -136,6 +137,12 @@ var processRunCmd = &cobra.Command{
 		asRoot, _ := cmd.Flags().GetBool(flags.AsRootFlag.Full)
 
 		path := args[0]
+		if fullPath, err := exec.LookPath(path); err == nil {
+			path = fullPath
+		} else {
+			return err
+		}
+
 		args = args[1:]
 		env := os.Environ()
 		wd, err := os.Getwd()


### PR DESCRIPTION
## Describe your changes
Currently, when executing a process from the CLI, with `cedana exec/cedana run process`, passing in
the env vars to the daemon is not sufficient. The daemon is executing under a different env and so
the full path of the process must be provided to the daemon. For CLI, we simply resolve the full
path from where the command is called before passing it to the daemon.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.