### PR TITLE
fix: List/download only compatible plugins from registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,11 +45,11 @@ stop: ## Stop the daemon
 
 install-systemd: install ## Install the systemd daemon
 	@echo "Installing systemd service..."
-	$(SUDO) $(SCRIPTS_DIR)/systemd-install.sh
+	$(SUDO) $(SCRIPTS_DIR)/host/systemd-install.sh
 
 reset-systemd: ## Reset the systemd daemon
 	@echo "Stopping systemd service..."
-	$(SUDO) $(SCRIPTS_DIR)/systemd-reset.sh ;\
+	$(SUDO) $(SCRIPTS_DIR)/host/systemd-reset.sh ;\
 	sleep 1
 
 reset: reset-systemd stop reset-plugins reset-db reset-config reset-tmp reset-logs ## Reset (everything)

--- a/cmd/plugin.go
+++ b/cmd/plugin.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cedana/cedana/pkg/utils"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-	"github.com/xeonx/timeago"
 )
 
 func init() {
@@ -39,7 +38,7 @@ var pluginCmd = &cobra.Command{
 	Use:   "plugin",
 	Short: "Manage plugins",
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) (err error) {
-		manager := plugins.NewPropagatorManager(config.Global.Connection)
+		manager := plugins.NewPropagatorManager(config.Global.Connection, rootCmd.Version)
 
 		ctx := context.WithValue(cmd.Context(), keys.PLUGIN_MANAGER_CONTEXT_KEY, manager)
 		cmd.SetContext(ctx)
@@ -99,7 +98,7 @@ var pluginListCmd = &cobra.Command{
 				statusStr(p.Status),
 				p.Version,
 				p.LatestVersion,
-				timeago.NoMax(timeago.English).Format(p.PublishedAt),
+				utils.TimeAgo(p.PublishedAt),
 			}
 			tableWriter.AppendRow(row)
 		}

--- a/pkg/plugins/feature.go
+++ b/pkg/plugins/feature.go
@@ -67,6 +67,7 @@ func (feature Feature[T]) IfAvailable(
 // Also returns an error if the symbol is present but incompatible.
 func (feature Feature[T]) IsAvailable(filter ...string) (bool, error) {
 	loadedPlugins := Load()
+
 	available := false
 
 	pluginSet := map[string]struct{}{}

--- a/pkg/plugins/manager_local.go
+++ b/pkg/plugins/manager_local.go
@@ -21,8 +21,9 @@ type LocalManager struct {
 }
 
 func NewLocalManager() *LocalManager {
+	wd, _ := os.Getwd()
 	return &LocalManager{
-		searchPath,
+		searchPath + ":" + wd, // add current working directory to search path
 		make(map[string]string),
 	}
 }

--- a/pkg/plugins/manager_propagator.go
+++ b/pkg/plugins/manager_propagator.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/style"
 )
 
 const (
@@ -84,7 +85,14 @@ func (m *PropagatorManager) List(latest bool, filter ...string) ([]Plugin, error
 		if err == nil {
 			defer resp.Body.Close()
 
-			if resp.StatusCode == http.StatusOK {
+			if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+				if resp.StatusCode == http.StatusPartialContent {
+					fmt.Println(style.WarningColors.Sprint(
+						"Some plugins have no compatible versions available in the registry or locally.\n",
+						"You may need to update Cedana. If this is a local build, you may ignore this warning.\n",
+					))
+				}
+
 				onlineList := make([]Plugin, len(list))
 				if err := json.NewDecoder(resp.Body).Decode(&onlineList); err != nil {
 					return nil, err
@@ -116,7 +124,7 @@ func (m *PropagatorManager) List(latest bool, filter ...string) ([]Plugin, error
 	}
 
 	if err != nil {
-		fmt.Printf("Warn: Using local list. Failed to connect to propagator registry: %v\n", err)
+		fmt.Println(style.WarningColors.Sprintf("Using local list. Failed to connect to propagator registry: %v", err))
 	}
 
 	return list, nil

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -106,6 +106,22 @@ func (p *Plugin) SyncVersion() {
 			version = "error"
 		}
 	}
+
+	// Get first line
+	if i := strings.Index(version, "\n"); i > 0 {
+		version = version[:i]
+	}
+
+	// Get last word
+	if i := strings.LastIndex(version, " "); i > 0 {
+		version = version[i+1:]
+	}
+
+	// Add 'v' prefix if missing
+	if !strings.HasPrefix(version, "v") {
+		version = "v" + version
+	}
+
 	p.Version = version
 }
 

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -101,25 +101,28 @@ func (p *Plugin) SyncVersion() {
 		cmd := exec.Command(binary.Name, "--version")
 		cmd.Env = append(os.Environ(), "PATH="+BinDir+":"+os.Getenv("PATH"))
 		if out, err := cmd.Output(); err == nil {
-			version = strings.TrimSpace(string(out))
-		} else {
-			version = "unknown"
+			if v := strings.TrimSpace(string(out)); v != "" {
+				version = v
+			}
 		}
 	}
 
-	// Get first line
-	if i := strings.Index(version, "\n"); i > 0 {
-		version = version[:i]
-	}
+	if version != "unknown" {
+		// Get first line
+		if i := strings.Index(version, "\n"); i > 0 {
+			version = version[:i]
+		}
 
-	// Get last word
-	if i := strings.LastIndex(version, " "); i > 0 {
-		version = version[i+1:]
-	}
+		// Get last word
+		if i := strings.LastIndex(version, " "); i > 0 {
+			version = version[i+1:]
+		}
 
-	// Add 'v' prefix if missing
-	if !strings.HasPrefix(version, "v") {
-		version = "v" + version
+		// Add 'v' prefix if missing
+		if !strings.HasPrefix(version, "v") {
+			version = "v" + version
+		}
+
 	}
 
 	p.Version = version

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -103,7 +103,7 @@ func (p *Plugin) SyncVersion() {
 		if out, err := cmd.Output(); err == nil {
 			version = strings.TrimSpace(string(out))
 		} else {
-			version = "error"
+			version = "unknown"
 		}
 	}
 

--- a/pkg/utils/time.go
+++ b/pkg/utils/time.go
@@ -1,0 +1,19 @@
+package utils
+
+import (
+	"time"
+
+	"github.com/xeonx/timeago"
+)
+
+const MaxTimeAgo = 24 * 365 * 20 * time.Hour // 20 years
+
+func TimeAgo(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+
+	config := timeago.English
+	config.Max = MaxTimeAgo
+	return config.Format(t)
+}

--- a/scripts/ci/release-summary-slack
+++ b/scripts/ci/release-summary-slack
@@ -96,7 +96,7 @@ if TAG and PREVIOUS_TAG and BINARIES_DIR and PREVIOUS_BINARIES_DIR:
                 / 1024
                 / 1024
             )
-            previous_binary_size_mib = f'_Previously {previous_size:.2f} MiB'
+            previous_binary_size_mib = f'_Previously {previous_size:.2f} MiB_'
         blocks.append(
             {
                 'type': 'context',


### PR DESCRIPTION
## Describe your changes
Updates the propagator plugin manager so that it only lists and downloads plugins that are
compatible with the current version of the binary. This is only needed for Go plugins, until we have
resolved the issues with cross-version compatibility. Other, external plugins like GPU, streamer are always
listed/downloaded latest. Even for external plugins, in the future, this would allow us to bind the binary to a compatible
version if there are breaking changes in the future.

Requires: https://github.com/cedana/cedana-propagator/pull/24

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.