### PR TITLE
fix: External namespace file not being passed in context

### DIFF
--- a/internal/server/process/restore_adapters.go
+++ b/internal/server/process/restore_adapters.go
@@ -144,7 +144,7 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 			}
 		}
 
-		req.Criu.InheritFd = append(req.Criu.InheritFd, inheritFds...)
+		req.Criu.InheritFd = inheritFds
 
 		return next(ctx, opts, resp, req)
 	}

--- a/plugins/runc/internal/namespace/restore_adapters.go
+++ b/plugins/runc/internal/namespace/restore_adapters.go
@@ -107,19 +107,21 @@ func InheritExternalNamespacesForRestore(nsTypes ...configs.NamespaceType) types
 				if err != nil {
 					return nil, status.Errorf(codes.Internal, "external namespace file %s does not exist: %v", nsPath, err)
 				}
+				defer nsFd.Close()
 				extraFiles = append(extraFiles, nsFd)
 
 				criuOpts := req.GetCriu()
 				if criuOpts == nil {
 					criuOpts = &criu_proto.CriuOpts{}
 				}
+
 				criuOpts.InheritFd = append(criuOpts.InheritFd, &criu_proto.InheritFd{
 					Key: proto.String(CriuNsToKey(t)),
 					Fd:  proto.Int32(int32(2 + len(extraFiles))),
 				})
-			}
 
-			ctx = context.WithValue(ctx, keys.EXTRA_FILES_CONTEXT_KEY, extraFiles)
+				ctx = context.WithValue(ctx, keys.EXTRA_FILES_CONTEXT_KEY, extraFiles)
+			}
 
 			return next(ctx, opts, resp, req)
 		}

--- a/test/regression/helpers/runc.bash
+++ b/test/regression/helpers/runc.bash
@@ -70,4 +70,18 @@ create_cmd_bundle() {
     echo "$bundle"
 }
 
+# modifies a bundle to instead use an external namespace
+share_namespace() {
+    local bundle="$1"
+    local type="$2"
+    local path="$3"
+
+    # remove item from namespaces array whose type is the type provided
+    jq "del(.linux.namespaces[] | select(.type == \"$type\"))" "$bundle/config.json" > "$bundle/config.json.tmp"
+
+    # add a new item to the namespaces array, with the same type as the one removed and a path to
+    # the provided path
+    jq ".linux.namespaces += [{\"type\":\"$type\",\"path\":\"$path\"}]" "$bundle/config.json.tmp" > "$bundle/config.json"
+}
+
 setup_rootfs

--- a/test/regression/plugins/runc.bats
+++ b/test/regression/plugins/runc.bats
@@ -168,6 +168,154 @@ load_lib file
     run runc delete "$id"
 }
 
+@test "dump container (external NET namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "network" "/proc/1/ns/net"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "dump container (external PID namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "pid" "/proc/1/ns/pid"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "dump container (external IPC namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "ipc" "/proc/1/ns/ipc"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "dump container (external UTS namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "uts" "/proc/1/ns/uts"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "dump container (external CGROUP namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "cgroup" "/proc/1/ns/cgroup"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "dump container (external ALL namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "network" "/proc/1/ns/net"
+    share_namespace "$bundle" "pid" "/proc/1/ns/pid"
+    share_namespace "$bundle" "ipc" "/proc/1/ns/ipc"
+    share_namespace "$bundle" "uts" "/proc/1/ns/uts"
+    share_namespace "$bundle" "cgroup" "/proc/1/ns/cgroup"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
 ###############
 ### Restore ###
 ###############
@@ -253,4 +401,196 @@ load_lib file
     assert_success
 
     run cedana kill "$jid"
+}
+
+@test "restore container (manage existing job)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external NET namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "network" "/proc/1/ns/net"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external PID namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "pid" "/proc/1/ns/pid"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external IPC namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "ipc" "/proc/1/ns/ipc"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external UTS namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "uts" "/proc/1/ns/uts"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external CGROUP namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "cgroup" "/proc/1/ns/cgroup"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_failure
+
+    assert_output --partial "CRIU does not support joining cgroup namespace"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external ALL namespace)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    share_namespace "$bundle" "network" "/proc/1/ns/net"
+    share_namespace "$bundle" "pid" "/proc/1/ns/pid"
+    share_namespace "$bundle" "ipc" "/proc/1/ns/ipc"
+    share_namespace "$bundle" "uts" "/proc/1/ns/uts"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
 }


### PR DESCRIPTION
## Describe your changes
If a container is using an external namespace, the namespace file needs to be opened by CRIU, so it
can `inherit-fd` it.

Also added tests for runc C/R, if a container has an external namespace or a combination of them.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.