### PR TITLE
fix: Replace all instances of CRIU ExtMountMap (deprecated)

### DIFF
--- a/plugins/runc/internal/device/dump_adapters.go
+++ b/plugins/runc/internal/device/dump_adapters.go
@@ -29,7 +29,7 @@ func AddDevicesForDump(next types.Dump) types.Dump {
 		config := container.Config()
 
 		for _, d := range config.Devices {
-			external := fmt.Sprintf("dev[%d/%d]:%s", d.Minor, d.Major, d.Path) // XXX: Not sure if %d should be %x (hexadecimal)
+			external := fmt.Sprintf("dev[%x/%x]:%s", d.Minor, d.Major, d.Path) // XXX: Not sure if %d should be %x (hexadecimal)
 			req.Criu.External = append(req.Criu.External, external)
 		}
 

--- a/plugins/runc/internal/device/dump_adapters.go
+++ b/plugins/runc/internal/device/dump_adapters.go
@@ -2,14 +2,13 @@ package device
 
 import (
 	"context"
+	"fmt"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 	"github.com/cedana/cedana/pkg/types"
-	"github.com/cedana/cedana/plugins/runc/internal/filesystem"
 	runc_keys "github.com/cedana/cedana/plugins/runc/pkg/keys"
 	"github.com/opencontainers/runc/libcontainer"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )
@@ -28,11 +27,10 @@ func AddDevicesForDump(next types.Dump) types.Dump {
 		}
 
 		config := container.Config()
-		rootfs := config.Rootfs
 
 		for _, d := range config.Devices {
-			m := &configs.Mount{Destination: d.Path, Source: d.Path}
-			filesystem.CriuAddExternalMount(req.Criu, m, rootfs)
+			external := fmt.Sprintf("dev[%d/%d]:%s", d.Minor, d.Major, d.Path) // XXX: Not sure if %d should be %x (hexadecimal)
+			req.Criu.External = append(req.Criu.External, external)
 		}
 
 		return next(ctx, opts, resp, req)

--- a/plugins/runc/internal/device/restore_adapters.go
+++ b/plugins/runc/internal/device/restore_adapters.go
@@ -2,14 +2,13 @@ package device
 
 import (
 	"context"
+	"fmt"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 	"github.com/cedana/cedana/pkg/types"
-	"github.com/cedana/cedana/plugins/runc/internal/filesystem"
 	runc_keys "github.com/cedana/cedana/plugins/runc/pkg/keys"
 	"github.com/opencontainers/runc/libcontainer"
-	"github.com/opencontainers/runc/libcontainer/configs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"google.golang.org/protobuf/proto"
@@ -27,11 +26,10 @@ func AddDevicesForRestore(next types.Restore) types.Restore {
 		}
 
 		config := container.Config()
-		rootfs := config.Rootfs
 
 		for _, node := range config.Devices {
-			m := &configs.Mount{Destination: node.Path, Source: node.Path}
-			filesystem.CriuAddExternalMount(req.Criu, m, rootfs)
+			external := fmt.Sprintf("dev[%s]:%s", node.Path, node.Path)
+			req.Criu.External = append(req.Criu.External, external)
 		}
 
 		return next(ctx, opts, resp, req)

--- a/plugins/runc/internal/filesystem/dump_adapters.go
+++ b/plugins/runc/internal/filesystem/dump_adapters.go
@@ -14,7 +14,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
-	"google.golang.org/protobuf/proto"
 )
 
 const extDescriptorsFilename = "descriptors.json"
@@ -93,11 +92,9 @@ func AddMaskedPathsForDump(next types.Dump) types.Dump {
 				continue
 			}
 
-			extMnt := &criu_proto.ExtMountMap{
-				Key: proto.String(path),
-				Val: proto.String("/dev/null"),
-			}
-			req.Criu.ExtMnt = append(req.Criu.ExtMnt, extMnt)
+			external := fmt.Sprintf("mnt[%s]:%s", path, "/dev/null")
+
+			req.Criu.External = append(req.Criu.External, external)
 		}
 
 		return next(ctx, opts, resp, req)

--- a/plugins/runc/internal/filesystem/helpers.go
+++ b/plugins/runc/internal/filesystem/helpers.go
@@ -1,6 +1,7 @@
 package filesystem
 
 import (
+	"fmt"
 	"path/filepath"
 	"strings"
 
@@ -9,7 +10,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"golang.org/x/sys/unix"
-	"google.golang.org/protobuf/proto"
 )
 
 // IsPathInPrefixList is a small function for CRIU restore to make sure
@@ -29,11 +29,8 @@ func CriuAddExternalMount(opts *criu_proto.CriuOpts, m *configs.Mount, rootfs st
 	if dest, err := securejoin.SecureJoin(rootfs, mountDest); err == nil {
 		mountDest = dest[len(rootfs):]
 	}
-	extMnt := &criu_proto.ExtMountMap{
-		Key: proto.String(mountDest),
-		Val: proto.String(mountDest),
-	}
-	opts.ExtMnt = append(opts.ExtMnt, extMnt)
+	external := fmt.Sprintf("mnt[%s]:%s", mountDest, mountDest)
+	opts.External = append(opts.External, external)
 }
 
 // lifted from libcontainer


### PR DESCRIPTION
## Describe your changes
CRIU's ``--ext-mnt-map`` option is deprecated and will be removed in the future. This PR replaces
all instances of `--ext-mnt-map` with the new `--external` option.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.