### PR TITLE
fix: config error handling

### DIFF
--- a/internal/server/gpu/controller.go
+++ b/internal/server/gpu/controller.go
@@ -133,6 +133,11 @@ func (m *controllers) spawnAsync(
 		Credential: user,
 	}
 	controller.Cancel = func() error { return controller.Cmd.Process.Signal(syscall.SIGTERM) } // NO SIGKILL!!!
+	controller.Env = append(
+		os.Environ(),
+		"CEDANA_URL="+config.Global.Connection.URL,
+		"CEDANA_AUTH_TOKEN="+config.Global.Connection.AuthToken,
+	)
 
 	err = controller.Start()
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -13,7 +14,7 @@ import (
 const (
 	DIR_NAME   = ".cedana"
 	FILE_NAME  = "config"
-	FILE_TYPE  = "yaml"
+	FILE_TYPE  = "json"
 	DIR_PERM   = 0o755
 	FILE_PERM  = 0o644
 	ENV_PREFIX = "CEDANA"
@@ -51,7 +52,7 @@ var Global Config = Config{
 		Path:   filepath.Join(os.TempDir(), "cedana.db"),
 	},
 	Profiling: Profiling{
-		Enabled:       true,
+		Enabled:   true,
 		Precision: "auto",
 	},
 	Metrics: Metrics{
@@ -115,17 +116,34 @@ func Init(args InitArgs) error {
 	gid, _ := strconv.Atoi(user.Gid)
 	os.Chown(configDir, uid, gid)
 
-	viper.ReadInConfig()
-
-	if args.Config != "" {
-		// we don't save config to file if it's passed as a string, as it's temporary
-		reader := strings.NewReader(args.Config)
-		err = viper.MergeConfig(reader)
-	} else {
-		viper.SafeWriteConfig() // Will only overwrite if file does not exist, ignore error
+	err = viper.ReadInConfig()
+	if err != nil {
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
+			return fmt.Errorf("Config file %s is either outdated or invalid. Please delete or update it: %w", viper.ConfigFileUsed(), err)
+		}
 	}
 
-	return viper.Unmarshal(&Global)
+	if args.Config != "" {
+		reader := strings.NewReader(args.Config)
+		err = viper.MergeConfig(reader)
+		if err != nil {
+			return fmt.Errorf("Provided config string is invalid: %w", err)
+		}
+	} else {
+		err = viper.SafeWriteConfig() // Will only overwrite if file does not exist, ignore other errors
+		if err != nil {
+			if _, ok := err.(viper.ConfigFileAlreadyExistsError); !ok {
+				return fmt.Errorf("Failed to write config file: %w", err)
+			}
+		}
+	}
+
+	err = viper.UnmarshalExact(&Global)
+	if err != nil {
+		return fmt.Errorf("Config file %s is either outdated or invalid. Please delete or update it: %w", viper.ConfigFileUsed(), err)
+	}
+
+	return nil
 }
 
 // Loads the global defaults into viper

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -9,90 +9,90 @@ type (
 	// alternative (alias) environment variable names (comma-separated).
 	Config struct {
 		// Address to use for incoming/outgoing connections
-		Address string `json:"address" mapstructure:"address" yaml:"address"`
+		Address string `json:"address" key:"address" yaml:"address"`
 		// Protocol to use for incoming/outgoing connections (TCP, UNIX, VSOCK)
-		Protocol string `json:"protocol" mapstructure:"protocol" yaml:"protocol"`
+		Protocol string `json:"protocol" key:"protocol" yaml:"protocol"`
 		// LogLevel is the default log level used by the server
-		LogLevel string `json:"log_level" mapstructure:"log_level" yaml:"log_level"`
+		LogLevel string `json:"log_level" key:"log_level" yaml:"log_level"`
 
 		// Connection settings
-		Connection Connection `json:"connection" mapstructure:"connection" yaml:"connection"`
+		Connection Connection `json:"connection" key:"connection" yaml:"connection"`
 		// Checkpoint and storage settings
-		Checkpoint Checkpoint `json:"checkpoint" mapstructure:"checkpoint" yaml:"checkpoint"`
+		Checkpoint Checkpoint `json:"checkpoint" key:"checkpoint" yaml:"checkpoint"`
 		// Database details
-		DB DB `json:"db"         mapstructure:"db" yaml:"db"`
+		DB DB `json:"db" key:"db" yaml:"db"`
 		// Profiling settings
-		Profiling Profiling `json:"profiling" mapstructure:"profiling" yaml:"profiling"`
+		Profiling Profiling `json:"profiling" key:"profiling" yaml:"profiling"`
 		// Metrics settings
-		Metrics Metrics `json:"metrics" mapstructure:"metrics" yaml:"metrics"`
+		Metrics Metrics `json:"metrics" key:"metrics" yaml:"metrics"`
 		// CRIU settings and defaults
-		CRIU CRIU `json:"criu" mapstructure:"criu" yaml:"criu"`
+		CRIU CRIU `json:"criu" key:"criu" yaml:"criu"`
 		// CLI settings
-		CLI CLI `json:"cli" mapstructure:"cli" yaml:"cli"`
+		CLI CLI `json:"cli" key:"cli" yaml:"cli"`
 		// Plugin settings
-		Plugins Plugins `json:"plugins" mapstructure:"plugins" yaml:"plugins"`
+		Plugins Plugins `json:"plugins" key:"plugins" yaml:"plugins"`
 	}
 
 	Connection struct {
 		// URL is your unique Cedana endpoint URL
-		URL string `json:"url"    mapstructure:"url" yaml:"url" env_aliases:"CEDANA_URL"`
+		URL string `json:"url" key:"url" yaml:"url" env_aliases:"CEDANA_URL"`
 		// AuthToken is your authentication token for the Cedana endpoint
-		AuthToken string `json:"auth_token" mapstructure:"auth_token" yaml:"auth_token" env_aliases:"CEDANA_AUTH_TOKEN"`
+		AuthToken string `json:"auth_token" key:"auth_token" yaml:"auth_token" env_aliases:"CEDANA_AUTH_TOKEN"`
 	}
 
 	Checkpoint struct {
 		// Dir is the default directory to store checkpoints
-		Dir string `json:"dir"         mapstructure:"dir" yaml:"dir"`
+		Dir string `json:"dir" key:"dir" yaml:"dir"`
 		// Compression is the default compression algorithm to use for checkpoints
-		Compression string `json:"compression" mapstructure:"compression" yaml:"compression"`
+		Compression string `json:"compression" key:"compression" yaml:"compression"`
 	}
 
 	DB struct {
 		// Remote sets whether to use a remote database
-		Remote bool `json:"remote"      mapstructure:"remote"  yaml:"remote" env_aliases:"CEDANA_REMOTE"`
+		Remote bool `json:"remote" key:"remote"  yaml:"remote" env_aliases:"CEDANA_REMOTE"`
 		// Path is the local path to the database file. E.g. /tmp/cedana.db
-		Path string `json:"path" mapstructure:"path" yaml:"path"`
+		Path string `json:"path" key:"path" yaml:"path"`
 	}
 
 	Profiling struct {
 		// Enabled sets whether to enable and show profiling information
-		Enabled bool `json:"enabled" mapstructure:"enabled" yaml:"enabled"`
+		Enabled bool `json:"enabled" key:"enabled" yaml:"enabled"`
 		// Precision sets the time precision when printing profiling information (auto, ns, us, ms, s)
-		Precision string `json:"precision" mapstructure:"precision" yaml:"precision"`
+		Precision string `json:"precision" key:"precision" yaml:"precision"`
 	}
 
 	Metrics struct {
 		// ASR sets whether to enable ASR metrics
-		ASR bool `json:"asr"  mapstructure:"asr" yaml:"asr"`
+		ASR bool `json:"asr" key:"asr" yaml:"asr"`
 		// Otel sets whether to enable OpenTelemetry metrics
-		Otel bool `json:"otel" mapstructure:"otel" yaml:"otel" env_aliases:"CEDANA_OTEL_ENABLED"`
+		Otel bool `json:"otel" key:"otel" yaml:"otel" env_aliases:"CEDANA_OTEL_ENABLED"`
 	}
 
 	CLI struct {
 		// Wait for ready sets CLI commands to block if the daemon is not up yet
-		WaitForReady bool `json:"wait_for_ready" mapstructure:"wait_for_ready" yaml:"wait_for_ready"`
+		WaitForReady bool `json:"wait_for_ready" key:"wait_for_ready" yaml:"wait_for_ready"`
 	}
 
 	CRIU struct {
 		// BinaryPath is a custom path to the CRIU binary
-		BinaryPath string `json:"binary_path"   mapstructure:"binary_path" yaml:"binary_path"`
+		BinaryPath string `json:"binary_path" key:"binary_path" yaml:"binary_path"`
 		// LeaveRunning sets whether to leave the process running after checkpoint
-		LeaveRunning bool `json:"leave_running" mapstructure:"leave_running" yaml:"leave_running"`
+		LeaveRunning bool `json:"leave_running" key:"leave_running" yaml:"leave_running"`
 	}
 
 	Plugins struct {
 		// BinDir is the directory where plugin binaries are stored
-		BinDir string `json:"bin_dir" mapstructure:"bin_dir" yaml:"bin_dir"`
+		BinDir string `json:"bin_dir" key:"bin_dir" yaml:"bin_dir"`
 		// LibDir is the directory where plugin libraries are stored
-		LibDir string `json:"lib_dir" mapstructure:"lib_dir" yaml:"lib_dir" env_aliases:"CEDANA_PLUGINS_LIB_DIR"`
+		LibDir string `json:"lib_dir" key:"lib_dir" yaml:"lib_dir" env_aliases:"CEDANA_PLUGINS_LIB_DIR"`
 		// GPU is settings for the GPU plugin
-		GPU GPU `json:"gpu"        mapstructure:"gpu" yaml:"gpu"`
+		GPU GPU `json:"gpu" key:"gpu" yaml:"gpu"`
 	}
 
 	GPU struct {
 		// Number of warm GPU controllers to keep in pool
-		PoolSize int `json:"pool_size" mapstructure:"pool_size" yaml:"pool_size"`
+		PoolSize int `json:"pool_size" key:"pool_size" yaml:"pool_size"`
 		// LogDir is the directory to write GPU logs to. By default, logs are written to daemon's stdout
-    LogDir string `json:"log_dir" mapstructure:"log_dir" yaml:"log_dir"`
+		LogDir string `json:"log_dir" key:"log_dir" yaml:"log_dir"`
 	}
 )

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -9,90 +9,90 @@ type (
 	// alternative (alias) environment variable names (comma-separated).
 	Config struct {
 		// Address to use for incoming/outgoing connections
-		Address string `json:"address" key:"address" yaml:"address"`
+		Address string `json:"address" key:"address" yaml:"address" mapstructure:"address"`
 		// Protocol to use for incoming/outgoing connections (TCP, UNIX, VSOCK)
-		Protocol string `json:"protocol" key:"protocol" yaml:"protocol"`
+		Protocol string `json:"protocol" key:"protocol" yaml:"protocol" mapstructure:"protocol"`
 		// LogLevel is the default log level used by the server
-		LogLevel string `json:"log_level" key:"log_level" yaml:"log_level"`
+		LogLevel string `json:"log_level" key:"log_level" yaml:"log_level" mapstructure:"log_level"`
 
 		// Connection settings
-		Connection Connection `json:"connection" key:"connection" yaml:"connection"`
+		Connection Connection `json:"connection" key:"connection" yaml:"connection" mapstructure:"connection"`
 		// Checkpoint and storage settings
-		Checkpoint Checkpoint `json:"checkpoint" key:"checkpoint" yaml:"checkpoint"`
+		Checkpoint Checkpoint `json:"checkpoint" key:"checkpoint" yaml:"checkpoint" mapstructure:"checkpoint"`
 		// Database details
-		DB DB `json:"db" key:"db" yaml:"db"`
+		DB DB `json:"db" key:"db" yaml:"db" mapstructure:"db"`
 		// Profiling settings
-		Profiling Profiling `json:"profiling" key:"profiling" yaml:"profiling"`
+		Profiling Profiling `json:"profiling" key:"profiling" yaml:"profiling" mapstructure:"profiling"`
 		// Metrics settings
-		Metrics Metrics `json:"metrics" key:"metrics" yaml:"metrics"`
+		Metrics Metrics `json:"metrics" key:"metrics" yaml:"metrics" mapstructure:"metrics"`
 		// CRIU settings and defaults
-		CRIU CRIU `json:"criu" key:"criu" yaml:"criu"`
+		CRIU CRIU `json:"criu" key:"criu" yaml:"criu" mapstructure:"criu"`
 		// CLI settings
-		CLI CLI `json:"cli" key:"cli" yaml:"cli"`
+		CLI CLI `json:"cli" key:"cli" yaml:"cli" mapstructure:"cli"`
 		// Plugin settings
-		Plugins Plugins `json:"plugins" key:"plugins" yaml:"plugins"`
+		Plugins Plugins `json:"plugins" key:"plugins" yaml:"plugins" mapstructure:"plugins"`
 	}
 
 	Connection struct {
 		// URL is your unique Cedana endpoint URL
-		URL string `json:"url" key:"url" yaml:"url" env_aliases:"CEDANA_URL"`
+		URL string `json:"url" key:"url" yaml:"url" mapstructure:"url" env_aliases:"CEDANA_URL"`
 		// AuthToken is your authentication token for the Cedana endpoint
-		AuthToken string `json:"auth_token" key:"auth_token" yaml:"auth_token" env_aliases:"CEDANA_AUTH_TOKEN"`
+		AuthToken string `json:"auth_token" key:"auth_token" yaml:"auth_token" mapstructure:"auth_token" env_aliases:"CEDANA_AUTH_TOKEN"`
 	}
 
 	Checkpoint struct {
 		// Dir is the default directory to store checkpoints
-		Dir string `json:"dir" key:"dir" yaml:"dir"`
+		Dir string `json:"dir" key:"dir" yaml:"dir" mapstructure:"dir"`
 		// Compression is the default compression algorithm to use for checkpoints
-		Compression string `json:"compression" key:"compression" yaml:"compression"`
+		Compression string `json:"compression" key:"compression" yaml:"compression" mapstructure:"compression"`
 	}
 
 	DB struct {
 		// Remote sets whether to use a remote database
-		Remote bool `json:"remote" key:"remote"  yaml:"remote" env_aliases:"CEDANA_REMOTE"`
+		Remote bool `json:"remote" key:"remote"  yaml:"remote" mapstructure:"remote" env_aliases:"CEDANA_REMOTE"`
 		// Path is the local path to the database file. E.g. /tmp/cedana.db
-		Path string `json:"path" key:"path" yaml:"path"`
+		Path string `json:"path" key:"path" yaml:"path" mapstructure:"path"`
 	}
 
 	Profiling struct {
 		// Enabled sets whether to enable and show profiling information
-		Enabled bool `json:"enabled" key:"enabled" yaml:"enabled"`
+		Enabled bool `json:"enabled" key:"enabled" yaml:"enabled" mapstructure:"enabled"`
 		// Precision sets the time precision when printing profiling information (auto, ns, us, ms, s)
-		Precision string `json:"precision" key:"precision" yaml:"precision"`
+		Precision string `json:"precision" key:"precision" yaml:"precision" mapstructure:"precision"`
 	}
 
 	Metrics struct {
 		// ASR sets whether to enable ASR metrics
-		ASR bool `json:"asr" key:"asr" yaml:"asr"`
+		ASR bool `json:"asr" key:"asr" yaml:"asr" mapstructure:"asr"`
 		// Otel sets whether to enable OpenTelemetry metrics
-		Otel bool `json:"otel" key:"otel" yaml:"otel" env_aliases:"CEDANA_OTEL_ENABLED"`
+		Otel bool `json:"otel" key:"otel" yaml:"otel" mapstructure:"otel" env_aliases:"CEDANA_OTEL_ENABLED"`
 	}
 
 	CLI struct {
 		// Wait for ready sets CLI commands to block if the daemon is not up yet
-		WaitForReady bool `json:"wait_for_ready" key:"wait_for_ready" yaml:"wait_for_ready"`
+		WaitForReady bool `json:"wait_for_ready" key:"wait_for_ready" yaml:"wait_for_ready" mapstructure:"wait_for_ready"`
 	}
 
 	CRIU struct {
 		// BinaryPath is a custom path to the CRIU binary
-		BinaryPath string `json:"binary_path" key:"binary_path" yaml:"binary_path"`
+		BinaryPath string `json:"binary_path" key:"binary_path" yaml:"binary_path" mapstructure:"binary_path"`
 		// LeaveRunning sets whether to leave the process running after checkpoint
-		LeaveRunning bool `json:"leave_running" key:"leave_running" yaml:"leave_running"`
+		LeaveRunning bool `json:"leave_running" key:"leave_running" yaml:"leave_running" mapstructure:"leave_running"`
 	}
 
 	Plugins struct {
 		// BinDir is the directory where plugin binaries are stored
-		BinDir string `json:"bin_dir" key:"bin_dir" yaml:"bin_dir"`
+		BinDir string `json:"bin_dir" key:"bin_dir" yaml:"bin_dir" mapstructure:"bin_dir"`
 		// LibDir is the directory where plugin libraries are stored
-		LibDir string `json:"lib_dir" key:"lib_dir" yaml:"lib_dir" env_aliases:"CEDANA_PLUGINS_LIB_DIR"`
+		LibDir string `json:"lib_dir" key:"lib_dir" yaml:"lib_dir" mapstructure:"lib_dir" env_aliases:"CEDANA_PLUGINS_LIB_DIR"`
 		// GPU is settings for the GPU plugin
-		GPU GPU `json:"gpu" key:"gpu" yaml:"gpu"`
+		GPU GPU `json:"gpu" key:"gpu" yaml:"gpu" mapstructure:"gpu"`
 	}
 
 	GPU struct {
 		// Number of warm GPU controllers to keep in pool
-		PoolSize int `json:"pool_size" key:"pool_size" yaml:"pool_size"`
+		PoolSize int `json:"pool_size" key:"pool_size" yaml:"pool_size" mapstructure:"pool_size"`
 		// LogDir is the directory to write GPU logs to. By default, logs are written to daemon's stdout
-		LogDir string `json:"log_dir" key:"log_dir" yaml:"log_dir"`
+		LogDir string `json:"log_dir" key:"log_dir" yaml:"log_dir" mapstructure:"log_dir"`
 	}
 )


### PR DESCRIPTION
## Describe your changes
1. If an incompatible old config file is found, a helpful error is thrown on launch.
2. Changes back config type to `json` as it's more easier to work with, especially if passing a
string config using the `--config` flag.
3. Fixes an issue where if CEDANA_URL/TOKEN are only set in the config file, and not the env, it wasn't being passed to the GPU controller.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.