### PR TITLE
fix: CRIU logging verbosity

### DIFF
--- a/internal/server/criu/dump_handlers.go
+++ b/internal/server/criu/dump_handlers.go
@@ -20,13 +20,13 @@ const (
 	GHOST_FILE_MAX_SIZE = 10000000 // 10MB
 )
 
-var CRIU_LOG_VERBOSITY_LEVEL int32 = 1
+var CRIU_LOG_VERBOSITY_LEVEL int32 = 1 // errors only
 
 func init() {
 	if log.Logger.GetLevel() <= zerolog.TraceLevel {
 		CRIU_LOG_VERBOSITY_LEVEL = 3 // debug statements
 	} else if log.Logger.GetLevel() <= zerolog.DebugLevel {
-		CRIU_LOG_VERBOSITY_LEVEL = 2 // info statements
+		CRIU_LOG_VERBOSITY_LEVEL = 2 // warning statements
 	}
 }
 

--- a/internal/server/criu/dump_handlers.go
+++ b/internal/server/criu/dump_handlers.go
@@ -24,9 +24,9 @@ var CRIU_LOG_VERBOSITY_LEVEL int32 = 1
 
 func init() {
 	if log.Logger.GetLevel() <= zerolog.TraceLevel {
-		CRIU_LOG_VERBOSITY_LEVEL = 3
+		CRIU_LOG_VERBOSITY_LEVEL = 3 // debug statements
 	} else if log.Logger.GetLevel() <= zerolog.DebugLevel {
-		CRIU_LOG_VERBOSITY_LEVEL = 2
+		CRIU_LOG_VERBOSITY_LEVEL = 2 // info statements
 	}
 }
 

--- a/internal/server/criu/dump_handlers.go
+++ b/internal/server/criu/dump_handlers.go
@@ -16,10 +16,19 @@ import (
 )
 
 const (
-	CRIU_LOG_VERBOSITY_LEVEL = 3
-	CRIU_LOG_FILE            = "criu.log"
-	GHOST_FILE_MAX_SIZE      = 10000000 // 10MB
+	CRIU_LOG_FILE       = "criu.log"
+	GHOST_FILE_MAX_SIZE = 10000000 // 10MB
 )
+
+var CRIU_LOG_VERBOSITY_LEVEL int32 = 1
+
+func init() {
+	if log.Logger.GetLevel() <= zerolog.TraceLevel {
+		CRIU_LOG_VERBOSITY_LEVEL = 3
+	} else if log.Logger.GetLevel() <= zerolog.DebugLevel {
+		CRIU_LOG_VERBOSITY_LEVEL = 2
+	}
+}
 
 var Dump types.Dump = dump
 


### PR DESCRIPTION
## Describe your changes
Noticed that the CRIU logging verbosity significantly slows down a dump, especially when dump a large container
with GPU support. This makes it so that CRIU will only log verbosely if Cedana's logging level is
set to debug/trace.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.