### PR TITLE
feat: Add `log_dir` option to config for GPU logs

### DIFF
--- a/internal/server/gpu/controller.go
+++ b/internal/server/gpu/controller.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strconv"
 	"sync"
 	"syscall"
@@ -14,6 +16,7 @@ import (
 	"buf.build/gen/go/cedana/cedana-gpu/grpc/go/gpu/gpugrpc"
 	"buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go/gpu"
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/pkg/config"
 	"github.com/cedana/cedana/pkg/logging"
 	"github.com/cedana/cedana/pkg/utils"
 	"github.com/rs/zerolog"
@@ -30,7 +33,9 @@ const (
 	// about the GPU controller's failure.
 	CONTROLLER_PREMATURE_EXIT_SIGNAL = syscall.SIGUSR1
 
-	MIN_SHM_SIZE = 8 << 30 // 8 GiB
+	CONTROLLER_LOG_FILE_FORMATTER = "cedana-gpu-controller-%s.log"
+	CONTROLLER_LOG_FILE_MODE      = os.O_CREATE | os.O_WRONLY | os.O_APPEND
+	CONTROLLER_LOG_FILE_PERMS     = 0o644
 )
 
 type controller struct {
@@ -109,7 +114,20 @@ func (m *controllers) spawnAsync(
 	}
 
 	controller.Stderr = controller.ErrBuf
-	controller.Stdout = logging.Writer("gpu-controller", jid, zerolog.TraceLevel)
+
+	if dir := config.Global.Plugins.GPU.LogDir; dir != "" {
+		file, err := os.OpenFile(
+			filepath.Join(dir, fmt.Sprintf(CONTROLLER_LOG_FILE_FORMATTER, jid)),
+			CONTROLLER_LOG_FILE_MODE,
+			CONTROLLER_LOG_FILE_PERMS,
+		)
+		if err != nil {
+			return fmt.Errorf("failed to open log file for GPU controller: %w", err)
+		}
+		controller.Stdout = file
+	} else {
+		controller.Stdout = logging.Writer("gpu-controller", jid, zerolog.TraceLevel)
+	}
 	controller.SysProcAttr = &syscall.SysProcAttr{
 		Pdeathsig:  syscall.SIGTERM,
 		Credential: user,

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -92,5 +92,7 @@ type (
 	GPU struct {
 		// Number of warm GPU controllers to keep in pool
 		PoolSize int `json:"pool_size" mapstructure:"pool_size" yaml:"pool_size"`
+		// LogDir is the directory to write logs GPU logs to. By default, logs are written to daemon's stdout
+    LogDir string `json:"log_dir" mapstructure:"log_dir" yaml:"log_dir"`
 	}
 )

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -92,7 +92,7 @@ type (
 	GPU struct {
 		// Number of warm GPU controllers to keep in pool
 		PoolSize int `json:"pool_size" mapstructure:"pool_size" yaml:"pool_size"`
-		// LogDir is the directory to write logs GPU logs to. By default, logs are written to daemon's stdout
+		// LogDir is the directory to write GPU logs to. By default, logs are written to daemon's stdout
     LogDir string `json:"log_dir" mapstructure:"log_dir" yaml:"log_dir"`
 	}
 )

--- a/pkg/logging/writer.go
+++ b/pkg/logging/writer.go
@@ -23,8 +23,8 @@ func Writer(context string, id string, level zerolog.Level) *LogWriter {
 	return &LogWriter{
 		context: context,
 		id:      id,
-		logger:  log.Logger.Level(log.Logger.GetLevel()), // set minimum level to parent logger
 		level:   level,
+		logger:  log.Logger.With().Str("context", context).Str("id", id).Logger(),
 	}
 }
 
@@ -34,8 +34,9 @@ func (w *LogWriter) Write(p []byte) (n int, err error) {
 		if len(line) == 0 {
 			continue
 		}
-		w.logger.WithLevel(w.level).Str("context", w.context).Str("id", w.id).Msg(string(line))
+		w.logger.WithLevel(w.level).Msg(string(line))
 	}
+
 	return len(p), nil
 }
 


### PR DESCRIPTION
## Describe your changes
https://github.com/cedana/cedana/blob/40cbf8c0b1f296febcd525b8367e4f130d7d9dfc/pkg/config/types.go#L95-L96

If option left empty, logs will appear in daemon stdout as before. If you set it to, for e.g.
`/var/log`, GPU controller will be written there.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.