### PR TITLE
feat: Port streaming C/R support

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -210,7 +210,7 @@ jobs:
 
   regression-test:
     name: Regression Tests
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-4
     container:
       image: cedana/cedana-test:latest
       credentials:
@@ -218,6 +218,9 @@ jobs:
         password: ${{ secrets.DOCKER_TOKEN }}
       options: --privileged --init
     needs: [build]
+    env:
+      CEDANA_URL: ${{ vars.CEDANA_URL }}
+      CEDANA_AUTH_TOKEN: ${{ secrets.CEDANA_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -248,7 +251,7 @@ jobs:
 
   regression-test-runc:
     name: Regression Tests (runc)
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-4
     container:
       image: cedana/cedana-test:latest
       credentials:
@@ -256,6 +259,9 @@ jobs:
         password: ${{ secrets.DOCKER_TOKEN }}
       options: --privileged --init
     needs: [build, build-plugins]
+    env:
+      CEDANA_URL: ${{ vars.CEDANA_URL }}
+      CEDANA_AUTH_TOKEN: ${{ secrets.CEDANA_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -292,7 +298,7 @@ jobs:
 
   regression-test-containerd:
     name: Regression Tests (containerd)
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-4
     container:
       image: cedana/cedana-test:latest
       credentials:
@@ -300,6 +306,9 @@ jobs:
         password: ${{ secrets.DOCKER_TOKEN }}
       options: --privileged --init
     needs: [build, build-plugins]
+    env:
+      CEDANA_URL: ${{ vars.CEDANA_URL }}
+      CEDANA_AUTH_TOKEN: ${{ secrets.CEDANA_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -336,7 +345,7 @@ jobs:
 
   regression-test-crio:
     name: Regression Tests (crio)
-    runs-on: ubicloud-standard-8
+    runs-on: ubicloud-standard-4
     container:
       image: cedana/cedana-test:latest
       credentials:
@@ -344,6 +353,9 @@ jobs:
         password: ${{ secrets.DOCKER_TOKEN }}
       options: --privileged --init
     needs: [build, build-plugins]
+    env:
+      CEDANA_URL: ${{ vars.CEDANA_URL }}
+      CEDANA_AUTH_TOKEN: ${{ secrets.CEDANA_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -378,9 +390,9 @@ jobs:
       - name: Run regression tests
         run: make test-regression-plugin PLUGIN=crio
 
-  regression-test-gpu:
-    name: Regression Tests (gpu)
-    runs-on: ubicloud-standard-8
+  regression-test-streamer:
+    name: Regression Tests (streamer)
+    runs-on: ubicloud-standard-4
     container:
       image: cedana/cedana-test:latest
       credentials:
@@ -388,6 +400,9 @@ jobs:
         password: ${{ secrets.DOCKER_TOKEN }}
       options: --privileged --init
     needs: [build, build-plugins]
+    env:
+      CEDANA_URL: ${{ vars.CEDANA_URL }}
+      CEDANA_AUTH_TOKEN: ${{ secrets.CEDANA_AUTH_TOKEN }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -409,6 +424,59 @@ jobs:
           chmod +x ./cedana
           chmod +x ./libcedana-*.so
           echo "$PWD" >> $GITHUB_PATH
+
+      - name: Install latest streamer plugin
+        run: sudo -E ./cedana plugin install streamer
+
+      - name: Mark git dir as safe
+        run: git config --global --add safe.directory "$(pwd)"
+
+      - name: Setup debugging session
+        uses: mxschmitt/action-tmate@v3
+        if: ${{ startsWith(github.event_name, 'workflow') && inputs.debug_regression_test }}
+        with:
+          limit-access-to-actor: true
+
+      - name: Run regression tests
+        run: make test-regression-plugin PLUGIN=streamer
+
+  regression-test-gpu:
+    name: Regression Tests (gpu)
+    runs-on: ubicloud-gpu
+    container:
+      image: cedana/cedana-test:latest
+      credentials:
+        username: ${{ vars.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_TOKEN }}
+      options: --privileged --init
+    needs: [build, build-plugins]
+    env:
+      CEDANA_URL: ${{ vars.CEDANA_URL }}
+      CEDANA_AUTH_TOKEN: ${{ secrets.CEDANA_AUTH_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Download binary
+        uses: actions/download-artifact@v4
+        with:
+          name: build
+
+      - name: Download plugins
+        uses: actions/download-artifact@v4
+        with:
+          name: plugins
+
+      - name: Make executable
+        run: |
+          chmod +x ./cedana
+          chmod +x ./libcedana-*.so
+          echo "$PWD" >> $GITHUB_PATH
+
+      - name: Install latest gpu plugin
+        run: sudo -E ./cedana plugin install gpu
 
       - name: Mark git dir as safe
         run: git config --global --add safe.directory "$(pwd)"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -448,7 +448,7 @@ jobs:
       credentials:
         username: ${{ vars.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
-      options: --privileged --init --gpus all
+      options: --privileged --init --ipc=host --gpus all
     needs: [build, build-plugins]
     env:
       CEDANA_URL: ${{ vars.CEDANA_URL }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -284,6 +284,9 @@ jobs:
           chmod +x ./libcedana-*.so
           echo "$PWD" >> $GITHUB_PATH
 
+      - name: Install plugin
+        run: sudo -E ./cedana plugin install runc
+
       - name: Mark git dir as safe
         run: git config --global --add safe.directory "$(pwd)"
 
@@ -331,6 +334,9 @@ jobs:
           chmod +x ./libcedana-*.so
           echo "$PWD" >> $GITHUB_PATH
 
+      - name: Install plugin
+        run: sudo -E ./cedana plugin install containerd
+
       - name: Mark git dir as safe
         run: git config --global --add safe.directory "$(pwd)"
 
@@ -377,6 +383,9 @@ jobs:
           chmod +x ./cedana
           chmod +x ./libcedana-*.so
           echo "$PWD" >> $GITHUB_PATH
+
+      - name: Install plugin
+        run: sudo -E ./cedana plugin install crio
 
       - name: Mark git dir as safe
         run: git config --global --add safe.directory "$(pwd)"

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -444,7 +444,7 @@ jobs:
     name: Regression Tests (gpu)
     runs-on: ubicloud-gpu
     container:
-      image: cedana/cedana-test:latest
+      image: cedana/cedana-test:cuda
       credentials:
         username: ${{ vars.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -448,7 +448,7 @@ jobs:
       credentials:
         username: ${{ vars.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}
-      options: --privileged --init
+      options: --privileged --init --gpus all
     needs: [build, build-plugins]
     env:
       CEDANA_URL: ${{ vars.CEDANA_URL }}

--- a/Makefile
+++ b/Makefile
@@ -179,7 +179,11 @@ test-regression-plugin: ## Run regression tests for a plugin (PLUGIN=<plugin>)
 ##########
 
 DOCKER_TEST_IMAGE=cedana/cedana-test:latest
-DOCKER_TEST_RUN=docker run --privileged --init --cgroupns=private -it --rm -v $(PWD):/src:ro $(DOCKER_TEST_IMAGE)
+DOCKER_TEST_RUN=docker run --privileged --init --cgroupns=private -it --rm \
+				-v $(PWD):/src:ro \
+				-v /usr/local/bin/criu:/usr/local/bin/criu \
+				-v /usr/local/bin/criu-image-streamer:/usr/local/bin/criu-image-streamer \
+				$(DOCKER_TEST_IMAGE)
 
 docker: ## Build the Docker image
 	@echo "Building Docker image..."

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -33,7 +33,7 @@ func init() {
 		StringP(flags.NameFlag.Full, "", "", "name of the dump")
 	dumpCmd.MarkPersistentFlagDirname(flags.DirFlag.Full)
 	dumpCmd.PersistentFlags().
-		StringP(flags.CompressionFlag.Full, flags.CompressionFlag.Short, "", "compression algorithm (tar, gzip, lz4, none)")
+		StringP(flags.CompressionFlag.Full, flags.CompressionFlag.Short, "", "compression algorithm (none, tar, gzip, lz4, zlib)")
 	dumpCmd.PersistentFlags().
 		Int32P(flags.StreamFlag.Full, flags.StreamFlag.Short, 0, "stream the dump (0: don't stream, n > 0: n parallelism)")
 	dumpCmd.PersistentFlags().

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -35,7 +35,7 @@ func init() {
 	dumpCmd.PersistentFlags().
 		StringP(flags.CompressionFlag.Full, flags.CompressionFlag.Short, "", "compression algorithm (tar, gzip, lz4, none)")
 	dumpCmd.PersistentFlags().
-		BoolP(flags.StreamFlag.Full, flags.StreamFlag.Short, false, "stream the dump using cedana-image-streamer")
+		Int32P(flags.StreamFlag.Full, flags.StreamFlag.Short, 0, "stream the dump (0: don't stream, n > 0: n parallelism)")
 	dumpCmd.PersistentFlags().
 		BoolP(flags.LeaveRunningFlag.Full, flags.LeaveRunningFlag.Short, false, "leave the process running after dump")
 	dumpCmd.PersistentFlags().
@@ -54,6 +54,7 @@ func init() {
 	// Bind to config
 	viper.BindPFlag("checkpoint.dir", dumpCmd.PersistentFlags().Lookup(flags.DirFlag.Full))
 	viper.BindPFlag("checkpoint.compression", dumpCmd.PersistentFlags().Lookup(flags.CompressionFlag.Full))
+	viper.BindPFlag("checkpoint.stream", dumpCmd.PersistentFlags().Lookup(flags.StreamFlag.Full))
 	viper.BindPFlag("criu.leave_running", dumpCmd.PersistentFlags().Lookup(flags.LeaveRunningFlag.Full))
 
 	///////////////////////////////////////////
@@ -87,8 +88,8 @@ var dumpCmd = &cobra.Command{
 		dir := config.Global.Checkpoint.Dir
 		name, _ := cmd.Flags().GetString(flags.NameFlag.Full)
 		compression := config.Global.Checkpoint.Compression
-		leaveRunning := config.Global.CRIU.LeaveRunning
 		stream, _ := cmd.Flags().GetInt32(flags.StreamFlag.Full)
+		leaveRunning := config.Global.CRIU.LeaveRunning
 		tcpEstablished, _ := cmd.Flags().GetBool(flags.TcpEstablishedFlag.Full)
 		tcpSkipInFlight, _ := cmd.Flags().GetBool(flags.TcpSkipInFlightFlag.Full)
 		fileLocks, _ := cmd.Flags().GetBool(flags.FileLocksFlag.Full)
@@ -101,7 +102,7 @@ var dumpCmd = &cobra.Command{
 			Dir:         dir,
 			Name:        name,
 			Compression: compression,
-			Stream:      stream,
+			Stream:      int32(stream),
 			Criu: &criu.CriuOpts{
 				LeaveRunning:    proto.Bool(leaveRunning),
 				TcpEstablished:  proto.Bool(tcpEstablished),

--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -35,7 +35,7 @@ func init() {
 	dumpCmd.PersistentFlags().
 		StringP(flags.CompressionFlag.Full, flags.CompressionFlag.Short, "", "compression algorithm (none, tar, gzip, lz4, zlib)")
 	dumpCmd.PersistentFlags().
-		Int32P(flags.StreamFlag.Full, flags.StreamFlag.Short, 0, "stream the dump (0: don't stream, n > 0: n parallelism)")
+		Int32P(flags.StreamFlag.Full, flags.StreamFlag.Short, 0, "stream the dump (using <n> parallel streams)")
 	dumpCmd.PersistentFlags().
 		BoolP(flags.LeaveRunningFlag.Full, flags.LeaveRunningFlag.Short, false, "leave the process running after dump")
 	dumpCmd.PersistentFlags().

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cedana/cedana/pkg/keys"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
+	"github.com/spf13/viper"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -28,7 +29,7 @@ func init() {
 	restoreCmd.PersistentFlags().
 		StringP(flags.PathFlag.Full, flags.PathFlag.Short, "", "path of dump")
 	restoreCmd.PersistentFlags().
-		BoolP(flags.StreamFlag.Full, flags.StreamFlag.Short, false, "stream the dump using cedana-image-streamer")
+		Int32P(flags.StreamFlag.Full, flags.StreamFlag.Short, 0, "stream the restore (0: don't stream, n > 0: n parallelism)")
 	restoreCmd.PersistentFlags().
 		BoolP(flags.TcpEstablishedFlag.Full, flags.TcpEstablishedFlag.Short, false, "restore tcp established connections")
 	restoreCmd.PersistentFlags().
@@ -51,6 +52,9 @@ func init() {
 		flags.AttachFlag.Full,
 		flags.LogFlag.Full,
 	) // only one of these can be set
+
+	// Bind to config
+	viper.BindPFlag("checkpoint.stream", restoreCmd.PersistentFlags().Lookup(flags.StreamFlag.Full))
 
 	///////////////////////////////////////////
 	// Add subcommands from supported plugins

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -29,7 +29,7 @@ func init() {
 	restoreCmd.PersistentFlags().
 		StringP(flags.PathFlag.Full, flags.PathFlag.Short, "", "path of dump")
 	restoreCmd.PersistentFlags().
-		Int32P(flags.StreamFlag.Full, flags.StreamFlag.Short, 0, "stream the restore (0: don't stream, n > 0: n parallelism)")
+		Int32P(flags.StreamFlag.Full, flags.StreamFlag.Short, 0, "stream the restore (using <n> parallel streams)")
 	restoreCmd.PersistentFlags().
 		BoolP(flags.TcpEstablishedFlag.Full, flags.TcpEstablishedFlag.Short, false, "restore tcp established connections")
 	restoreCmd.PersistentFlags().

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -48,7 +48,7 @@ func init() {
 	rootCmd.PersistentFlags().
 		BoolP(flags.ProfilingFlag.Full, flags.ProfilingFlag.Short, false, "enable profiling/show profiling data")
 
-		// Bind to config
+	// Bind to config
 	viper.BindPFlag("protocol", rootCmd.PersistentFlags().Lookup(flags.ProtocolFlag.Full))
 	viper.BindPFlag("address", rootCmd.PersistentFlags().Lookup(flags.AddressFlag.Full))
 	viper.BindPFlag("profiling.enabled", rootCmd.PersistentFlags().Lookup(flags.ProfilingFlag.Full))

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 require (
 	buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-3a3f8e393b2b.2
 	buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-3a3f8e393b2b.1
+	buf.build/gen/go/cedana/cedana-image-streamer/protocolbuffers/go v1.36.3-20250123222419-fd1f5023e83d.1
 	buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2
 	buf.build/gen/go/cedana/cedana/protocolbuffers/go v1.36.3-00000000000000-4d54deb59aa0.1
 	buf.build/gen/go/cedana/criu/protocolbuffers/go v1.36.3-20250123205248-8e8bdecabee9.1

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-3a3f8e393b2b.2 
 buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-3a3f8e393b2b.2/go.mod h1:tHQOLLuGVnFRLsvKLtCRTZEAkt7AvCPP3fbT3Yww3jo=
 buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-3a3f8e393b2b.1 h1:DfHL/JS34o4ESEsFb5mZzPjejIusc9vvrBYXuylcIJ0=
 buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-3a3f8e393b2b.1/go.mod h1:RoDVyq9Z0G9myjkZI2oQk90AOR/lBBesb+MoxMBcOiw=
+buf.build/gen/go/cedana/cedana-image-streamer/protocolbuffers/go v1.36.3-20250123222419-fd1f5023e83d.1 h1:W3h73ma5VycaOGypSHnJ/vTzr7gu439fBpSM7XzL2XU=
+buf.build/gen/go/cedana/cedana-image-streamer/protocolbuffers/go v1.36.3-20250123222419-fd1f5023e83d.1/go.mod h1:ZGzaQu7YeMTP6LLNvBl/rhKQzRDQ/4MZauoGZF7acCY=
 buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2 h1:iRLt94w3lZJR8qXlziExK8HXGXpKtKbYF+VpP+YT560=
 buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2/go.mod h1:wvJKo4x/c9J2U97MKkIPKSpYpR5CtoE+jEBPE06brgE=
 buf.build/gen/go/cedana/cedana/protocolbuffers/go v1.36.3-00000000000000-4d54deb59aa0.1 h1:8/JPDysTPGnFA9ptG72cqhv1BLUNLv7TpsFwZhufKcQ=

--- a/internal/server/criu/dump_handlers.go
+++ b/internal/server/criu/dump_handlers.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	CRIU_LOG_FILE       = "criu.log"
+	CRIU_DUMP_LOG_FILE  = "criu-dump.log"
 	GHOST_FILE_MAX_SIZE = 10000000 // 10MB
 )
 
@@ -46,7 +46,7 @@ func dump(ctx context.Context, opts types.Opts, resp *daemon.DumpResp, req *daem
 	criuOpts := req.GetCriu()
 
 	// Set CRIU server
-	criuOpts.LogFile = proto.String(CRIU_LOG_FILE)
+	criuOpts.LogFile = proto.String(CRIU_DUMP_LOG_FILE)
 	criuOpts.LogLevel = proto.Int32(CRIU_LOG_VERBOSITY_LEVEL)
 	criuOpts.GhostLimit = proto.Uint32(GHOST_FILE_MAX_SIZE)
 	criuOpts.Pid = proto.Int32(int32(resp.GetState().GetPID()))
@@ -68,7 +68,7 @@ func dump(ctx context.Context, opts types.Opts, resp *daemon.DumpResp, req *daem
 	// Capture internal logs from CRIU
 	utils.LogFromFile(
 		log.With().Int("CRIU", version).Logger().WithContext(ctx),
-		filepath.Join(criuOpts.GetImagesDir(), CRIU_LOG_FILE),
+		filepath.Join(criuOpts.GetImagesDir(), CRIU_DUMP_LOG_FILE),
 		zerolog.TraceLevel,
 	)
 

--- a/internal/server/criu/restore_handlers.go
+++ b/internal/server/criu/restore_handlers.go
@@ -47,6 +47,17 @@ func restore(ctx context.Context, opts types.Opts, resp *daemon.RestoreResp, req
 	criuOpts.NotifyScripts = proto.Bool(true)
 	criuOpts.LogToStderr = proto.Bool(false)
 
+	// Change ownership of the dump directory
+	uids := resp.GetState().GetUIDs()
+	gids := resp.GetState().GetGIDs()
+	if len(uids) == 0 || len(gids) == 0 {
+		return nil, status.Error(codes.Internal, "missing UIDs/GIDs in process state")
+	}
+	err = utils.ChownAll(criuOpts.GetImagesDir(), int(uids[0]), int(gids[0]))
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to change ownership of dump directory: %v", err)
+	}
+
 	log.Debug().Int("CRIU", version).Interface("opts", criuOpts).Msg("CRIU restore starting")
 	// utils.LogProtoMessage(criuOpts, "CRIU option", zerolog.DebugLevel)
 

--- a/internal/server/defaults/restore_adapters.go
+++ b/internal/server/defaults/restore_adapters.go
@@ -2,10 +2,8 @@ package defaults
 
 import (
 	"context"
-	"os"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
-	"github.com/cedana/cedana/pkg/keys"
 	"github.com/cedana/cedana/pkg/types"
 )
 
@@ -13,8 +11,6 @@ import (
 func FillMissingRestoreDefaults(next types.Restore) types.Restore {
 	return func(ctx context.Context, opts types.Opts, resp *daemon.RestoreResp, req *daemon.RestoreReq) (chan int, error) {
 		// Nothing to do, yet
-
-		ctx = context.WithValue(ctx, keys.EXTRA_FILES_CONTEXT_KEY, []*os.File{})
 
 		return next(ctx, opts, resp, req)
 	}

--- a/internal/server/dump.go
+++ b/internal/server/dump.go
@@ -10,7 +10,9 @@ import (
 	"github.com/cedana/cedana/internal/server/job"
 	"github.com/cedana/cedana/internal/server/network"
 	"github.com/cedana/cedana/internal/server/process"
+	"github.com/cedana/cedana/internal/server/streamer"
 	"github.com/cedana/cedana/internal/server/validation"
+	"github.com/cedana/cedana/pkg/config"
 	"github.com/cedana/cedana/pkg/features"
 	"github.com/cedana/cedana/pkg/types"
 	"github.com/cedana/cedana/pkg/utils"
@@ -23,10 +25,15 @@ func (s *Server) Dump(ctx context.Context, req *daemon.DumpReq) (*daemon.DumpRes
 	// The order below is the order followed before executing
 	// the final handler (criu.Dump).
 
+	dumpDirAdapter := filesystem.PrepareDumpDir
+	if req.Stream > 0 || config.Global.Checkpoint.Stream > 0 {
+		dumpDirAdapter = streamer.PrepareDumpDir
+	}
+
 	middleware := types.Middleware[types.Dump]{
 		defaults.FillMissingDumpDefaults,
 		validation.ValidateDumpRequest,
-		filesystem.PrepareDumpDir,
+		dumpDirAdapter,
 
 		pluginDumpMiddleware, // middleware from plugins
 

--- a/internal/server/filesystem/dump_adapters.go
+++ b/internal/server/filesystem/dump_adapters.go
@@ -19,7 +19,7 @@ import (
 	"google.golang.org/protobuf/proto"
 )
 
-const DUMP_DIR_PERMS = 0o777
+const DUMP_DIR_PERMS = 0o755
 
 // This adapter ensures the specified dump dir exists and is writable.
 // Creates a unique directory within this directory for the dump.

--- a/internal/server/filesystem/dump_adapters.go
+++ b/internal/server/filesystem/dump_adapters.go
@@ -48,7 +48,7 @@ func PrepareDumpDir(next types.Dump) types.Dump {
 			return nil, status.Errorf(codes.InvalidArgument, "dump dir does not exist: %s", dir)
 		}
 
-		// Create a unique directory within the dump dir, using type, PID, and timestamp
+		// Create a new directory within the dump dir, where dump will happen
 		imagesDirectory := filepath.Join(dir, req.Name)
 
 		// Create the directory
@@ -65,7 +65,6 @@ func PrepareDumpDir(next types.Dump) types.Dump {
 			return nil, status.Errorf(codes.Internal, "failed to chmod dump dir: %v", err)
 		}
 
-		// Set CRIU server
 		f, err := os.Open(imagesDirectory)
 		if err != nil {
 			return nil, status.Errorf(codes.Internal, "failed to open dump dir: %v", err)
@@ -76,8 +75,8 @@ func PrepareDumpDir(next types.Dump) types.Dump {
 			req.Criu = &criu_proto.CriuOpts{}
 		}
 
-		req.GetCriu().ImagesDir = proto.String(imagesDirectory)
-		req.GetCriu().ImagesDirFd = proto.Int32(int32(f.Fd()))
+		req.Criu.ImagesDir = proto.String(imagesDirectory)
+		req.Criu.ImagesDirFd = proto.Int32(int32(f.Fd()))
 
 		// Setup dump fs that can be used by future adapters to directly read write/extra files
 		// to the dump directory

--- a/internal/server/filesystem/dump_adapters.go
+++ b/internal/server/filesystem/dump_adapters.go
@@ -8,6 +8,7 @@ import (
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/io"
 	"github.com/cedana/cedana/pkg/profiling"
 	"github.com/cedana/cedana/pkg/types"
 	"github.com/cedana/cedana/pkg/utils"
@@ -37,7 +38,7 @@ func PrepareDumpDir(next types.Dump) types.Dump {
 
 		// Check if compression is valid, because we don't want to fail after the dump
 		// as the process would be killed
-		if _, ok := utils.SUPPORTED_COMPRESSIONS[compression]; !ok {
+		if _, ok := io.SUPPORTED_COMPRESSIONS[compression]; !ok {
 			return nil, status.Errorf(codes.Unimplemented, "unsupported compression format '%s'", compression)
 		}
 

--- a/internal/server/filesystem/restore_adapters.go
+++ b/internal/server/filesystem/restore_adapters.go
@@ -21,7 +21,7 @@ import (
 
 // This adapter decompresses (if required) the dump to a temporary directory for restore.
 // Automatically detects the compression format from the file extension.
-func PrepareRestoreDir(next types.Restore) types.Restore {
+func PrepareDumpDirForRestore(next types.Restore) types.Restore {
 	return func(ctx context.Context, opts types.Opts, resp *daemon.RestoreResp, req *daemon.RestoreReq) (chan int, error) {
 		path := req.GetPath()
 		stat, err := os.Stat(path)
@@ -69,10 +69,10 @@ func PrepareRestoreDir(next types.Restore) types.Restore {
 			req.Criu = &criu_proto.CriuOpts{}
 		}
 
-		req.GetCriu().ImagesDir = proto.String(imagesDirectory)
-		req.GetCriu().ImagesDirFd = proto.Int32(int32(dir.Fd()))
+		req.Criu.ImagesDir = proto.String(imagesDirectory)
+		req.Criu.ImagesDirFd = proto.Int32(int32(dir.Fd()))
 
-		// Setup dump fs that can be used by future adapters to directly read write/extra files
+		// Setup dump fs that can be used by future adapters to directly read files
 		// to the dump directory
 		opts.DumpFs = afero.NewBasePathFs(afero.NewOsFs(), imagesDirectory)
 

--- a/internal/server/gpu/controller.go
+++ b/internal/server/gpu/controller.go
@@ -115,7 +115,7 @@ func (m *controllers) spawnAsync(
 
 	controller.Stderr = controller.ErrBuf
 
-	if dir := config.Global.Plugins.GPU.LogDir; dir != "" {
+	if dir := config.Global.GPU.LogDir; dir != "" {
 		file, err := os.OpenFile(
 			filepath.Join(dir, fmt.Sprintf(CONTROLLER_LOG_FILE_FORMATTER, jid)),
 			CONTROLLER_LOG_FILE_MODE,

--- a/internal/server/gpu/manager.go
+++ b/internal/server/gpu/manager.go
@@ -58,7 +58,7 @@ func (ManagerMissing) Detach(jid string) error {
 	return fmt.Errorf("GPU manager missing")
 }
 
-func (ManagerMissing) CRIUCallback(lifetime context.Context, jid string, user *syscall.Credential) *criu.NotifyCallback {
+func (ManagerMissing) CRIUCallback(lifetime context.Context, jid string, user *syscall.Credential, stream int32) *criu.NotifyCallback {
 	return nil
 }
 

--- a/internal/server/gpu/manager.go
+++ b/internal/server/gpu/manager.go
@@ -29,7 +29,7 @@ type Manager interface {
 	Checks() types.Checks
 
 	// CRIUCallback returns the CRIU notify callback for GPU C/R.
-	CRIUCallback(lifetime context.Context, jid string, user *syscall.Credential) *criu.NotifyCallback
+	CRIUCallback(lifetime context.Context, jid string, user *syscall.Credential, stream int32) *criu.NotifyCallback
 }
 
 /////////////////

--- a/internal/server/gpu/manager_simple.go
+++ b/internal/server/gpu/manager_simple.go
@@ -171,7 +171,7 @@ func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string, user 
 			waitCtx, cancel = context.WithTimeout(ctx, DUMP_TIMEOUT)
 			defer cancel()
 
-			_, err := controller.Dump(waitCtx, &gpu.DumpReq{Dir: opts.GetImagesDir()})
+			_, err := controller.Dump(waitCtx, &gpu.DumpReq{Dir: opts.GetImagesDir(), Stream: stream > 0})
 			if err != nil {
 				log.Error().Err(err).Str("JID", jid).Msg("failed to dump GPU")
 				dumpErr <- fmt.Errorf("failed to dump GPU: %v", err)

--- a/internal/server/gpu/manager_simple.go
+++ b/internal/server/gpu/manager_simple.go
@@ -143,7 +143,7 @@ func (m *ManagerSimple) Checks() types.Checks {
 	}
 }
 
-func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string, user *syscall.Credential) *criu_client.NotifyCallback {
+func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string, user *syscall.Credential, stream int32) *criu_client.NotifyCallback {
 	callback := &criu_client.NotifyCallback{Name: "gpu"}
 
 	// Add pre-dump hook for GPU dump. We freeze the GPU controller so we can
@@ -207,7 +207,7 @@ func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string, user 
 				restoreErr <- fmt.Errorf("GPU controller not found, is the task still running?")
 			}
 
-			_, err := controller.Restore(waitCtx, &gpu.RestoreReq{Dir: opts.GetImagesDir()})
+			_, err := controller.Restore(waitCtx, &gpu.RestoreReq{Dir: opts.GetImagesDir(), Stream: stream > 0})
 			if err != nil {
 				log.Error().Err(err).Str("JID", jid).Msg("failed to restore GPU")
 				restoreErr <- fmt.Errorf("failed to restore GPU: %v", err)
@@ -223,7 +223,7 @@ func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string, user 
 			// profiling.AddTimingComponent(ctx, copyMemTime, "controller.CopyMemory")
 			// profiling.AddTimingComponent(ctx, replayCallsTime, "controller.ReplayCalls")
 		}()
-		return nil
+		return <-restoreErr
 	}
 
 	// Wait for GPU restore to finish before resuming the process

--- a/internal/server/healthcheck.go
+++ b/internal/server/healthcheck.go
@@ -6,6 +6,7 @@ import (
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	"github.com/cedana/cedana/internal/server/criu"
+	"github.com/cedana/cedana/internal/server/streamer"
 	"github.com/cedana/cedana/pkg/features"
 	"github.com/cedana/cedana/pkg/plugins"
 	"github.com/cedana/cedana/pkg/types"
@@ -38,9 +39,14 @@ func (s *Server) HealthCheck(ctx context.Context, req *daemon.HealthCheckReq) (*
 func (s *Server) pluginChecklist() types.Checklist {
 	checklist := []types.Checks{}
 
-	// Add a GPU helth check if plugin is installed
+	// Add a GPU health check if plugin is installed
 	if s.plugins.IsInstalled("gpu") {
 		checklist = append(checklist, s.gpus.Checks())
+	}
+
+	// Add a streamer health check if plugin is installed
+	if s.plugins.IsInstalled("streamer") {
+		checklist = append(checklist, streamer.Checks(s.plugins))
 	}
 
 	// Add health checks from other plugins

--- a/internal/server/healthcheck.go
+++ b/internal/server/healthcheck.go
@@ -63,7 +63,7 @@ func (s *Server) pluginChecklist() types.Checklist {
 // Assumes plugin is installed
 func checkPluginVersion(plugins plugins.Manager, plugin string) types.Check {
 	return func(ctx context.Context) []*daemon.HealthCheckComponent {
-		component := &daemon.HealthCheckComponent{Name: "plugin version"}
+		component := &daemon.HealthCheckComponent{Name: "version"}
 
 		p := plugins.Get(plugin)
 		component.Data = p.Version

--- a/internal/server/job/dump_adapters.go
+++ b/internal/server/job/dump_adapters.go
@@ -46,7 +46,7 @@ func ManageDump(jobs Manager) types.Adapter[types.Dump] {
 			req.Details = mergedDetails
 
 			// Import saved notify callbacks
-			opts.CRIUCallback.IncludeMulti(jobs.CRIUCallback(opts.Lifetime, jid))
+			opts.CRIUCallback.IncludeMulti(jobs.CRIUCallback(opts.Lifetime, jid, req.Stream))
 
 			exited, err := next(ctx, opts, resp, req)
 			if err != nil {

--- a/internal/server/job/dump_adapters.go
+++ b/internal/server/job/dump_adapters.go
@@ -3,6 +3,7 @@ package job
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	"github.com/cedana/cedana/pkg/types"
@@ -36,7 +37,7 @@ func ManageDump(jobs Manager) types.Adapter[types.Dump] {
 			req.Type = job.GetType()
 			resp.State = job.GetState()
 			if req.Name == "" {
-				req.Name = fmt.Sprintf("dump-%s-%s", req.Type, jid)
+				req.Name = fmt.Sprintf("dump-%s-%s-%d", req.Type, jid, time.Now().Unix())
 			}
 
 			// Use saved job details, but allow overriding from request

--- a/internal/server/job/manager.go
+++ b/internal/server/job/manager.go
@@ -76,7 +76,7 @@ type Manager interface {
 	GPUs() gpu.Manager
 
 	// CRIUCallback returns the saved CRIU notify callback for the job.
-	CRIUCallback(lifetime context.Context, jid string) *criu.NotifyCallbackMulti
+	CRIUCallback(lifetime context.Context, jid string, stream int32) *criu.NotifyCallbackMulti
 
 	// GetWG returns the waitgroup for the manager.
 	GetWG() *sync.WaitGroup

--- a/internal/server/job/manager_lazy.go
+++ b/internal/server/job/manager_lazy.go
@@ -393,7 +393,7 @@ func (m *ManagerLazy) DeleteCheckpoint(id string) {
 	m.pending <- action{putCheckpoint, id}
 }
 
-func (m *ManagerLazy) CRIUCallback(lifetime context.Context, jid string) *criu.NotifyCallbackMulti {
+func (m *ManagerLazy) CRIUCallback(lifetime context.Context, jid string, stream int32) *criu.NotifyCallbackMulti {
 	job := m.Get(jid)
 	if job == nil {
 		return nil
@@ -407,7 +407,7 @@ func (m *ManagerLazy) CRIUCallback(lifetime context.Context, jid string) *criu.N
 			Gid:    state.GetGIDs()[0],
 			Groups: state.GetGroups(),
 		}
-		multiCallback.Include(m.gpus.CRIUCallback(lifetime, jid, user))
+		multiCallback.Include(m.gpus.CRIUCallback(lifetime, jid, user, stream))
 	}
 	return multiCallback
 }

--- a/internal/server/job/restore_adapters.go
+++ b/internal/server/job/restore_adapters.go
@@ -75,7 +75,7 @@ func ManageRestore(jobs Manager) types.Adapter[types.Restore] {
 			opts.Lifetime = lifetime
 
 			// Import saved notify callbacks
-			opts.CRIUCallback.IncludeMulti(jobs.CRIUCallback(opts.Lifetime, jid))
+			opts.CRIUCallback.IncludeMulti(jobs.CRIUCallback(opts.Lifetime, jid, req.Stream))
 
 			exited, err := next(ctx, opts, resp, req)
 			if err != nil {

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -84,7 +84,7 @@ func NewServer(ctx context.Context, opts *ServeOpts) (*Server, error) {
 	pluginManager := plugins.NewLocalManager()
 
 	var gpuManager gpu.Manager
-	gpuPoolSize := config.Global.Plugins.GPU.PoolSize
+	gpuPoolSize := config.Global.GPU.PoolSize
 	if gpuPoolSize > 0 {
 		log.Info().Int("pool_size", gpuPoolSize).Msg("GPU pool size set")
 		gpuManager = gpu.NewPoolManager(ctx, wg, gpuPoolSize)

--- a/internal/server/streamer/checks.go
+++ b/internal/server/streamer/checks.go
@@ -93,11 +93,16 @@ func CheckKernelSettings() types.Check {
 			softLimitComponent.Errors = append(softLimitComponent.Errors, "Failed to read /proc/sys/fs/pipe-user-pages-soft")
 		} else {
 			softLimit = bytes.TrimSpace(softLimit)
-			if string(softLimit) == fmt.Sprintf("%d", OPTIMAL_SOFT_LIMIT) {
-				softLimitComponent.Data = "unlimited"
+			softLimitBytes, err := strconv.ParseInt(string(softLimit), 10, 64)
+			if err != nil {
+				softLimitComponent.Errors = append(softLimitComponent.Errors, "Failed to parse /proc/sys/fs/pipe-user-pages-soft")
 			} else {
-				softLimitComponent.Warnings = append(softLimitComponent.Warnings, fmt.Sprintf("For optimal performance, `echo %d > /proc/sys/fs/pipe-user-pages-soft`", OPTIMAL_SOFT_LIMIT))
-				softLimitComponent.Data = string(softLimit)
+				if softLimitBytes == OPTIMAL_SOFT_LIMIT {
+					softLimitComponent.Data = "unlimited"
+				} else {
+					softLimitComponent.Warnings = append(softLimitComponent.Warnings, fmt.Sprintf("For optimal performance, `echo %d > /proc/sys/fs/pipe-user-pages-soft`", OPTIMAL_SOFT_LIMIT))
+					softLimitComponent.Data = utils.SizeStr(softLimitBytes)
+				}
 			}
 		}
 
@@ -106,11 +111,16 @@ func CheckKernelSettings() types.Check {
 			hardLimitComponent.Errors = append(hardLimitComponent.Errors, "Failed to read /proc/sys/fs/pipe-user-pages-hard")
 		} else {
 			hardLimit = bytes.TrimSpace(hardLimit)
-			if string(hardLimit) == fmt.Sprintf("%d", OPTIMAL_HARD_LIMIT) {
-				hardLimitComponent.Data = "unlimited"
+			hardLimitBytes, err := strconv.ParseInt(string(hardLimit), 10, 64)
+			if err != nil {
+				hardLimitComponent.Errors = append(hardLimitComponent.Errors, "Failed to parse /proc/sys/fs/pipe-user-pages-hard")
 			} else {
-				hardLimitComponent.Warnings = append(hardLimitComponent.Warnings, fmt.Sprintf("For optimal performance, `echo %d > /proc/sys/fs/pipe-user-pages-hard`", OPTIMAL_HARD_LIMIT))
-				hardLimitComponent.Data = string(hardLimit)
+				if hardLimitBytes == OPTIMAL_HARD_LIMIT {
+					hardLimitComponent.Data = "unlimited"
+				} else {
+					hardLimitComponent.Warnings = append(hardLimitComponent.Warnings, fmt.Sprintf("For optimal performance, `echo %d > /proc/sys/fs/pipe-user-pages-hard`", OPTIMAL_HARD_LIMIT))
+					hardLimitComponent.Data = utils.SizeStr(hardLimitBytes)
+				}
 			}
 		}
 
@@ -118,7 +128,7 @@ func CheckKernelSettings() types.Check {
 		if err != nil {
 			maxSizeComponent.Errors = append(maxSizeComponent.Errors, "Failed to read /proc/sys/fs/pipe-max-size")
 		} else {
-      maxSize = bytes.TrimSpace(maxSize)
+			maxSize = bytes.TrimSpace(maxSize)
 			maxSizeBytes, err := strconv.ParseInt(string(maxSize), 10, 64)
 			if err != nil {
 				maxSizeComponent.Errors = append(maxSizeComponent.Errors, "Failed to parse /proc/sys/fs/pipe-max-size")

--- a/internal/server/streamer/checks.go
+++ b/internal/server/streamer/checks.go
@@ -1,0 +1,71 @@
+package streamer
+
+// Health checks for streamer
+
+import (
+	"context"
+	"os/exec"
+
+	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/plugins"
+	"github.com/cedana/cedana/pkg/types"
+)
+
+func Checks(m plugins.Manager) types.Checks {
+	return types.Checks{
+		Name: "streamer",
+		List: []types.Check{
+			CheckVersion(m),
+			CheckCriu(m),
+		},
+	}
+}
+
+func CheckVersion(manager plugins.Manager) types.Check {
+	return func(ctx context.Context) []*daemon.HealthCheckComponent {
+		component := &daemon.HealthCheckComponent{Name: "version"}
+
+		// Check if CRIU plugin is installed, then use that binary
+		var p *plugins.Plugin
+		if p = manager.Get("streamer"); p.IsInstalled() {
+			component.Data = p.Version
+		} else {
+			component.Errors = append(component.Errors, "Streamer plugin is not installed. This is required for streaming C/R support.")
+			component.Data = "unknown"
+		}
+
+		return []*daemon.HealthCheckComponent{component}
+	}
+}
+
+func CheckCriu(manager plugins.Manager) types.Check {
+	return func(ctx context.Context) []*daemon.HealthCheckComponent {
+		component := &daemon.HealthCheckComponent{Name: "criu"}
+
+		// Check if CRIU plugin is installed
+		var p *plugins.Plugin
+		if p = manager.Get("criu"); p.IsInstalled() {
+			component.Data = "supported"
+		} else {
+			if custom_path := config.Global.CRIU.BinaryPath; custom_path != "" {
+				component.Errors = append(component.Warnings,
+					"CRIU plugin not installed but a custom CRIU path was provided. Streaming C/R requires the CRIU plugin.",
+				)
+				component.Data = "unsupported"
+			} else if _, err := exec.LookPath("criu"); err == nil {
+				component.Errors = append(component.Warnings,
+					"CRIU plugin not installed but CRIU binary found in PATH. Streaming C/R requires the CRIU plugin.",
+				)
+				component.Data = "unsupported"
+			} else {
+				component.Errors = append(component.Errors,
+					"CRIU plugin is not installed. This is required for userspace C/R support.",
+				)
+				component.Data = "missing"
+			}
+		}
+
+		return []*daemon.HealthCheckComponent{component}
+	}
+}

--- a/internal/server/streamer/checks.go
+++ b/internal/server/streamer/checks.go
@@ -3,13 +3,24 @@ package streamer
 // Health checks for streamer
 
 import (
+	"bytes"
 	"context"
+	"fmt"
+	"os"
 	"os/exec"
+	"strconv"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	"github.com/cedana/cedana/pkg/config"
 	"github.com/cedana/cedana/pkg/plugins"
 	"github.com/cedana/cedana/pkg/types"
+	"github.com/cedana/cedana/pkg/utils"
+)
+
+const (
+	OPTIMAL_SOFT_LIMIT = 0
+	OPTIMAL_HARD_LIMIT = 0
+	OPTIMAL_MAX_SIZE   = 4 * utils.MEBIBYTE
 )
 
 func Checks(m plugins.Manager) types.Checks {
@@ -18,6 +29,7 @@ func Checks(m plugins.Manager) types.Checks {
 		List: []types.Check{
 			CheckVersion(m),
 			CheckCriu(m),
+			CheckKernelSettings(),
 		},
 	}
 }
@@ -67,5 +79,57 @@ func CheckCriu(manager plugins.Manager) types.Check {
 		}
 
 		return []*daemon.HealthCheckComponent{component}
+	}
+}
+
+func CheckKernelSettings() types.Check {
+	return func(ctx context.Context) []*daemon.HealthCheckComponent {
+		softLimitComponent := &daemon.HealthCheckComponent{Name: "pipe pages soft limit"}
+		hardLimitComponent := &daemon.HealthCheckComponent{Name: "pipe pages hard limit"}
+		maxSizeComponent := &daemon.HealthCheckComponent{Name: "pipe max size"}
+
+		softLimit, err := os.ReadFile("/proc/sys/fs/pipe-user-pages-soft")
+		if err != nil {
+			softLimitComponent.Errors = append(softLimitComponent.Errors, "Failed to read /proc/sys/fs/pipe-user-pages-soft")
+		} else {
+			softLimit = bytes.TrimSpace(softLimit)
+			if string(softLimit) == fmt.Sprintf("%d", OPTIMAL_SOFT_LIMIT) {
+				softLimitComponent.Data = "unlimited"
+			} else {
+				softLimitComponent.Warnings = append(softLimitComponent.Warnings, fmt.Sprintf("For optimal performance, `echo %d > /proc/sys/fs/pipe-user-pages-soft`", OPTIMAL_SOFT_LIMIT))
+				softLimitComponent.Data = string(softLimit)
+			}
+		}
+
+		hardLimit, err := os.ReadFile("/proc/sys/fs/pipe-user-pages-hard")
+		if err != nil {
+			hardLimitComponent.Errors = append(hardLimitComponent.Errors, "Failed to read /proc/sys/fs/pipe-user-pages-hard")
+		} else {
+			hardLimit = bytes.TrimSpace(hardLimit)
+			if string(hardLimit) == fmt.Sprintf("%d", OPTIMAL_HARD_LIMIT) {
+				hardLimitComponent.Data = "unlimited"
+			} else {
+				hardLimitComponent.Warnings = append(hardLimitComponent.Warnings, fmt.Sprintf("For optimal performance, `echo %d > /proc/sys/fs/pipe-user-pages-hard`", OPTIMAL_HARD_LIMIT))
+				hardLimitComponent.Data = string(hardLimit)
+			}
+		}
+
+		maxSize, err := os.ReadFile("/proc/sys/fs/pipe-max-size")
+		if err != nil {
+			maxSizeComponent.Errors = append(maxSizeComponent.Errors, "Failed to read /proc/sys/fs/pipe-max-size")
+		} else {
+      maxSize = bytes.TrimSpace(maxSize)
+			maxSizeBytes, err := strconv.ParseInt(string(maxSize), 10, 64)
+			if err != nil {
+				maxSizeComponent.Errors = append(maxSizeComponent.Errors, "Failed to parse /proc/sys/fs/pipe-max-size")
+			} else {
+				maxSizeComponent.Data = utils.SizeStr(maxSizeBytes)
+				if maxSizeBytes < OPTIMAL_MAX_SIZE {
+					maxSizeComponent.Warnings = append(maxSizeComponent.Warnings, fmt.Sprintf("For optimal performance, `echo %d > /proc/sys/fs/pipe-max-size`", OPTIMAL_MAX_SIZE))
+				}
+			}
+		}
+
+		return []*daemon.HealthCheckComponent{softLimitComponent, hardLimitComponent, maxSizeComponent}
 	}
 }

--- a/internal/server/streamer/dump_adapters.go
+++ b/internal/server/streamer/dump_adapters.go
@@ -1,0 +1,133 @@
+package streamer
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
+	"github.com/cedana/cedana/internal/server/filesystem"
+	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/plugins"
+	"github.com/cedana/cedana/pkg/types"
+	"github.com/cedana/cedana/pkg/utils"
+	"github.com/rs/zerolog/log"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+// TODO: Handle compression in the daemon itself to ensure
+// parity with the normal filesystem dump adapter.
+var SUPPORTED_STREAMING_COMPRESSION = "lz4"
+
+// This adapter sets up the cedana-image-streamer for directly streaming
+// files to the dump directory.
+func PrepareDumpDir(next types.Dump) types.Dump {
+	return func(ctx context.Context, opts types.Opts, resp *daemon.DumpResp, req *daemon.DumpReq) (exited chan int, err error) {
+		compression := req.Compression
+		if compression == "" {
+			compression = config.Global.Checkpoint.Compression
+		}
+
+		// Check if compression is valid, because we don't want to fail after the dump
+		// as the process would be killed
+		if _, ok := utils.SUPPORTED_COMPRESSIONS[compression]; !ok {
+			return nil, status.Errorf(codes.Unimplemented, "unsupported compression format '%s'", compression)
+		}
+
+		// Check if compression is valid for streaming, because we don't want to fail after the dump
+		// as the process would be killed
+		// TODO: Remove this once compression for streaming is handled by daemon
+		if compression != SUPPORTED_STREAMING_COMPRESSION {
+			resp.Messages = append(resp.Messages,
+				fmt.Sprintf("'%s' is not supported for streaming C/R. Using %s instead.", compression, SUPPORTED_STREAMING_COMPRESSION),
+			)
+		}
+
+		dir := req.GetDir()
+
+		// Check if the provided dir exists
+		if _, err := os.Stat(dir); os.IsNotExist(err) {
+			return nil, status.Errorf(codes.InvalidArgument, "dump dir does not exist: %s", dir)
+		}
+
+		// Create a new directory within the dump dir, where dump will happen
+		imagesDirectory := filepath.Join(dir, req.Name)
+
+		// Create the directory
+		if err := os.Mkdir(imagesDirectory, filesystem.DUMP_DIR_PERMS); err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to create dump dir: %v", err)
+		}
+		defer func() {
+			if err != nil {
+				os.RemoveAll(imagesDirectory)
+			}
+		}()
+
+		f, err := os.Open(imagesDirectory)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to open dump dir: %v", err)
+		}
+		defer f.Close()
+
+		if req.GetCriu() == nil {
+			req.Criu = &criu_proto.CriuOpts{}
+		}
+
+		req.Criu.ImagesDir = proto.String(imagesDirectory)
+		req.Criu.ImagesDirFd = proto.Int32(int32(f.Fd()))
+		req.Criu.Stream = proto.Bool(true)
+
+		// Streamer also requires Cedana's CRIU version until the Stream proto option
+		// is merged into CRIU upstream.
+		if !opts.Plugins.IsInstalled("criu") {
+			return nil, status.Errorf(
+				codes.FailedPrecondition,
+				"Streaming C/R requires the CRIU plugin to be installed. Default CRIU is not supported yet.",
+			)
+		}
+
+		// Setup dump fs that can be used by future adapters to directly read write/extra files
+		// to the dump directory. Here, instead of OsFs we use the streamer's Fs implementation
+		// that handles all read/writes directly through streaming.
+		var imgStreamer *plugins.Plugin
+		if imgStreamer = opts.Plugins.Get("streamer"); !imgStreamer.IsInstalled() {
+			return nil, status.Errorf(
+				codes.FailedPrecondition,
+				"Please install the streamer plugin to use streaming C/R",
+			)
+		}
+		parallelism := req.Stream
+		if parallelism == 0 {
+			parallelism = config.Global.Checkpoint.Stream
+		}
+		opts.DumpFs, err = NewStreamingFs(ctx, opts.WG, imgStreamer.BinaryPaths()[0], imagesDirectory, parallelism, WRITE_ONLY)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to create streaming fs: %v", err)
+		}
+
+		exited, err = next(ctx, opts, resp, req)
+		if err != nil {
+			return nil, err
+		}
+
+		// If nothing was put in the directory, remove it and return early
+		entries, err := os.ReadDir(imagesDirectory)
+		if err != nil {
+			return exited, status.Errorf(codes.Internal, "failed to read dump dir: %v", err)
+		}
+		if len(entries) == 0 {
+			os.RemoveAll(imagesDirectory)
+			return exited, nil
+		}
+
+		resp.Path = imagesDirectory
+
+		log.Debug().Str("path", imagesDirectory).Str("compression", compression).Msg("stream dump completed")
+
+		return exited, nil
+	}
+}

--- a/internal/server/streamer/dump_adapters.go
+++ b/internal/server/streamer/dump_adapters.go
@@ -9,10 +9,10 @@ import (
 	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 	"github.com/cedana/cedana/internal/server/filesystem"
 	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/io"
 	"github.com/cedana/cedana/pkg/plugins"
 	"github.com/cedana/cedana/pkg/profiling"
 	"github.com/cedana/cedana/pkg/types"
-	"github.com/cedana/cedana/pkg/utils"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -30,7 +30,7 @@ func PrepareDumpDir(next types.Dump) types.Dump {
 
 		// Check if compression is valid, because we don't want to fail after the dump
 		// as the process would be killed
-		if _, ok := utils.SUPPORTED_COMPRESSIONS[compression]; !ok {
+		if _, ok := io.SUPPORTED_COMPRESSIONS[compression]; !ok {
 			return nil, status.Errorf(codes.Unimplemented, "unsupported compression format '%s'", compression)
 		}
 

--- a/internal/server/streamer/dump_adapters.go
+++ b/internal/server/streamer/dump_adapters.go
@@ -53,6 +53,10 @@ func PrepareDumpDir(next types.Dump) types.Dump {
 				os.RemoveAll(imagesDirectory)
 			}
 		}()
+		err = os.Chmod(imagesDirectory, filesystem.DUMP_DIR_PERMS) // XXX: Because for some reason mkdir is not applying perms
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to chmod dump dir: %v", err)
+		}
 
 		f, err := os.Open(imagesDirectory)
 		if err != nil {

--- a/internal/server/streamer/file.go
+++ b/internal/server/streamer/file.go
@@ -10,7 +10,7 @@ import (
 type File struct {
 	name string
 	mode Mode
-	fd   int
+	pipe int
 }
 
 func (f *File) Name() string {
@@ -21,32 +21,32 @@ func (f *File) Read(p []byte) (n int, err error) {
 	if f.mode != READ_ONLY {
 		return 0, fmt.Errorf("file is not open for reading")
 	}
-	return syscall.Read(f.fd, p)
+	return syscall.Read(f.pipe, p)
 }
 
 func (f *File) Write(p []byte) (n int, err error) {
 	if f.mode != WRITE_ONLY {
 		return 0, fmt.Errorf("file is not open for writing")
 	}
-	return syscall.Write(f.fd, p)
+	return syscall.Write(f.pipe, p)
 }
 
 func (f *File) Truncate(size int64) error {
 	if f.mode != WRITE_ONLY {
 		return fmt.Errorf("file is not open for writing")
 	}
-	return syscall.Ftruncate(f.fd, size)
+	return syscall.Ftruncate(f.pipe, size)
 }
 
 func (f *File) WriteString(s string) (ret int, err error) {
 	if f.mode != WRITE_ONLY {
 		return 0, fmt.Errorf("file is not open for writing")
 	}
-	return syscall.Write(f.fd, []byte(s))
+	return syscall.Write(f.pipe, []byte(s))
 }
 
 func (f *File) Close() (err error) {
-	return syscall.Close(f.fd)
+	return syscall.Close(f.pipe)
 }
 
 func (f *File) ReadAt(p []byte, off int64) (n int, err error) {

--- a/internal/server/streamer/file.go
+++ b/internal/server/streamer/file.go
@@ -4,9 +4,6 @@ import (
 	"fmt"
 	"os"
 	"syscall"
-
-	"github.com/rs/zerolog/log"
-	"github.com/spf13/afero"
 )
 
 // Implementation of the afero.File interface that uses streaming as the backend
@@ -14,7 +11,6 @@ type File struct {
 	name string
 	rFd  int // read file descriptor
 	wFd  int // write file descriptor
-	afero.File
 }
 
 func (f *File) Name() string {
@@ -22,10 +18,7 @@ func (f *File) Name() string {
 }
 
 func (f *File) Read(p []byte) (n int, err error) {
-  log.Warn().Msg("Read called")
-	n, err = syscall.Read(f.rFd, p)
-  log.Warn().Msgf("Read called: %d", n)
-  return
+	return syscall.Read(f.rFd, p)
 }
 
 func (f *File) Write(p []byte) (n int, err error) {

--- a/internal/server/streamer/file.go
+++ b/internal/server/streamer/file.go
@@ -1,0 +1,78 @@
+package streamer
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+
+	"github.com/rs/zerolog/log"
+	"github.com/spf13/afero"
+)
+
+// Implementation of the afero.File interface that uses streaming as the backend
+type File struct {
+	name string
+	rFd  int // read file descriptor
+	wFd  int // write file descriptor
+	afero.File
+}
+
+func (f *File) Name() string {
+	return f.name
+}
+
+func (f *File) Read(p []byte) (n int, err error) {
+  log.Warn().Msg("Read called")
+	n, err = syscall.Read(f.rFd, p)
+  log.Warn().Msgf("Read called: %d", n)
+  return
+}
+
+func (f *File) Write(p []byte) (n int, err error) {
+	return syscall.Write(f.wFd, p)
+}
+
+func (f *File) Truncate(size int64) error {
+	return syscall.Ftruncate(f.wFd, size)
+}
+
+func (f *File) WriteString(s string) (ret int, err error) {
+	return syscall.Write(f.wFd, []byte(s))
+}
+
+func (f *File) Close() (err error) {
+	err = syscall.Close(f.rFd)
+	if err != nil {
+		return
+	}
+	err = syscall.Close(f.wFd)
+	return
+}
+
+func (f *File) ReadAt(p []byte, off int64) (n int, err error) {
+	return 0, fmt.Errorf("not implemented for streaming")
+}
+
+func (f *File) Seek(offset int64, whence int) (int64, error) {
+	return 0, fmt.Errorf("not implemented for streaming")
+}
+
+func (f *File) WriteAt(p []byte, off int64) (n int, err error) {
+	return 0, fmt.Errorf("not implemented for streaming")
+}
+
+func (f *File) Readdir(count int) ([]os.FileInfo, error) {
+	return nil, fmt.Errorf("not implemented for streaming")
+}
+
+func (f *File) Readdirnames(n int) ([]string, error) {
+	return nil, fmt.Errorf("not implemented for streaming")
+}
+
+func (f *File) Stat() (os.FileInfo, error) {
+	return nil, fmt.Errorf("not implemented for streaming")
+}
+
+func (f *File) Sync() error {
+	return fmt.Errorf("not implemented for streaming")
+}

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -74,7 +74,7 @@ func NewStreamingFs(
 	var readFds, writeFds []*os.File
 	var shardFds []string
 	for i := range parallelism {
-		r, w, err := os.Pipe()
+    r, w, err := os.Pipe() // TODO: Increase pipe capacity
 		if err != nil {
 			return nil, nil, fmt.Errorf("failed to create pipe: %w", err)
 		}

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -28,6 +28,7 @@ const (
 	READ_ONLY Mode = iota
 	WRITE_ONLY
 )
+const DEFAULT_PARALLELISM = 2
 
 const (
 	CAPTURE_SOCK        = "streamer-capture.sock"

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -409,25 +409,3 @@ func imgPaths(dir string, mode Mode, parallelism int32) ([]string, error) {
 		return nil, fmt.Errorf("invalid mode: %d", mode)
 	}
 }
-
-func (fs *Fs) stopListener() error {
-	// Send file request to streamer
-	req := &img_streamer.ImgStreamerRequestEntry{Filename: STOP_LISTENER_MSG}
-	data, err := proto.Marshal(req)
-	if err != nil {
-		return fmt.Errorf("failed to marshal request: %w", err)
-	}
-	size := len(data)
-	sizeBuf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(sizeBuf, uint32(size))
-	_, err = fs.conn.Write(sizeBuf)
-	if err != nil {
-		return fmt.Errorf("failed to write size to file request: %w", err)
-	}
-	_, err = fs.conn.Write(data)
-	if err != nil {
-		return fmt.Errorf("failed to write data to file request: %w", err)
-	}
-
-	return nil
-}

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"os/signal"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -127,7 +128,7 @@ func NewStreamingFs(
 		return nil, nil, fmt.Errorf("invalid mode: %d", mode)
 	}
 
-	cmd := exec.CommandContext(context.WithoutCancel(ctx), streamerBinary, args...)
+	cmd := exec.CommandContext(ctx, streamerBinary, args...)
 	cmd.ExtraFiles = extraFiles
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGTERM,
@@ -207,11 +208,15 @@ func NewStreamingFs(
 	fs.conn = conn.(*net.UnixConn)
 	log.Debug().Str("dir", dir).Msg("streamer connected")
 
+	signal.Ignored(syscall.SIGPIPE) // Avoid program termination due to broken pipe
+
 	wait = func() error {
 		// Stop the listener, and wait for all IO to finish
+		// NOTE: The order of below operations is important.
 		fs.stopListener()
 		fs.conn.Close()
 		io.Wait()
+		signal.Reset(syscall.SIGPIPE) // Reset to default behavior
 		close(ioErr)
 		return <-ioErr
 	}
@@ -220,20 +225,22 @@ func NewStreamingFs(
 }
 
 func (fs *Fs) Create(name string) (afero.File, error) {
-	rFd, wFd, err := fs.openFds(name)
+	if fs.mode != WRITE_ONLY {
+		return nil, fmt.Errorf("create failed: streaming filesystem not open for writing")
+	}
+	fd, err := fs.openFd(name)
 	if err != nil {
 		return nil, err
 	}
-	return &File{name: name, rFd: rFd, wFd: wFd}, nil
+	return &File{name, fs.mode, fd}, nil
 }
 
 func (fs *Fs) Open(name string) (afero.File, error) {
-	rFd, wFd, err := fs.openFds(name)
+	fd, err := fs.openFd(name)
 	if err != nil {
 		return nil, err
 	}
-
-	return &File{name: name, rFd: rFd, wFd: wFd}, nil
+	return &File{name, fs.mode, fd}, nil
 }
 
 func (fs *Fs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
@@ -277,51 +284,86 @@ func (fs *Fs) Chtimes(name string, atime, mtime time.Time) error {
 ////////////////////
 
 // Opens a pair of file descriptors for reading and writing through the streamer
-func (fs *Fs) openFds(name string) (int, int, error) {
+func (fs *Fs) openFd(name string) (int, error) {
 	fds := make([]int, 2)
 	err := syscall.Pipe(fds)
 	if err != nil {
-		return 0, 0, err
+		return 0, err
 	}
 	rFd, wFd := fds[0], fds[1]
 
-	var streamerFd int
+	var streamerFd, ourFd int
 
 	switch fs.mode {
 	case READ_ONLY:
 		streamerFd = wFd // streamer should be able to write to this fd
+		ourFd = rFd      // we should be able to read from this fd
 	case WRITE_ONLY:
 		streamerFd = rFd // streamer should be able to read from this fd
+		ourFd = wFd      // we should be able to write to this fd
 	default:
-		return 0, 0, fmt.Errorf("invalid mode: %d", fs.mode)
+		return 0, fmt.Errorf("invalid mode: %d", fs.mode)
 	}
+	defer syscall.Close(streamerFd) // close it after sending it to streamer
+	defer func() {
+		if err != nil {
+			syscall.Close(ourFd)
+		}
+	}()
 
 	// Send file request to streamer
 	req := &img_streamer.ImgStreamerRequestEntry{Filename: name}
 	data, err := proto.Marshal(req)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to marshal request: %w", err)
+		return 0, fmt.Errorf("failed to marshal request: %w", err)
 	}
 	size := len(data)
-	sizeBuf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(sizeBuf, uint32(size))
-	_, err = fs.conn.Write(sizeBuf)
+	var sizeBuf [4]byte
+	binary.LittleEndian.PutUint32(sizeBuf[:], uint32(size))
+	_, err = fs.conn.Write(sizeBuf[:])
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to write size to file request: %w", err)
+		return 0, fmt.Errorf("failed to write size to file request: %w", err)
 	}
 	_, err = fs.conn.Write(data)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to write data to file request: %w", err)
+		return 0, fmt.Errorf("failed to write data to file request: %w", err)
 	}
+
+	// If read-only, read for msg from streamer if file exists
+	if fs.mode == READ_ONLY {
+		resp := &img_streamer.ImgStreamerReplyEntry{}
+		var sizeBuf [4]byte
+		_, err = fs.conn.Read(sizeBuf[:])
+		if err != nil {
+			return 0, fmt.Errorf("failed to read size from file response: %w", err)
+		}
+		size := binary.LittleEndian.Uint32(sizeBuf[:])
+		data := make([]byte, size)
+		n, err := fs.conn.Read(data)
+		if err != nil {
+			return 0, fmt.Errorf("failed to read data from file response: %w", err)
+		}
+		if n != int(size) {
+			return 0, fmt.Errorf("failed to read data from file response: expected %d bytes, got %d", size, n)
+		}
+		err = proto.Unmarshal(data, resp)
+		if err != nil {
+			return 0, fmt.Errorf("failed to unmarshal response: %w", err)
+		}
+		if !resp.Exists {
+			return 0, fmt.Errorf("file does not exist: %s", name)
+		}
+	}
+
 	sock, err := fs.conn.File()
 	defer sock.Close()
 	rights := syscall.UnixRights(streamerFd)
 	err = syscall.Sendmsg(int(sock.Fd()), nil, rights, nil, 0)
 	if err != nil {
-		return 0, 0, fmt.Errorf("failed to send streamer fd: %w", err)
+		return 0, fmt.Errorf("failed to send streamer fd: %w", err)
 	}
 
-	return rFd, wFd, nil
+	return ourFd, nil
 }
 
 // Tells the streamer to stop listening for new connections
@@ -333,13 +375,10 @@ func (fs *Fs) stopListener() error {
 		return fmt.Errorf("failed to marshal request: %w", err)
 	}
 	size := len(data)
-	sizeBuf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(sizeBuf, uint32(size))
-	_, err = fs.conn.Write(sizeBuf)
-	if err != nil {
-		return fmt.Errorf("failed to write size to file request: %w", err)
-	}
-	_, err = fs.conn.Write(data)
+	buf := make([]byte, 4+size)
+	binary.LittleEndian.PutUint32(buf, uint32(size))
+	copy(buf[4:], data)
+	_, err = fs.conn.Write(buf)
 	if err != nil {
 		return fmt.Errorf("failed to write data to file request: %w", err)
 	}

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -55,7 +55,7 @@ type Fs struct {
 // For READ_ONLY mode, compression is automatically determined.
 // For WRITE_ONLY mode, compression may be specified.
 // Returns a wait function that *must* be called to tell the streamer to shutdown,
-// and wait for it to finish streaming and exit gracefully. This function returns
+// and wait for it to finish streaming and exit gracefully. The wait function returns
 // any IO errors that occurred during the streaming process.
 func NewStreamingFs(
 	ctx context.Context,
@@ -103,6 +103,7 @@ func NewStreamingFs(
 			go func() {
 				defer io.Done()
 				_, err := utils.ReadFrom(paths[i], writeFds[i])
+        writeFds[i].Close()
 				if err != nil {
 					ioErr <- err
 				}
@@ -112,6 +113,7 @@ func NewStreamingFs(
 			go func() {
 				defer io.Done()
 				_, err := utils.WriteTo(readFds[i], paths[i], compression)
+        readFds[i].Close()
 				if err != nil {
 					ioErr <- err
 				}

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -40,7 +40,6 @@ const (
 	IMG_FILE_FORMATTER  = "img-%d"
 	CONNECTION_TIMEOUT  = 30 * time.Second
 	DEFAULT_PARALLELISM = 4
-	MAX_PARALLELISM     = 32
 	PIPE_SIZE           = 4 * utils.MEBIBYTE
 )
 
@@ -103,7 +102,7 @@ func NewStreamingFs(
 			go func() {
 				defer io.Done()
 				_, err := utils.ReadFrom(paths[i], writeFds[i])
-        writeFds[i].Close()
+				writeFds[i].Close()
 				if err != nil {
 					ioErr <- err
 				}
@@ -113,7 +112,7 @@ func NewStreamingFs(
 			go func() {
 				defer io.Done()
 				_, err := utils.WriteTo(readFds[i], paths[i], compression)
-        readFds[i].Close()
+				readFds[i].Close()
 				if err != nil {
 					ioErr <- err
 				}

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -28,7 +28,6 @@ const (
 	READ_ONLY Mode = iota
 	WRITE_ONLY
 )
-const DEFAULT_PARALLELISM = 2
 
 const (
 	CAPTURE_SOCK        = "streamer-capture.sock"
@@ -409,4 +408,26 @@ func imgPaths(dir string, mode Mode, parallelism int32) ([]string, error) {
 	default:
 		return nil, fmt.Errorf("invalid mode: %d", mode)
 	}
+}
+
+func (fs *Fs) stopListener() error {
+	// Send file request to streamer
+	req := &img_streamer.ImgStreamerRequestEntry{Filename: STOP_LISTENER_MSG}
+	data, err := proto.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	size := len(data)
+	sizeBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBuf, uint32(size))
+	_, err = fs.conn.Write(sizeBuf)
+	if err != nil {
+		return fmt.Errorf("failed to write size to file request: %w", err)
+	}
+	_, err = fs.conn.Write(data)
+	if err != nil {
+		return fmt.Errorf("failed to write data to file request: %w", err)
+	}
+
+	return nil
 }

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -9,14 +9,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
+	"strings"
 	"sync"
 	"syscall"
 	"time"
 
 	"buf.build/gen/go/cedana/cedana-image-streamer/protocolbuffers/go/img_streamer"
-	"github.com/cedana/cedana/pkg/logging"
-	"github.com/rs/zerolog"
+	"github.com/cedana/cedana/pkg/utils"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"google.golang.org/protobuf/proto"
@@ -28,11 +27,15 @@ const (
 	READ_ONLY Mode = iota
 	WRITE_ONLY
 )
-const DEFAULT_PARALLELISM = 2
 
 const (
-	CAPTURE_SOCK = "ced-capture.sock"
-	SERVE_SOCK   = "ced-serve.sock"
+	CAPTURE_SOCK        = "streamer-capture.sock"
+	SERVE_SOCK          = "streamer-serve.sock"
+	INIT_PROGRESS_MSG   = "socket-init"
+	STOP_LISTENER_MSG   = "stop-listener"
+	IMG_FILE_FORMATTER  = "img-%d"
+	CONNECTION_TIMEOUT  = 5 * time.Second
+	DEFAULT_PARALLELISM = 2
 )
 
 // Implementation of the afero.Fs filesystem interface that uses streaming as the backend
@@ -43,71 +46,132 @@ type Fs struct {
 	afero.Fs
 }
 
-func NewStreamingFs(ctx context.Context, wg *sync.WaitGroup, streamerBinary string, dir string, parallelism int32, mode Mode) (*Fs, error) {
-	// Start the image streamer based on the provided mode
-
+// For READ_ONLY mode, compression is automatically determined.
+// For WRITE_ONLY mode, compression may be specified.
+// Returns a wait function that *must* be called to tell the streamer to shutdown,
+// and wait for it to finish streaming and exit gracefully. This function returns
+// any IO errors that occurred during the streaming process.
+func NewStreamingFs(
+	ctx context.Context,
+	wg *sync.WaitGroup,
+	streamerBinary string,
+	dir string,
+	parallelism int32,
+	mode Mode,
+	compressions ...string,
+) (fs *Fs, wait func() error, err error) {
 	if parallelism < 1 {
 		parallelism = DEFAULT_PARALLELISM
 	}
+	var compression string
+	if len(compressions) > 0 {
+		compression = compressions[0]
+	}
 
-	args := []string{"--dir", dir, "--num-pipes", strconv.Itoa(int(parallelism))}
+	// Create pipes for reading and writing data
+	var readFds, writeFds []*os.File
+	var shardFds []string
+	for i := range parallelism {
+		r, w, err := os.Pipe()
+		if err != nil {
+			return nil, nil, fmt.Errorf("failed to create pipe: %w", err)
+		}
+		readFds = append(readFds, r)
+		writeFds = append(writeFds, w)
+		shardFds = append(shardFds, fmt.Sprintf("%d", 3+i))
+	}
+
+	io := &sync.WaitGroup{}
+	ioErr := make(chan error, 1)
+	for i := range parallelism {
+		path := filepath.Join(dir, fmt.Sprintf(IMG_FILE_FORMATTER, i))
+		io.Add(1)
+		switch mode {
+		case READ_ONLY:
+			defer readFds[i].Close()
+			go func() {
+				defer io.Done()
+				err := utils.ReadFile(path, writeFds[i])
+				if err != nil {
+					ioErr <- err
+				}
+			}()
+		case WRITE_ONLY:
+			defer writeFds[i].Close()
+			go func() {
+				defer io.Done()
+				err := utils.WriteFile(path, readFds[i], compression)
+				if err != nil {
+					ioErr <- err
+				}
+			}()
+		}
+	}
+
+	args := []string{"--images-dir", dir}
+	var extraFiles []*os.File
 
 	switch mode {
 	case READ_ONLY:
-		args = append(args, "serve")
+		args = append(args, "--shard-fds", strings.Join(shardFds, ","), "serve")
+		extraFiles = readFds
 	case WRITE_ONLY:
-		args = append(args, "capture")
+		args = append(args, "--shard-fds", strings.Join(shardFds, ","), "capture")
+		extraFiles = writeFds
 	default:
-		return nil, fmt.Errorf("invalid mode: %d", mode)
+		return nil, nil, fmt.Errorf("invalid mode: %d", mode)
 	}
 
-	logger := logging.Writer("streamer", dir, zerolog.TraceLevel)
-
-	cmd := exec.CommandContext(ctx, streamerBinary, args...)
-	cmd.Stdout = logger
+	cmd := exec.CommandContext(context.WithoutCancel(ctx), streamerBinary, args...)
+	cmd.ExtraFiles = extraFiles
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGTERM,
 	}
 	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) } // AVOID SIGKILL
 	stderrPipe, err := cmd.StderrPipe()
 	if err != nil {
-		return nil, fmt.Errorf("failed to get stderr pipe: %w", err)
+		return nil, nil, fmt.Errorf("failed to get stderr pipe: %w", err)
 	}
 
 	ready := make(chan bool, 1)
+	defer close(ready)
 
-	// Wait on stderr for readiness
+	// Mark ready when we read init progress message on stderr
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		defer close(ready)
-
-		bufio.NewReader(stderrPipe).ReadString('\n') // just wait for the first line/err
+		scanner := bufio.NewScanner(stderrPipe)
+		for {
+			if !scanner.Scan() || ctx.Err() != nil {
+				break
+			}
+			if scanner.Text() == INIT_PROGRESS_MSG {
+				ready <- true
+			}
+			log.Trace().Str("context", "streamer").Str("dir", dir).Msg(scanner.Text())
+		}
 	}()
-
-	// embed OS FS, so methods we don't override are still available as normal FS operations in the dir
-	fs := &Fs{mode, nil, afero.NewBasePathFs(afero.NewOsFs(), dir)}
 
 	err = cmd.Start()
 	if err != nil {
-		return nil, fmt.Errorf("failed to start streamer: %w", err)
+		return nil, nil, fmt.Errorf("failed to start streamer: %w", err)
 	}
+
+	// embed OS FS, so methods we don't override are still available as normal FS operations in the dir
+	fs = &Fs{mode, nil, afero.NewBasePathFs(afero.NewOsFs(), dir)}
 
 	// Clean up on exit
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		if fs.conn != nil {
-			defer fs.conn.Close()
-		}
 
 		err := cmd.Wait()
 		if err != nil {
 			log.Trace().Err(err).Msg("streamer Wait()")
 		}
-		log.Debug().Int("code", cmd.ProcessState.ExitCode()).Msg("streamer exited")
+		log.Trace().Int("code", cmd.ProcessState.ExitCode()).Msg("streamer exited")
 
-		// FIXME: Remove socket files. Should be cleaned up by the streamer itself (?)
+		// FIXME: Remove socket files. Should be cleaned up by the streamer itself
 		matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))
 		if err == nil {
 			for _, match := range matches {
@@ -116,7 +180,13 @@ func NewStreamingFs(ctx context.Context, wg *sync.WaitGroup, streamerBinary stri
 		}
 	}()
 
-	<-ready
+	select {
+	case <-ctx.Done():
+		return nil, nil, ctx.Err()
+	case <-time.After(CONNECTION_TIMEOUT):
+		return nil, nil, fmt.Errorf("connection timed out after %s", CONNECTION_TIMEOUT)
+	case <-ready:
+	}
 
 	// Connect to the streamer
 	var conn net.Conn
@@ -127,12 +197,21 @@ func NewStreamingFs(ctx context.Context, wg *sync.WaitGroup, streamerBinary stri
 		conn, err = net.Dial("unix", filepath.Join(dir, CAPTURE_SOCK))
 	}
 	if err != nil {
-		return nil, fmt.Errorf("failed to connect to streamer: %w", err)
+		return nil, nil, fmt.Errorf("failed to connect to streamer: %w", err)
+	}
+	fs.conn = conn.(*net.UnixConn)
+	log.Debug().Str("dir", dir).Msg("streamer connected")
+
+	wait = func() error {
+		// Stop the listener, and wait for all IO to finish
+		fs.stopListener()
+		fs.conn.Close()
+		io.Wait()
+		close(ioErr)
+		return <-ioErr
 	}
 
-	fs.conn = conn.(*net.UnixConn)
-
-	return fs, nil
+	return fs, wait, nil
 }
 
 func (fs *Fs) Create(name string) (afero.File, error) {
@@ -237,4 +316,26 @@ func (fs *Fs) openFds(name string) (int, int, error) {
 	}
 
 	return rFd, wFd, nil
+}
+
+func (fs *Fs) stopListener() error {
+	// Send file request to streamer
+	req := &img_streamer.ImgStreamerRequestEntry{Filename: STOP_LISTENER_MSG}
+	data, err := proto.Marshal(req)
+	if err != nil {
+		return fmt.Errorf("failed to marshal request: %w", err)
+	}
+	size := len(data)
+	sizeBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBuf, uint32(size))
+	_, err = fs.conn.Write(sizeBuf)
+	if err != nil {
+		return fmt.Errorf("failed to write size to file request: %w", err)
+	}
+	_, err = fs.conn.Write(data)
+	if err != nil {
+		return fmt.Errorf("failed to write data to file request: %w", err)
+	}
+
+	return nil
 }

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -91,7 +91,7 @@ func NewStreamingFs(
 			defer readFds[i].Close()
 			go func() {
 				defer io.Done()
-				err := utils.ReadFile(path, writeFds[i])
+				err := utils.ReadFrom(path, writeFds[i])
 				if err != nil {
 					ioErr <- err
 				}
@@ -100,7 +100,7 @@ func NewStreamingFs(
 			defer writeFds[i].Close()
 			go func() {
 				defer io.Done()
-				err := utils.WriteFile(path, readFds[i], compression)
+				err := utils.WriteTo(readFds[i], path, compression)
 				if err != nil {
 					ioErr <- err
 				}

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -68,7 +68,7 @@ func NewStreamingFs(
 		compression = compressions[0]
 	}
 
-	// Create pipes for reading and writing data
+	// Create pipes for reading and writing data to/from the streamer to dir
 	var readFds, writeFds []*os.File
 	var shardFds []string
 	for i := range parallelism {
@@ -81,6 +81,7 @@ func NewStreamingFs(
 		shardFds = append(shardFds, fmt.Sprintf("%d", 3+i))
 	}
 
+  // Start IO on the pipes from the dir
 	io := &sync.WaitGroup{}
 	ioErr := make(chan error, 1)
 	for i := range parallelism {

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -1,20 +1,25 @@
 package streamer
 
-// Implementation of the afero.Fs interface that streams read/write operations
-// using the cedana-image-streamer.
-
 import (
+	"bufio"
 	"context"
+	"encoding/binary"
 	"fmt"
+	"net"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
+	"sync"
 	"syscall"
 	"time"
 
+	"buf.build/gen/go/cedana/cedana-image-streamer/protocolbuffers/go/img_streamer"
 	"github.com/cedana/cedana/pkg/logging"
 	"github.com/rs/zerolog"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
+	"google.golang.org/protobuf/proto"
 )
 
 type Mode int
@@ -23,55 +28,213 @@ const (
 	READ_ONLY Mode = iota
 	WRITE_ONLY
 )
+const DEFAULT_PARALLELISM = 2
 
-const DEFAULT_NUM_PIPES = 4
+const (
+	CAPTURE_SOCK = "ced-capture.sock"
+	SERVE_SOCK   = "ced-serve.sock"
+)
 
-type StreamerFs struct {
-	mode  Mode
-	ready chan any
+// Implementation of the afero.Fs filesystem interface that uses streaming as the backend
+// using the streamer plugin.
+type Fs struct {
+	mode Mode
+	conn *net.UnixConn
 	afero.Fs
 }
 
-func NewStreamerFs(ctx context.Context, streamerBinary string, dir string, mode Mode) (*StreamerFs, error) {
+func NewStreamingFs(ctx context.Context, wg *sync.WaitGroup, streamerBinary string, dir string, parallelism int32, mode Mode) (*Fs, error) {
 	// Start the image streamer based on the provided mode
 
-	args := []string{"--dir", dir, "--num-pipes", strconv.Itoa(DEFAULT_NUM_PIPES)}
+	if parallelism < 1 {
+		parallelism = DEFAULT_PARALLELISM
+	}
+
+	args := []string{"--dir", dir, "--num-pipes", strconv.Itoa(int(parallelism))}
 
 	switch mode {
 	case READ_ONLY:
 		args = append(args, "serve")
 	case WRITE_ONLY:
 		args = append(args, "capture")
+	default:
+		return nil, fmt.Errorf("invalid mode: %d", mode)
 	}
 
 	logger := logging.Writer("streamer", dir, zerolog.TraceLevel)
 
 	cmd := exec.CommandContext(ctx, streamerBinary, args...)
 	cmd.Stdout = logger
-	cmd.Stderr = logger
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig: syscall.SIGTERM,
 	}
 	cmd.Cancel = func() error { return cmd.Process.Signal(syscall.SIGTERM) } // AVOID SIGKILL
+	stderrPipe, err := cmd.StderrPipe()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get stderr pipe: %w", err)
+	}
 
-	err := cmd.Start()
+	ready := make(chan bool, 1)
+
+	// Wait on stderr for readiness
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		defer close(ready)
+
+		bufio.NewReader(stderrPipe).ReadString('\n') // just wait for the first line/err
+	}()
+
+	// embed OS FS, so methods we don't override are still available as normal FS operations in the dir
+	fs := &Fs{mode, nil, afero.NewBasePathFs(afero.NewOsFs(), dir)}
+
+	err = cmd.Start()
 	if err != nil {
 		return nil, fmt.Errorf("failed to start streamer: %w", err)
 	}
 
-	// Clean up once it exits
+	// Clean up on exit
+	wg.Add(1)
 	go func() {
+		defer wg.Done()
+		if fs.conn != nil {
+			defer fs.conn.Close()
+		}
+
 		err := cmd.Wait()
 		if err != nil {
 			log.Trace().Err(err).Msg("streamer Wait()")
 		}
 		log.Debug().Int("code", cmd.ProcessState.ExitCode()).Msg("streamer exited")
+
+		// FIXME: Remove socket files. Should be cleaned up by the streamer itself (?)
+		matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))
+		if err == nil {
+			for _, match := range matches {
+				os.Remove(match)
+			}
+		}
 	}()
 
-	ready := make(chan any, 1)
-	defer close(ready)
+	<-ready
 
-	time.Sleep(1 * time.Second) // TODO: use better synchronization
+	// Connect to the streamer
+	var conn net.Conn
+	switch mode {
+	case READ_ONLY:
+		conn, err = net.Dial("unix", filepath.Join(dir, SERVE_SOCK))
+	case WRITE_ONLY:
+		conn, err = net.Dial("unix", filepath.Join(dir, CAPTURE_SOCK))
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to streamer: %w", err)
+	}
 
-	return &StreamerFs{mode: mode, Fs: afero.NewBasePathFs(afero.NewOsFs(), dir), ready: ready}, nil
+	fs.conn = conn.(*net.UnixConn)
+
+	return fs, nil
+}
+
+func (fs *Fs) Create(name string) (afero.File, error) {
+	rFd, wFd, err := fs.openFds(name)
+	if err != nil {
+		return nil, err
+	}
+	return &File{name: name, rFd: rFd, wFd: wFd}, nil
+}
+
+func (fs *Fs) Open(name string) (afero.File, error) {
+	rFd, wFd, err := fs.openFds(name)
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{name: name, rFd: rFd, wFd: wFd}, nil
+}
+
+func (fs *Fs) OpenFile(name string, flag int, perm os.FileMode) (afero.File, error) {
+	return nil, fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) Remove(name string) error {
+	return fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) RemoveAll(path string) error {
+	return fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) Rename(oldname, newname string) error {
+	return fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) Mkdir(name string, perm os.FileMode) error {
+	return fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) MkdirAll(path string, perm os.FileMode) error {
+	return fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) Stat(name string) (os.FileInfo, error) {
+	return nil, fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) Chown(name string, uid, gid int) error {
+	return fmt.Errorf("not implemented for streaming")
+}
+
+func (fs *Fs) Chtimes(name string, atime, mtime time.Time) error {
+	return fmt.Errorf("not implemented for streaming")
+}
+
+////////////////////
+// Helper Methods //
+////////////////////
+
+func (fs *Fs) openFds(name string) (int, int, error) {
+	fds := make([]int, 2)
+	err := syscall.Pipe(fds)
+	if err != nil {
+		return 0, 0, err
+	}
+	rFd, wFd := fds[0], fds[1]
+
+	var streamerFd int
+
+	switch fs.mode {
+	case READ_ONLY:
+		streamerFd = wFd // streamer should be able to write to this fd
+	case WRITE_ONLY:
+		streamerFd = rFd // streamer should be able to read from this fd
+	default:
+		return 0, 0, fmt.Errorf("invalid mode: %d", fs.mode)
+	}
+
+	// Send file request to streamer
+	req := &img_streamer.ImgStreamerRequestEntry{Filename: name}
+	data, err := proto.Marshal(req)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to marshal request: %w", err)
+	}
+	size := len(data)
+	sizeBuf := make([]byte, 4)
+	binary.LittleEndian.PutUint32(sizeBuf, uint32(size))
+	_, err = fs.conn.Write(sizeBuf)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to write size to file request: %w", err)
+	}
+	_, err = fs.conn.Write(data)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to write data to file request: %w", err)
+	}
+	sock, err := fs.conn.File()
+	defer sock.Close()
+	rights := syscall.UnixRights(streamerFd)
+	err = syscall.Sendmsg(int(sock.Fd()), nil, rights, nil, 0)
+	if err != nil {
+		return 0, 0, fmt.Errorf("failed to send streamer fd: %w", err)
+	}
+
+	return rFd, wFd, nil
 }

--- a/internal/server/streamer/restore_adapters.go
+++ b/internal/server/streamer/restore_adapters.go
@@ -1,0 +1,82 @@
+package streamer
+
+import (
+	"context"
+	"os"
+
+	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
+	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/plugins"
+	"github.com/cedana/cedana/pkg/types"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
+)
+
+func PrepareDumpDirForRestore(next types.Restore) types.Restore {
+	return func(ctx context.Context, opts types.Opts, resp *daemon.RestoreResp, req *daemon.RestoreReq) (exited chan int, err error) {
+		path := req.GetPath()
+		stat, err := os.Stat(path)
+		if err != nil {
+			return nil, status.Errorf(codes.NotFound, "path error: %s", path)
+		}
+
+		var dir *os.File
+		var imagesDirectory string
+
+		if !stat.IsDir() {
+			return nil, status.Errorf(codes.InvalidArgument, "path must be a directory container streamed images")
+		}
+
+		imagesDirectory = path
+
+		// Streamer also requires Cedana's CRIU version until the Stream proto option
+		// is merged into CRIU upstream.
+		if !opts.Plugins.IsInstalled("criu") {
+			return nil, status.Errorf(
+				codes.FailedPrecondition,
+				"Streaming C/R requires the CRIU plugin to be installed. Default CRIU is not supported yet.",
+			)
+		}
+
+		dir, err = os.Open(imagesDirectory)
+		if err != nil {
+			os.RemoveAll(imagesDirectory)
+			return nil, status.Errorf(codes.Internal, "failed to open dump dir: %v", err)
+		}
+		defer dir.Close()
+
+		if req.GetCriu() == nil {
+			req.Criu = &criu_proto.CriuOpts{}
+		}
+
+		req.Criu.ImagesDir = proto.String(imagesDirectory)
+		req.Criu.ImagesDirFd = proto.Int32(int32(dir.Fd()))
+		req.Criu.Stream = proto.Bool(true)
+
+		// Setup dump fs that can be used by future adapters to directly read write/extra files
+		// to the dump directory. Here, instead of OsFs we use the streamer's Fs implementation
+		// that handles all read/writes directly through streaming.
+		var imgStreamer *plugins.Plugin
+		if imgStreamer = opts.Plugins.Get("streamer"); !imgStreamer.IsInstalled() {
+			return nil, status.Errorf(
+				codes.FailedPrecondition,
+				"Please install the streamer plugin to use streaming C/R",
+			)
+		}
+
+		// Setup dump fs that can be used by future adapters to directly write extra files
+		// to the dump directory
+		parallelism := req.Stream
+		if parallelism == 0 {
+			parallelism = config.Global.Checkpoint.Stream
+		}
+		opts.DumpFs, err = NewStreamingFs(ctx, opts.WG, imgStreamer.BinaryPaths()[0], imagesDirectory, parallelism, READ_ONLY)
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to create streaming fs: %v", err)
+		}
+
+		return next(ctx, opts, resp, req)
+	}
+}

--- a/internal/server/validation/dump_adapters.go
+++ b/internal/server/validation/dump_adapters.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
-	"github.com/cedana/cedana/internal/server/streamer"
 	"github.com/cedana/cedana/pkg/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -21,9 +20,6 @@ func ValidateDumpRequest(next types.Dump) types.Dump {
 		}
 		if req.GetType() == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "missing type")
-		}
-		if req.GetStream() < 0 || req.GetStream() > streamer.MAX_PARALLELISM {
-			return nil, status.Errorf(codes.InvalidArgument, "stream parallelism must be between 0 and %d", streamer.MAX_PARALLELISM)
 		}
 
 		return next(ctx, opts, resp, req)

--- a/internal/server/validation/dump_adapters.go
+++ b/internal/server/validation/dump_adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/internal/server/streamer"
 	"github.com/cedana/cedana/pkg/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -20,6 +21,9 @@ func ValidateDumpRequest(next types.Dump) types.Dump {
 		}
 		if req.GetType() == "" {
 			return nil, status.Errorf(codes.InvalidArgument, "missing type")
+		}
+		if req.GetStream() < 0 || req.GetStream() > streamer.MAX_PARALLELISM {
+			return nil, status.Errorf(codes.InvalidArgument, "stream parallelism must be between 0 and %d", streamer.MAX_PARALLELISM)
 		}
 
 		return next(ctx, opts, resp, req)

--- a/internal/server/validation/restore_adapters.go
+++ b/internal/server/validation/restore_adapters.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
-	"github.com/cedana/cedana/internal/server/streamer"
 	"github.com/cedana/cedana/pkg/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -18,9 +17,6 @@ func ValidateRestoreRequest(next types.Restore) types.Restore {
 		}
 		if req.GetType() == "" {
 			return nil, status.Error(codes.InvalidArgument, "missing type")
-		}
-		if req.GetStream() < 0 || req.GetStream() > streamer.MAX_PARALLELISM {
-			return nil, status.Errorf(codes.InvalidArgument, "stream parallelism must be between 0 and %d", streamer.MAX_PARALLELISM)
 		}
 
 		return next(ctx, opts, resp, req)

--- a/internal/server/validation/restore_adapters.go
+++ b/internal/server/validation/restore_adapters.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/internal/server/streamer"
 	"github.com/cedana/cedana/pkg/types"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,6 +18,9 @@ func ValidateRestoreRequest(next types.Restore) types.Restore {
 		}
 		if req.GetType() == "" {
 			return nil, status.Error(codes.InvalidArgument, "missing type")
+		}
+		if req.GetStream() < 0 || req.GetStream() > streamer.MAX_PARALLELISM {
+			return nil, status.Errorf(codes.InvalidArgument, "stream parallelism must be between 0 and %d", streamer.MAX_PARALLELISM)
 		}
 
 		return next(ctx, opts, resp, req)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -78,7 +78,7 @@ var Global Config = Config{
 func init() {
 	setDefaults()
 	bindEnvVars()
-	viper.UnmarshalExact(&Global)
+	viper.Unmarshal(&Global)
 }
 
 type InitArgs struct {
@@ -149,12 +149,12 @@ func Init(args InitArgs) error {
 
 // Loads the global defaults into viper
 func setDefaults() {
-	viper.SetTypeByDefaultValue(true)
 	for _, field := range utils.ListLeaves(Config{}) {
 		tag := utils.GetTag(Config{}, field, FILE_TYPE)
 		defaultVal := utils.GetValue(Global, field)
 		viper.SetDefault(tag, defaultVal)
 	}
+	viper.SetTypeByDefaultValue(true)
 }
 
 // Add bindings for env vars so env vars can be used as backup

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -72,9 +72,6 @@ var Global Config = Config{
 	Plugins: Plugins{
 		LibDir: DEFAULT_PLUGINS_LIB_DIR,
 		BinDir: DEFAULT_PLUGINS_BIN_DIR,
-		GPU: GPU{
-			PoolSize: 0,
-		},
 	},
 }
 

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -25,10 +25,12 @@ type (
 		Profiling Profiling `json:"profiling" key:"profiling" yaml:"profiling" mapstructure:"profiling"`
 		// Metrics settings
 		Metrics Metrics `json:"metrics" key:"metrics" yaml:"metrics" mapstructure:"metrics"`
-		// CRIU settings and defaults
-		CRIU CRIU `json:"criu" key:"criu" yaml:"criu" mapstructure:"criu"`
 		// Client settings
 		Client Client `json:"client" key:"client" yaml:"client" mapstructure:"client"`
+		// CRIU settings and defaults
+		CRIU CRIU `json:"criu" key:"criu" yaml:"criu" mapstructure:"criu"`
+		// GPU is settings for the GPU plugin
+		GPU GPU `json:"gpu" key:"gpu" yaml:"gpu" mapstructure:"gpu"`
 		// Plugin settings
 		Plugins Plugins `json:"plugins" key:"plugins" yaml:"plugins" mapstructure:"plugins"`
 	}
@@ -45,6 +47,9 @@ type (
 		Dir string `json:"dir" key:"dir" yaml:"dir" mapstructure:"dir"`
 		// Compression is the default compression algorithm to use for checkpoints
 		Compression string `json:"compression" key:"compression" yaml:"compression" mapstructure:"compression"`
+		// Stream (for streaming checkpoints) specifies the number of parallel streams to use.
+		// 0 means no streaming. n > 0 means n parallel streams (or number of pipes) to use.
+		Stream int32 `json:"stream" key:"stream" yaml:"stream" mapstructure:"stream"`
 	}
 
 	DB struct {
@@ -80,19 +85,17 @@ type (
 		LeaveRunning bool `json:"leave_running" key:"leave_running" yaml:"leave_running" mapstructure:"leave_running"`
 	}
 
-	Plugins struct {
-		// BinDir is the directory where plugin binaries are stored
-		BinDir string `json:"bin_dir" key:"bin_dir" yaml:"bin_dir" mapstructure:"bin_dir"`
-		// LibDir is the directory where plugin libraries are stored
-		LibDir string `json:"lib_dir" key:"lib_dir" yaml:"lib_dir" mapstructure:"lib_dir" env_aliases:"CEDANA_PLUGINS_LIB_DIR"`
-		// GPU is settings for the GPU plugin
-		GPU GPU `json:"gpu" key:"gpu" yaml:"gpu" mapstructure:"gpu"`
-	}
-
 	GPU struct {
 		// Number of warm GPU controllers to keep in pool
 		PoolSize int `json:"pool_size" key:"pool_size" yaml:"pool_size" mapstructure:"pool_size"`
 		// LogDir is the directory to write GPU logs to. By default, logs are written to daemon's stdout
 		LogDir string `json:"log_dir" key:"log_dir" yaml:"log_dir" mapstructure:"log_dir"`
+	}
+
+	Plugins struct {
+		// BinDir is the directory where plugin binaries are stored
+		BinDir string `json:"bin_dir" key:"bin_dir" yaml:"bin_dir" mapstructure:"bin_dir"`
+		// LibDir is the directory where plugin libraries are stored
+		LibDir string `json:"lib_dir" key:"lib_dir" yaml:"lib_dir" mapstructure:"lib_dir" env_aliases:"CEDANA_PLUGINS_LIB_DIR"`
 	}
 )

--- a/pkg/flags/cmd.go
+++ b/pkg/flags/cmd.go
@@ -17,7 +17,7 @@ var (
 	DirFlag         = Flag{Full: "dir", Short: "d"}
 	NameFlag        = Flag{Full: "name"}
 	PathFlag        = Flag{Full: "path", Short: "p"}
-	StreamFlag      = Flag{Full: "stream", Short: "s"}
+	StreamFlag      = Flag{Full: "stream"}
 	WorkingDirFlag  = Flag{Full: "working-dir", Short: "w"}
 	JidFlag         = Flag{Full: "jid", Short: "j"}
 	GpuEnabledFlag  = Flag{Full: "gpu-enabled", Short: "g"}

--- a/pkg/io/compression.go
+++ b/pkg/io/compression.go
@@ -1,0 +1,104 @@
+package io
+
+import (
+	"compress/gzip"
+	"compress/zlib"
+	"fmt"
+	"io"
+	"path/filepath"
+
+	"github.com/pierrec/lz4"
+)
+
+var SUPPORTED_COMPRESSIONS = map[string]bool{
+	"":     true,
+	"none": true,
+	"tar":  true,
+	"gzip": true,
+	"gz":   true,
+	"lz4":  true,
+	"zlib": true,
+}
+
+func NewCompressionWriter(writer io.Writer, compression string) (io.WriteCloser, error) {
+	switch compression {
+	case "lz4":
+		return lz4.NewWriter(writer), nil
+	case "gzip", "gz":
+		return gzip.NewWriter(writer), nil
+	case "zlib":
+		return zlib.NewWriter(writer), nil
+	case "tar", "none", "":
+		return NopWriteCloser{writer}, nil
+	default:
+		return nil, fmt.Errorf("Unsupported compression format: %s", compression)
+	}
+}
+
+func NewCompressionReader(reader io.Reader, compression string) (io.ReadCloser, error) {
+	switch compression {
+	case "lz4":
+		return NopReadCloser{lz4.NewReader(reader)}, nil
+	case "gzip", "gz":
+		return gzip.NewReader(reader)
+	case "zlib":
+		return zlib.NewReader(reader)
+	case "tar", "none", "":
+		return NopReadCloser{reader}, nil
+	default:
+		return nil, fmt.Errorf("Unsupported compression format: %s", compression)
+	}
+}
+
+func CompressionFromExt(path string) (string, error) {
+	ext := filepath.Ext(path)
+	switch ext {
+	case ".lz4":
+		return "lz4", nil
+	case ".gz", ".gzip":
+		return "gzip", nil
+	case ".zlib":
+		return "zlib", nil
+	case ".tar":
+		return "tar", nil
+	case "":
+		return "none", nil
+	default:
+		return "", fmt.Errorf("Unsupported compression format: %s", ext)
+	}
+}
+
+func ExtForCompression(compression string) (string, error) {
+	switch compression {
+	case "lz4":
+		return ".lz4", nil
+	case "gzip":
+		return ".gz", nil
+	case "zlib":
+		return ".zlib", nil
+	case "tar", "none", "":
+		return "", nil
+	default:
+		return "", fmt.Errorf("Unsupported compression format: %s", compression)
+	}
+}
+
+///////////////
+/// Helpers ///
+///////////////
+
+type NopWriteCloser struct {
+	io.Writer
+}
+
+type NopReadCloser struct {
+	io.Reader
+}
+
+func (NopWriteCloser) Close() error {
+	return nil
+}
+
+func (NopReadCloser) Close() error {
+	return nil
+}

--- a/pkg/io/constants.go
+++ b/pkg/io/constants.go
@@ -1,0 +1,8 @@
+package io
+
+const (
+	BYTE = 1.0 << (10 * iota)
+	KIBIBYTE
+	MEBIBYTE
+	GIBIBYTE
+)

--- a/pkg/io/pipe.go
+++ b/pkg/io/pipe.go
@@ -1,0 +1,33 @@
+package io
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+const CHUNK_SIZE = 4 * MEBIBYTE
+
+// Splice copies data from srcFd to dstFd using the splice system call, until EOF is reached.
+// which moves data between two file descriptors without copying it b/w kernel and user space.
+// One of the file descriptors must be a pipe. Check out splice(2) man page for more information.
+func Splice(srcFd, dstFd uintptr) (int64, error) {
+	var total int64
+	for {
+		n, err := unix.Splice(int(srcFd), nil, int(dstFd), nil, CHUNK_SIZE, unix.SPLICE_F_MOVE)
+		if err != nil {
+			return total, err
+		}
+		if n == 0 {
+			break
+		}
+		total += int64(n)
+	}
+	return total, nil
+}
+
+func IsPipe(fd uintptr) (bool, error) {
+	var stat unix.Stat_t
+	if err := unix.Fstat(int(fd), &stat); err != nil {
+		return false, err
+	}
+	return stat.Mode&unix.S_IFIFO != 0, nil
+}

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -52,7 +52,7 @@ var Registry = []Plugin{
 	{
 		Name:     "streamer",
 		Type:     EXTERNAL,
-		Binaries: []Binary{{Name: "cedana-image-streamer"}},
+		Binaries: []Binary{{Name: "criu-image-streamer"}},
 	},
 	{
 		Name:      "k8s",

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -52,7 +52,7 @@ var Registry = []Plugin{
 	{
 		Name:     "streamer",
 		Type:     EXTERNAL,
-		Binaries: []Binary{{Name: "criu-image-streamer"}},
+		Binaries: []Binary{{Name: "cedana-image-streamer"}},
 	},
 	{
 		Name:      "k8s",

--- a/pkg/profiling/timing.go
+++ b/pkg/profiling/timing.go
@@ -49,9 +49,7 @@ func StartTiming(ctx context.Context, f ...any) (childCtx context.Context, end f
 		log.Trace().Str("in", data.Name).Msgf("spent %s", duration)
 	}
 
-	component := &Data{}
-	data.Components = append(data.Components, component)
-	childCtx = context.WithValue(childCtx, keys.PROFILING_CONTEXT_KEY, component)
+	childCtx = context.WithValue(childCtx, keys.PROFILING_CONTEXT_KEY, data)
 
 	return
 }
@@ -59,7 +57,7 @@ func StartTiming(ctx context.Context, f ...any) (childCtx context.Context, end f
 // StartTimingComponent starts a timer and returns a function that should be called to end the timer.
 // Unlike StartTiming, this adds the data as a new component of the current data in ctx.
 // Returns childCtx, which should be used by the children of the new component.
-// If not data found in passed ctx, just returns noops, as like parent is not being profiled.
+// If no data found in passed ctx, just returns noops, as the parent is not being profiled.
 func StartTimingComponent(ctx context.Context, f ...any) (childCtx context.Context, end func()) {
 	var data *Data
 	data, ok := ctx.Value(keys.PROFILING_CONTEXT_KEY).(*Data)
@@ -130,7 +128,7 @@ func AddTimingComponent(ctx context.Context, duration time.Duration, f ...any) (
 // Instead of directly inserting a component like StartTimingComponent, this adds the data as a child component
 // to an empty component (category component) whose name is matching the category provided.
 // Returns childCtx, which should be used by the children of the new component.
-// If not data found in passed ctx, just returns noops, as like parent is not being profiled.
+// If no data found in passed ctx, just returns noops, as the parent is not being profiled.
 func StartTimingCategory(ctx context.Context, category string, f ...any) (childCtx context.Context, end func()) {
 	var data *Data
 	data, ok := ctx.Value(keys.PROFILING_CONTEXT_KEY).(*Data)

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -335,3 +335,12 @@ func WaitForFile(ctx context.Context, path string, timeout chan int) (string, er
 		}
 	}
 }
+
+func ChownAll(path string, uid, gid int) error {
+	return filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return fmt.Errorf("filepath.Walk() failed: %s", err)
+		}
+		return os.Chown(path, uid, gid)
+	})
+}

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -30,7 +30,7 @@ var SUPPORTED_COMPRESSIONS = map[string]bool{
 	"lz4":  true,
 }
 
-// CreateTarball creates a tarball from the provided sources and writes it to the destination.
+// Tar creates a tarball from the provided sources and writes it to the destination.
 // The desination should be a path without any file extension, as the function will add extension
 // based on the compression format specified.
 // XXX: Works only with files, not directories.
@@ -113,7 +113,7 @@ func Tar(src string, tarball string, compression string) (string, error) {
 	return tarball, nil
 }
 
-// DecompressTarball decompresses the provided tarball to the destination directory.
+// Untar decompresses the provided tarball to the destination directory.
 // The destination directory should already exist.
 // The function automatically detects the compression format from the file extension.
 // XXX: Works only with files, not directories.
@@ -131,23 +131,11 @@ func Untar(tarball string, dest string) error {
 	perm := stat.Mode().Perm()
 
 	var reader io.Reader
-	var compression string
 
 	switch filepath.Ext(tarball) {
 	case ".lz4":
-		compression = "lz4"
-	case ".gz":
-		compression = "gzip"
-	case ".tar":
-		compression = "none"
-	default:
-		return fmt.Errorf("Unsupported compression format: %s", compression)
-	}
-
-	switch compression {
-	case "lz4":
 		reader = lz4.NewReader(file)
-	case "gzip":
+	case ".gz":
 		var readCloser io.ReadCloser
 		readCloser, err = gzip.NewReader(file)
 		if err != nil {
@@ -155,8 +143,10 @@ func Untar(tarball string, dest string) error {
 		}
 		defer readCloser.Close()
 		reader = readCloser
-	default:
+	case ".tar":
 		reader = file
+	default:
+		return fmt.Errorf("Unsupported compression format: %s", strings.TrimPrefix(filepath.Ext(tarball), "."))
 	}
 
 	tarReader := tar.NewReader(reader)
@@ -203,6 +193,81 @@ func Untar(tarball string, dest string) error {
 	}
 
 	return nil
+}
+
+// WriteFile writes the contents of the provided reader to the file at the provided path.
+func WriteFile(path string, reader io.ReadCloser, compression string) error {
+	defer reader.Close()
+	switch compression {
+	case "lz4":
+		path += ".lz4"
+	case "gzip", "gz":
+		path += ".gz"
+	case "tar":
+		path += ".tar"
+	case "", "none":
+		// Do nothing
+	default:
+		return fmt.Errorf("Unsupported compression format: %s", compression)
+	}
+
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("Could not create file: %s", err)
+	}
+
+	var writer io.WriteCloser
+	switch compression {
+	case "lz4":
+		writer = lz4.NewWriter(file)
+		defer writer.Close()
+	case "gzip", "gz":
+		writer = gzip.NewWriter(file)
+		defer writer.Close()
+	case "tar":
+		writer = tar.NewWriter(file)
+	case "", "none":
+		writer = file
+	default:
+		os.Remove(path)
+		return fmt.Errorf("Unsupported compression format: %s", compression)
+	}
+
+	_, err = io.Copy(writer, reader)
+	return err
+}
+
+// ReadFile reads the contents of the file at the provided path and writes it to the provided writer.
+// The function automatically detects the compression format from the file extension.
+func ReadFile(path string, writer io.WriteCloser) error {
+	defer writer.Close()
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("Could not open file: %s", err)
+	}
+	defer file.Close()
+
+	var reader io.Reader
+	switch filepath.Ext(path) {
+	case ".lz4":
+		reader = lz4.NewReader(file)
+	case ".gz":
+		readCloser, err := gzip.NewReader(file)
+		if err != nil {
+			return fmt.Errorf("Could not create gzip reader: %s", err)
+		}
+		defer readCloser.Close()
+		reader = readCloser
+	case ".tar":
+		reader = tar.NewReader(file)
+	case "":
+		reader = file
+	default:
+		return fmt.Errorf("Unsupported compression format: %s", strings.TrimPrefix(filepath.Ext(path), "."))
+	}
+
+	_, err = io.Copy(writer, reader)
+	return err
 }
 
 //////////////////////////

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -166,55 +166,53 @@ func Untar(tarball string, dest string) error {
 
 // WriteTo writes the contents from the provided src to the the provided target file.
 // Compression format is specified by the compression argument.
-func WriteTo(src *os.File, target string, compression string) error {
+func WriteTo(src *os.File, target string, compression string) (int64, error) {
 	defer src.Close()
 
 	ext, err := cedana_io.ExtForCompression(compression)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	target += ext
 
 	file, err := os.Create(target)
 	if err != nil {
-		return fmt.Errorf("Could not create file: %s", err)
+		return 0, fmt.Errorf("Could not create file: %s", err)
 	}
 
 	writer, err := cedana_io.NewCompressionWriter(file, compression)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer writer.Close()
 
-	_, err = src.WriteTo(writer)
-	return err
+	return src.WriteTo(writer)
 }
 
 // ReadFrom reads the contents of the src file and writes it to the provided target.
 // The function automatically detects the compression format from the file extension.
-func ReadFrom(src string, target *os.File) error {
+func ReadFrom(src string, target *os.File) (int64, error) {
 	defer target.Close()
 
 	file, err := os.Open(src)
 	if err != nil {
-		return fmt.Errorf("Could not open file: %s", err)
+		return 0, fmt.Errorf("Could not open file: %s", err)
 	}
 	defer file.Close()
 
 	compression, err := cedana_io.CompressionFromExt(src)
 	if err != nil {
-		return err
+		return 0, err
 	}
 
 	reader, err := cedana_io.NewCompressionReader(file, compression)
 	if err != nil {
-		return err
+		return 0, err
 	}
 	defer reader.Close()
 
-	_, err = target.ReadFrom(reader)
-	return err
+	return target.ReadFrom(reader)
 }
 
 //////////////////////////

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -167,7 +167,7 @@ func Untar(tarball string, dest string) error {
 // WriteTo writes the contents from the provided src to the the provided target file.
 // Compression format is specified by the compression argument.
 // If the src is a pipe:
-// 1. No compression: Uses the splice() system call to move the data avoiding kernel-user space copy.
+// 1. No compression: WIP
 // 2. With compression: WIP
 func WriteTo(src *os.File, target string, compression string) (int64, error) {
 	defer src.Close()
@@ -184,16 +184,6 @@ func WriteTo(src *os.File, target string, compression string) (int64, error) {
 		return 0, err
 	}
 	defer file.Close()
-
-	if ext == "" {
-		isPipe, err := cedana_io.IsPipe(src.Fd())
-		if err != nil {
-			return 0, err
-		}
-		if isPipe {
-			return cedana_io.Splice(src.Fd(), file.Fd())
-		}
-	}
 
 	writer, err := cedana_io.NewCompressionWriter(file, compression)
 	if err != nil {

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -256,6 +256,9 @@ func WriteTo(src *os.File, path string, compression string) error {
 // The function automatically detects the compression format from the file extension.
 func ReadFrom(path string, target *os.File) error {
 	defer target.Close()
+
+	ext := filepath.Ext(path)
+
 	file, err := os.Open(path)
 	if err != nil {
 		return fmt.Errorf("Could not open file: %s", err)
@@ -263,7 +266,7 @@ func ReadFrom(path string, target *os.File) error {
 	defer file.Close()
 
 	var reader io.Reader
-	switch filepath.Ext(path) {
+	switch ext {
 	case ".lz4":
 		reader = lz4.NewReader(file)
 	case ".gz":

--- a/pkg/utils/string.go
+++ b/pkg/utils/string.go
@@ -1,5 +1,7 @@
 package utils
 
+import "strings"
+
 // Prints a string list as comma separated string.
 func StrList(strs []string) string {
 	str := ""
@@ -10,4 +12,10 @@ func StrList(strs []string) string {
 		}
 	}
 	return str
+}
+
+func LastLine(s string) string {
+  s = strings.Trim(s, "\n")
+	lines := strings.Split(s, "\n")
+	return strings.Trim(lines[len(lines)-1], "\n")
 }

--- a/plugins/runc/internal/namespace/restore_adapters.go
+++ b/plugins/runc/internal/namespace/restore_adapters.go
@@ -54,7 +54,7 @@ func InheritExternalNamespacesForRestore(nsTypes ...configs.NamespaceType) types
 			}
 			extraFiles, ok := ctx.Value(keys.EXTRA_FILES_CONTEXT_KEY).([]*os.File)
 			if !ok {
-				return nil, status.Error(codes.FailedPrecondition, "failed to get extra files from context")
+				extraFiles = []*os.File{}
 			}
 
 			config := container.Config()

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -3,6 +3,9 @@
 FROM ubuntu:24.04
 LABEL org.opencontainers.image.source https://github.com/cedana/cedana
 
+ARG GO_VERSION=1.23.0
+ARG CEDANA_SAMPLES_VERSION=0.0.1
+
 # install packages
 RUN <<EOT
 set -eux
@@ -34,15 +37,32 @@ EOT
 # install go
 RUN <<EOT
 set -eux
-wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go
-tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz && rm go1.23.0.linux-amd64.tar.gz
+wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && rm -rf /usr/local/go
+tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz
 EOT
 ENV PATH=${PATH}:/usr/local/go/bin:${GOPATH}/bin:/usr/local/bin
+
+# Install backup CRIU
+RUN <<EOT
+wget https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_22.04/amd64/criu_4.0-3_amd64.deb
+dpkg -i criu_4.0-3_amd64.deb
+rm criu_4.0-3_amd64.deb
+EOT
+
+# clone cedana-samples for test workloads
+RUN <<EOT
+set -eux
+curl -L -o cedana-samples.zip https://github.com/cedana/cedana-samples/archive/refs/tags/v${CEDANA_SAMPLES_VERSION}.zip
+unzip cedana-samples.zip
+mv cedana-samples-${CEDANA_SAMPLES_VERSION} cedana-samples
+rm cedana-samples.zip
+EOT
 
 VOLUME ["/src"]
 WORKDIR /src
 ENV PATH=${PATH}:/src
 RUN git config --global --add safe.directory `pwd`
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 CMD ["/entrypoint.sh"]

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -4,7 +4,7 @@ FROM ubuntu:24.04
 LABEL org.opencontainers.image.source https://github.com/cedana/cedana
 
 ARG GO_VERSION=1.23.0
-ARG CEDANA_SAMPLES_VERSION=0.0.1
+ARG CEDANA_SAMPLES_VERSION=0.0.2
 
 # install packages
 RUN <<EOT

--- a/test/Dockerfile.cuda
+++ b/test/Dockerfile.cuda
@@ -4,7 +4,7 @@ FROM nvidia/cuda:12.6.3-base-ubuntu24.04
 LABEL org.opencontainers.image.source https://github.com/cedana/cedana
 
 ARG GO_VERSION=1.23.0
-ARG CEDANA_SAMPLES_VERSION=0.0.1
+ARG CEDANA_SAMPLES_VERSION=0.0.2
 
 # install packages
 RUN <<EOT

--- a/test/Dockerfile.cuda
+++ b/test/Dockerfile.cuda
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.6
 
-FROM ubuntu:24.04
+FROM nvidia/cuda:12.6.3-base-ubuntu24.04
 LABEL org.opencontainers.image.source https://github.com/cedana/cedana
 
 # install packages

--- a/test/Dockerfile.cuda
+++ b/test/Dockerfile.cuda
@@ -3,6 +3,9 @@
 FROM nvidia/cuda:12.6.3-base-ubuntu24.04
 LABEL org.opencontainers.image.source https://github.com/cedana/cedana
 
+ARG GO_VERSION=1.23.0
+ARG CEDANA_SAMPLES_VERSION=0.0.1
+
 # install packages
 RUN <<EOT
 set -eux
@@ -34,15 +37,32 @@ EOT
 # install go
 RUN <<EOT
 set -eux
-wget https://go.dev/dl/go1.23.0.linux-amd64.tar.gz && rm -rf /usr/local/go
-tar -C /usr/local -xzf go1.23.0.linux-amd64.tar.gz && rm go1.23.0.linux-amd64.tar.gz
+wget https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz && rm -rf /usr/local/go
+tar -C /usr/local -xzf go${GO_VERSION}.linux-amd64.tar.gz && rm go${GO_VERSION}.linux-amd64.tar.gz
 EOT
 ENV PATH=${PATH}:/usr/local/go/bin:${GOPATH}/bin:/usr/local/bin
+
+# Install backup CRIU
+RUN <<EOT
+wget https://download.opensuse.org/repositories/devel:/tools:/criu/xUbuntu_22.04/amd64/criu_4.0-3_amd64.deb
+dpkg -i criu_4.0-3_amd64.deb
+rm criu_4.0-3_amd64.deb
+EOT
+
+# clone cedana-samples for test workloads
+RUN <<EOT
+set -eux
+curl -L -o cedana-samples.zip https://github.com/cedana/cedana-samples/archive/refs/tags/v${CEDANA_SAMPLES_VERSION}.zip
+unzip cedana-samples.zip
+mv cedana-samples-${CEDANA_SAMPLES_VERSION} cedana-samples
+rm cedana-samples.zip
+EOT
 
 VOLUME ["/src"]
 WORKDIR /src
 ENV PATH=${PATH}:/src
 RUN git config --global --add safe.directory `pwd`
 COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 CMD ["/entrypoint.sh"]

--- a/test/entrypoint.sh
+++ b/test/entrypoint.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Launch containerd in the background
+containerd > /dev/null &
+
+$@

--- a/test/regression/cr.bats
+++ b/test/regression/cr.bats
@@ -78,6 +78,19 @@ load_lib file
     run kill $pid
 }
 
+@test "dump process (zlib compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --compression zlib
+    assert_success
+
+    assert_exists "/tmp/$name.tar.zlib"
+
+    run kill $pid
+}
+
 @test "dump process (invalid compression)" {
     "$WORKLOADS"/date-loop.sh &
     pid=$!
@@ -171,7 +184,7 @@ load_lib file
     run kill $pid
 }
 
-@test "restore process (compression tar)" {
+@test "restore process (tar compression)" {
     "$WORKLOADS"/date-loop.sh &
     pid=$!
     name=$(unix_nano)
@@ -191,7 +204,7 @@ load_lib file
     run kill $pid
 }
 
-@test "restore process (compression gzip)" {
+@test "restore process (gzip compression)" {
     "$WORKLOADS"/date-loop.sh &
     pid=$!
     name=$(unix_nano)
@@ -211,7 +224,7 @@ load_lib file
     run kill $pid
 }
 
-@test "restore process (compression lz4)" {
+@test "restore process (lz4 compression)" {
     "$WORKLOADS"/date-loop.sh &
     pid=$!
     name=$(unix_nano)
@@ -231,7 +244,27 @@ load_lib file
     run kill $pid
 }
 
-@test "restore process (invalid compression)" {
+@test "restore process (zlib compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --compression zlib
+    assert_success
+
+    assert_exists "/tmp/$name.tar.zlib"
+
+    run cedana restore process --path "/tmp/$name.tar.zlib"
+    assert_success
+
+    run ps --pid $pid
+    assert_success
+    assert_output --partial "$pid"
+
+    run kill $pid
+}
+
+@test "restore process (compression invalid)" {
     "$WORKLOADS"/date-loop.sh &
     pid=$!
     name=$(unix_nano)

--- a/test/regression/helpers/utils.bash
+++ b/test/regression/helpers/utils.bash
@@ -52,3 +52,7 @@ env_exists() {
     local var=$1
     [ -n "${!var}" ]
 }
+
+cmd_exists() {
+    command -v "$1" >/dev/null 2>&1
+}

--- a/test/regression/plugins/gpu.bats
+++ b/test/regression/plugins/gpu.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+# This file assumes its being run from the same directory as the Makefile
+
+load ../helpers/utils
+load ../helpers/daemon
+
+load_lib support
+load_lib assert
+load_lib file
+
+###########
+### Run ###
+###########
+
+@test "run GPU process (dummy)" {
+    jid=$(unix_nano)
+    log_file="/var/log/cedana-output-$jid.log"
+
+    run cedana run process -g --jid "$jid" -- echo hello
+
+    assert_success
+    assert_exists "$log_file"
+    assert_file_contains "$log_file" "hello"
+
+    run cedana ps
+
+    assert_success
+    assert_output --partial "$jid"
+}

--- a/test/regression/plugins/gpu.bats
+++ b/test/regression/plugins/gpu.bats
@@ -17,7 +17,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 ###########
 
 @test "run GPU process (non-GPU binary)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 
@@ -34,7 +34,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
 
 @test "run GPU process (GPU binary)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 
@@ -47,7 +47,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
 
 @test "run GPU process (non-existent binary)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 
@@ -64,7 +64,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
 
 @test "exec GPU process (run process alias)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 
@@ -81,7 +81,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 ############
 
 @test "dump GPU process (vector add)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 
@@ -106,7 +106,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
 
 @test "dump GPU process (mem throughput saxpy)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 
@@ -135,7 +135,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 ###############
 
 @test "restore GPU process (vector add)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 
@@ -165,7 +165,7 @@ export BATS_NO_PARALLELIZE_WITHIN_FILE=true
 }
 
 @test "restore GPU process (mem throughput saxpy)" {
-    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+    if ! cmd_exists nvidia-smi; then
         skip "GPU not available"
     fi
 

--- a/test/regression/plugins/gpu.bats
+++ b/test/regression/plugins/gpu.bats
@@ -9,22 +9,187 @@ load_lib support
 load_lib assert
 load_lib file
 
+# So that we don't run out of shm space
+export BATS_NO_PARALLELIZE_WITHIN_FILE=true
+
 ###########
 ### Run ###
 ###########
 
-@test "run GPU process (dummy)" {
+@test "run GPU process (non-GPU binary)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
     jid=$(unix_nano)
     log_file="/var/log/cedana-output-$jid.log"
 
     run cedana run process -g --jid "$jid" -- echo hello
-
     assert_success
     assert_exists "$log_file"
-    assert_file_contains "$log_file" "hello"
 
     run cedana ps
-
     assert_success
     assert_output --partial "$jid"
+}
+
+@test "run GPU process (GPU binary)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
+    jid=$(unix_nano)
+    log_file="/var/log/cedana-output-$jid.log"
+
+    run cedana run process -g --jid "$jid" -- /cedana-samples/gpu_smr/mem-throughput-saxpy
+    assert_success
+    assert_exists "$log_file"
+}
+
+@test "run GPU process (non-existent binary)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
+    jid=$(unix_nano)
+    log_file="/var/log/cedana-output-$jid.log"
+
+    run cedana exec -g --jid "$jid" -- non-existent
+    assert_failure
+    assert_file_not_exist "$log_file"
+
+    run cedana ps
+    assert_success
+    refute_output --partial "$jid"
+}
+
+@test "exec GPU process (run process alias)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
+    jid=$(unix_nano)
+    log_file="/var/log/cedana-output-$jid.log"
+
+    run cedana exec -g --jid "$jid" -- /cedana-samples/gpu_smr/mem-throughput-saxpy
+    assert_success
+    assert_exists "$log_file"
+}
+
+############
+### Dump ###
+############
+
+@test "dump GPU process (vector add)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
+    jid=$(unix_nano)
+    log_file="/var/log/cedana-output-$jid.log"
+
+    run cedana run process -g --jid "$jid" -- /cedana-samples/gpu_smr/vector_add
+    assert_success
+    assert_exists "$log_file"
+
+    sleep 2
+
+    run cedana dump job "$jid"
+    assert_success
+
+    sleep 1
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana job kill "$jid"
+}
+
+@test "dump GPU process (mem throughput saxpy)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
+    jid=$(unix_nano)
+    log_file="/var/log/cedana-output-$jid.log"
+
+    run cedana run process -g --jid "$jid" -- /cedana-samples/gpu_smr/mem-throughput-saxpy-loop
+    assert_success
+    assert_exists "$log_file"
+
+    sleep 2
+
+    run cedana dump job "$jid"
+    assert_success
+
+    sleep 1
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana job kill "$jid"
+}
+
+###############
+### Restore ###
+###############
+
+@test "restore GPU process (vector add)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
+    jid=$(unix_nano)
+
+    run cedana run process -g --jid "$jid" -- /cedana-samples/gpu_smr/vector_add
+    assert_success
+
+    sleep 2
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    sleep 1
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run cedana ps
+    assert_success
+    assert_output --partial "$jid"
+
+    run cedana job kill "$jid"
+}
+
+@test "restore GPU process (mem throughput saxpy)" {
+    if ! env_exists "NVIDIA_VISIBLE_DEVICES"; then
+        skip "GPU not available"
+    fi
+
+    jid=$(unix_nano)
+
+    run cedana run process -g --jid "$jid" -- /cedana-samples/gpu_smr/mem-throughput-saxpy-loop
+    assert_success
+
+    sleep 2
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    sleep 1
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run cedana ps
+    assert_success
+    assert_output --partial "$jid"
+
+    run cedana job kill "$jid"
 }

--- a/test/regression/plugins/streamer.bats
+++ b/test/regression/plugins/streamer.bats
@@ -13,107 +13,107 @@ load_lib file
 ### Dump ###
 ############
 
-@test "stream dump process" {
-    "$WORKLOADS"/date-loop.sh &
-    pid=$!
+# @test "stream dump process" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
 
-    run cedana dump process $pid --stream 1
-    assert_success
+#     run cedana dump process $pid --stream 1
+#     assert_success
 
-    dump_file=$(echo "$output" | awk '{print $NF}')
-    assert_exists "$dump_file"
+#     dump_file=$(echo "$output" | awk '{print $NF}')
+#     assert_exists "$dump_file"
 
-    run kill $pid
-}
+#     run kill $pid
+# }
 
-@test "stream dump process (custom name)" {
-    "$WORKLOADS"/date-loop.sh &
-    pid=$!
-    name=$(unix_nano)
+# @test "stream dump process (custom name)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 1
-    assert_success
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream 1
+#     assert_success
 
-    assert_exists "/tmp/$name"
+#     assert_exists "/tmp/$name"
 
-    run kill $pid
-}
+#     run kill $pid
+# }
 
-@test "stream dump process (parallelism)" {
-    "$WORKLOADS"/date-loop.sh &
-    pid=$!
-    name=$(unix_nano)
+# @test "stream dump process (parallelism)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 4
-    assert_success
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream 4
+#     assert_success
 
-    assert_exists "/tmp/$name"
-    assert_exists "/tmp/$name/img-0"
-    assert_exists "/tmp/$name/img-1"
-    assert_exists "/tmp/$name/img-2"
-    assert_exists "/tmp/$name/img-3"
+#     assert_exists "/tmp/$name"
+#     assert_exists "/tmp/$name/img-0"
+#     assert_exists "/tmp/$name/img-1"
+#     assert_exists "/tmp/$name/img-2"
+#     assert_exists "/tmp/$name/img-3"
 
-    run kill $pid
-}
+#     run kill $pid
+# }
 
-@test "dump process (tar compression)" {
-    "$WORKLOADS"/date-loop.sh &
-    pid=$!
-    name=$(unix_nano)
+# @test "dump process (tar compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression tar
-    assert_success
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression tar
+#     assert_success
 
-    assert_exists "/tmp/$name"
-    assert_exists "/tmp/$name/img-0.tar"
-    assert_exists "/tmp/$name/img-1.tar"
+#     assert_exists "/tmp/$name"
+#     assert_exists "/tmp/$name/img-0.tar"
+#     assert_exists "/tmp/$name/img-1.tar"
 
-    run kill $pid
-}
+#     run kill $pid
+# }
 
-@test "dump process (gzip compression)" {
-    "$WORKLOADS"/date-loop.sh &
-    pid=$!
-    name=$(unix_nano)
+# @test "dump process (gzip compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression gzip
-    assert_success
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression gzip
+#     assert_success
 
-    assert_exists "/tmp/$name"
-    assert_exists "/tmp/$name/img-0.gz"
-    assert_exists "/tmp/$name/img-1.gz"
+#     assert_exists "/tmp/$name"
+#     assert_exists "/tmp/$name/img-0.gz"
+#     assert_exists "/tmp/$name/img-1.gz"
 
-    run kill $pid
-}
+#     run kill $pid
+# }
 
-@test "dump process (lz4 compression)" {
-    "$WORKLOADS"/date-loop.sh &
-    pid=$!
-    name=$(unix_nano)
+# @test "dump process (lz4 compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression lz4
-    assert_success
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression lz4
+#     assert_success
 
-    assert_exists "/tmp/$name"
-    assert_exists "/tmp/$name/img-0.lz4"
-    assert_exists "/tmp/$name/img-1.lz4"
+#     assert_exists "/tmp/$name"
+#     assert_exists "/tmp/$name/img-0.lz4"
+#     assert_exists "/tmp/$name/img-1.lz4"
 
-    run kill $pid
-}
+#     run kill $pid
+# }
 
-@test "dump process (invalid compression)" {
-    "$WORKLOADS"/date-loop.sh &
-    pid=$!
-    name=$(unix_nano)
+# @test "dump process (invalid compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression jibberish
-    assert_failure
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression jibberish
+#     assert_failure
 
-    assert_not_exists "/tmp/$name"
+#     assert_not_exists "/tmp/$name"
 
-    run kill $pid
-}
+#     run kill $pid
+# }
 
-###############
-### Restore ###
-###############
+# ###############
+# ### Restore ###
+# ###############

--- a/test/regression/plugins/streamer.bats
+++ b/test/regression/plugins/streamer.bats
@@ -13,87 +13,107 @@ load_lib file
 ### Dump ###
 ############
 
-# @test "stream dump process" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
+@test "stream dump process" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
 
-#     run cedana dump process $pid --stream 1
-#     assert_success
+    run cedana dump process $pid --stream 1
+    assert_success
 
-#     dump_file=$(echo "$output" | awk '{print $NF}')
-#     assert_exists "$dump_file"
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "stream dump process (custom name)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "stream dump process (custom name)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream 1
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 1
+    assert_success
 
-#     assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "dump process (tar compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "stream dump process (parallelism)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression tar
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 4
+    assert_success
 
-#     assert_exists "/tmp/$name"
-#     assert_exists "/tmp/$name/img-0.lz4" # XXX: Will just override to lz4 until we move compression from streamer to the daemon
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0"
+    assert_exists "/tmp/$name/img-1"
+    assert_exists "/tmp/$name/img-2"
+    assert_exists "/tmp/$name/img-3"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "dump process (gzip compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "dump process (tar compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression gzip
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression tar
+    assert_success
 
-#     assert_exists "/tmp/$name.tar.gz"
-#     assert_exists "/tmp/$name/img-0.lz4" # XXX: Will just override to lz4 until we move compression from streamer to the daemon
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0.tar"
+    assert_exists "/tmp/$name/img-1.tar"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "dump process (lz4 compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "dump process (gzip compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression lz4
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression gzip
+    assert_success
 
-#     assert_exists "/tmp/$name.tar.lz4"
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0.gz"
+    assert_exists "/tmp/$name/img-1.gz"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "dump process (invalid compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "dump process (lz4 compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression jibberish
-#     assert_failure
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression lz4
+    assert_success
 
-#     assert_not_exists "/tmp/$name"
-#     assert_not_exists "/tmp/$name/img-0.lz4"
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0.lz4"
+    assert_exists "/tmp/$name/img-1.lz4"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# ############
-# ### Dump ###
-# ############
+@test "dump process (invalid compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression jibberish
+    assert_failure
+
+    assert_not_exists "/tmp/$name"
+
+    run kill $pid
+}
+
+###############
+### Restore ###
+###############

--- a/test/regression/plugins/streamer.bats
+++ b/test/regression/plugins/streamer.bats
@@ -17,7 +17,7 @@ load_lib file
     "$WORKLOADS"/date-loop.sh &
     pid=$!
 
-    run cedana dump process $pid --stream 1
+    run cedana dump process $pid --stream 1 --compression none
     assert_success
 
     dump_file=$(echo "$output" | awk '{print $NF}')
@@ -32,7 +32,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 1
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 1 --compression none
     assert_success
 
     assert_exists "/tmp/$name"
@@ -46,7 +46,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 0
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 0 --compression none
     assert_success
 
     assert_exists "/tmp/$name"
@@ -60,7 +60,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 4
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 4 --compression none
     assert_success
 
     assert_exists "/tmp/$name"
@@ -77,7 +77,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 8
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 8 --compression none
     assert_success
 
     assert_exists "/tmp/$name"
@@ -177,7 +177,7 @@ load_lib file
     "$WORKLOADS"/date-loop.sh &
     pid=$!
 
-    run cedana dump process $pid --stream 1
+    run cedana dump process $pid --stream 1 --compression none
     assert_success
 
     dump_file=$(echo "$output" | awk '{print $NF}')
@@ -195,7 +195,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 1
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 1 --compression none
     assert_success
 
     dump_file="/tmp/$name"
@@ -213,7 +213,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 0
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 0 --compression none
     assert_success
 
     dump_file="/tmp/$name"
@@ -231,7 +231,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 4
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 4 --compression none
     assert_success
 
     dump_file="/tmp/$name"
@@ -252,7 +252,7 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
-    run cedana dump process $pid --name "$name" --dir /tmp --stream 8
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 8 --compression none
     assert_success
 
     dump_file="/tmp/$name"

--- a/test/regression/plugins/streamer.bats
+++ b/test/regression/plugins/streamer.bats
@@ -8,3 +8,92 @@ load ../helpers/daemon
 load_lib support
 load_lib assert
 load_lib file
+
+############
+### Dump ###
+############
+
+# @test "stream dump process" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+
+#     run cedana dump process $pid --stream 1
+#     assert_success
+
+#     dump_file=$(echo "$output" | awk '{print $NF}')
+#     assert_exists "$dump_file"
+
+#     run kill $pid
+# }
+
+# @test "stream dump process (custom name)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
+
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream 1
+#     assert_success
+
+#     assert_exists "/tmp/$name"
+
+#     run kill $pid
+# }
+
+# @test "dump process (tar compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
+
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression tar
+#     assert_success
+
+#     assert_exists "/tmp/$name"
+#     assert_exists "/tmp/$name/img-0.lz4" # XXX: Will just override to lz4 until we move compression from streamer to the daemon
+
+#     run kill $pid
+# }
+
+# @test "dump process (gzip compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
+
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression gzip
+#     assert_success
+
+#     assert_exists "/tmp/$name.tar.gz"
+#     assert_exists "/tmp/$name/img-0.lz4" # XXX: Will just override to lz4 until we move compression from streamer to the daemon
+
+#     run kill $pid
+# }
+
+# @test "dump process (lz4 compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
+
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression lz4
+#     assert_success
+
+#     assert_exists "/tmp/$name.tar.lz4"
+
+#     run kill $pid
+# }
+
+# @test "dump process (invalid compression)" {
+#     "$WORKLOADS"/date-loop.sh &
+#     pid=$!
+#     name=$(unix_nano)
+
+#     run cedana dump process $pid --name "$name" --dir /tmp --stream --compression jibberish
+#     assert_failure
+
+#     assert_not_exists "/tmp/$name"
+#     assert_not_exists "/tmp/$name/img-0.lz4"
+
+#     run kill $pid
+# }
+
+# ############
+# ### Dump ###
+# ############

--- a/test/regression/plugins/streamer.bats
+++ b/test/regression/plugins/streamer.bats
@@ -13,107 +13,356 @@ load_lib file
 ### Dump ###
 ############
 
-# @test "stream dump process" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
+@test "stream dump process" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
 
-#     run cedana dump process $pid --stream 1
-#     assert_success
+    run cedana dump process $pid --stream 1
+    assert_success
 
-#     dump_file=$(echo "$output" | awk '{print $NF}')
-#     assert_exists "$dump_file"
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "stream dump process (custom name)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "stream dump process (custom name)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream 1
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 1
+    assert_success
 
-#     assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "stream dump process (parallelism)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "stream dump process (0 parallelism = no streaming)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream 4
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 0
+    assert_success
 
-#     assert_exists "/tmp/$name"
-#     assert_exists "/tmp/$name/img-0"
-#     assert_exists "/tmp/$name/img-1"
-#     assert_exists "/tmp/$name/img-2"
-#     assert_exists "/tmp/$name/img-3"
+    assert_exists "/tmp/$name"
+    assert_not_exists "/tmp/$name/img-0"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "dump process (tar compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "stream dump process (4 parallelism)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression tar
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 4
+    assert_success
 
-#     assert_exists "/tmp/$name"
-#     assert_exists "/tmp/$name/img-0.tar"
-#     assert_exists "/tmp/$name/img-1.tar"
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0"
+    assert_exists "/tmp/$name/img-1"
+    assert_exists "/tmp/$name/img-2"
+    assert_exists "/tmp/$name/img-3"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "dump process (gzip compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "stream dump process (8 parallelism)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression gzip
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 8
+    assert_success
 
-#     assert_exists "/tmp/$name"
-#     assert_exists "/tmp/$name/img-0.gz"
-#     assert_exists "/tmp/$name/img-1.gz"
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0"
+    assert_exists "/tmp/$name/img-1"
+    assert_exists "/tmp/$name/img-2"
+    assert_exists "/tmp/$name/img-3"
+    assert_exists "/tmp/$name/img-4"
+    assert_exists "/tmp/$name/img-5"
+    assert_exists "/tmp/$name/img-6"
+    assert_exists "/tmp/$name/img-7"
 
-#     run kill $pid
-# }
+    run kill $pid
+}
 
-# @test "dump process (lz4 compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+@test "stream dump process (tar compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression lz4
-#     assert_success
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression tar
+    assert_success
 
-#     assert_exists "/tmp/$name"
-#     assert_exists "/tmp/$name/img-0.lz4"
-#     assert_exists "/tmp/$name/img-1.lz4"
+    # tar does no compression, but since the option is valid for non-stream dump,
+    # it just creates uncompressed files
 
-#     run kill $pid
-# }
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0"
+    assert_exists "/tmp/$name/img-1"
 
-# @test "dump process (invalid compression)" {
-#     "$WORKLOADS"/date-loop.sh &
-#     pid=$!
-#     name=$(unix_nano)
+    run kill $pid
+}
 
-#     run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression jibberish
-#     assert_failure
+@test "stream dump process (gzip compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
 
-#     assert_not_exists "/tmp/$name"
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression gzip
+    assert_success
 
-#     run kill $pid
-# }
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0.gz"
+    assert_exists "/tmp/$name/img-1.gz"
 
-# ###############
-# ### Restore ###
-# ###############
+    run kill $pid
+}
+
+@test "stream dump process (lz4 compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression lz4
+    assert_success
+
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0.lz4"
+    assert_exists "/tmp/$name/img-1.lz4"
+
+    run kill $pid
+}
+
+@test "stream dump process (zlib compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression zlib
+    assert_success
+
+    assert_exists "/tmp/$name"
+    assert_exists "/tmp/$name/img-0.zlib"
+    assert_exists "/tmp/$name/img-1.zlib"
+
+    run kill $pid
+}
+
+@test "stream dump process (invalid compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression jibberish
+    assert_failure
+
+    assert_not_exists "/tmp/$name"
+
+    run kill $pid
+}
+
+###############
+### Restore ###
+###############
+
+@test "stream restore process" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+
+    run cedana dump process $pid --stream 1
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0"
+
+    run cedana restore process --path "$dump_file" --stream 1
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (custom name)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 1
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0"
+
+    run cedana restore process --path "$dump_file" --stream 1
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (0 parallelism = no streaming)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 0
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_not_exists "$dump_file/img-0"
+
+    run cedana restore process --path "$dump_file" --stream 0
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (4 parallelism)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 4
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0"
+    assert_exists "$dump_file/img-1"
+    assert_exists "$dump_file/img-2"
+    assert_exists "$dump_file/img-3"
+
+    run cedana restore process --path "$dump_file" --stream 4
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (8 parallelism)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 8
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0"
+    assert_exists "$dump_file/img-1"
+    assert_exists "$dump_file/img-2"
+    assert_exists "$dump_file/img-3"
+    assert_exists "$dump_file/img-4"
+    assert_exists "$dump_file/img-5"
+    assert_exists "$dump_file/img-6"
+    assert_exists "$dump_file/img-7"
+
+    run cedana restore process --path "$dump_file" --stream 8
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (mismatched parallelism)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0"
+    assert_exists "$dump_file/img-1"
+
+    run cedana restore process --path "$dump_file" --stream 3
+    assert_failure
+
+    run kill $pid
+}
+
+@test "stream restore process (tar compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression tar
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0"
+    assert_exists "$dump_file/img-1"
+
+    run cedana restore process --path "$dump_file" --stream 2
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (gzip compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression gzip
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0.gz"
+    assert_exists "$dump_file/img-1.gz"
+
+    run cedana restore process --path "$dump_file" --stream 2
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (lz4 compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression lz4
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0.lz4"
+    assert_exists "$dump_file/img-1.lz4"
+
+    run cedana restore process --path "$dump_file" --stream 2
+    assert_success
+
+    run kill $pid
+}
+
+@test "stream restore process (zlib compression)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp --stream 2 --compression zlib
+    assert_success
+
+    dump_file="/tmp/$name"
+    assert_exists "$dump_file"
+    assert_exists "$dump_file/img-0.zlib"
+    assert_exists "$dump_file/img-1.zlib"
+
+    run cedana restore process --path "$dump_file" --stream 2
+    assert_success
+
+    run kill $pid
+}


### PR DESCRIPTION
## Describe your changes

### Accompanying PRs
- cedana-gpu: https://github.com/cedana/cedana-gpu/pull/116
- cedana-image-streamer: https://github.com/cedana/cedana-image-streamer/pull/14

### Implementation
Implements support for streaming C/R through a new filesystem implementation of `afero.Fs`. Supports all compression formats that are supported for default C/R.

The `types.Opts` passed to the C/R handler includes a new field called `DumpFs`, that provides access to the dump directory through a convenient filesystem interface:
https://github.com/cedana/cedana/blob/001ef5f1c11b23ad12525d08eb9d8051983ec5d9/pkg/types/handler.go#L18-L25

If streaming is enabled, the file system operations are handled under the hood through the streamer. If streaming is disabled, the file system operations are handled through a regular file system implementation. This is achieved by simply using the appropriate `PrepareDumpDir` adapter:
https://github.com/cedana/cedana/blob/001ef5f1c11b23ad12525d08eb9d8051983ec5d9/internal/server/dump.go#L28-L36

The `Checkpoint` section in config now includes a `Stream` field, to enable streaming by default:
https://github.com/cedana/cedana/blob/001ef5f1c11b23ad12525d08eb9d8051983ec5d9/pkg/config/types.go#L45-L53

### Other changes
- Adds support for `zlib` compression.
- Few other minor fixes and QoL improvements.
- Added health check component for streamer, that checks for optimal kernel settings.

![image](https://github.com/user-attachments/assets/27c6b5a9-e7e3-4835-a327-fe02225e1107)

### Testing
- Added some streamer tests in `test/regression/plugins/streamer.bats`
- Added some gpu tests in `test/regression/plugins/gpu.bats`
- [cedana-samples](https://github.com/cedana/cedana-samples) is available in the test environment. You can directly use workloads from it when adding new regression tests, e.g. in a GPU test:
https://github.com/cedana/cedana/blob/001ef5f1c11b23ad12525d08eb9d8051983ec5d9/test/regression/plugins/gpu.bats#L83-L106
- All tests can be run locally. When running `make test` locally, the tests will be run in a containerized environment automatically. Any GPU tests are skipped by default, unless you do `make test GPU=1` or `make test-regression GPU=1`, which will use a GPU-enabled container. See `make help` for the new/updated targets.

### TODO
- [ ] Add integration tests for streaming + GPU, streaming + runc, etc. This will be done in a separate PR.
- [ ] Reuse test suite in other repositories instead of duplicating it.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.