### PR TITLE
fix: External bind mounts on runc restore

### DIFF
--- a/plugins/runc/internal/filesystem/helpers.go
+++ b/plugins/runc/internal/filesystem/helpers.go
@@ -1,11 +1,9 @@
 package filesystem
 
 import (
-	"fmt"
 	"path/filepath"
 	"strings"
 
-	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/opencontainers/runc/libcontainer/cgroups"
 	"github.com/opencontainers/runc/libcontainer/configs"
@@ -23,14 +21,13 @@ func IsPathInPrefixList(path string, prefix []string) bool {
 	return false
 }
 
-// lifted from libcontainer
-func CriuAddExternalMount(opts *criu_proto.CriuOpts, m *configs.Mount, rootfs string) {
-	mountDest := strings.TrimPrefix(m.Destination, rootfs)
-	if dest, err := securejoin.SecureJoin(rootfs, mountDest); err == nil {
-		mountDest = dest[len(rootfs):]
+// Ensures the path is within the rootfs and returns the path relative to the rootfs
+func SecureJoin(rootfs, path string) string {
+	path = strings.TrimPrefix(path, rootfs)
+	if path, err := securejoin.SecureJoin(rootfs, path); err == nil {
+		return path[len(rootfs):]
 	}
-	external := fmt.Sprintf("mnt[%s]:%s", mountDest, mountDest)
-	opts.External = append(opts.External, external)
+	return path
 }
 
 // lifted from libcontainer

--- a/test/regression/helpers/runc.bash
+++ b/test/regression/helpers/runc.bash
@@ -84,4 +84,13 @@ share_namespace() {
     jq ".linux.namespaces += [{\"type\":\"$type\",\"path\":\"$path\"}]" "$bundle/config.json.tmp" > "$bundle/config.json"
 }
 
+add_bind_mount() {
+    local bundle="$1"
+    local src="$2"
+    local dest="$3"
+
+    # add a new item to the mounts array, with the provided source and destination
+    jq ".mounts += [{\"source\":\"$src\",\"destination\":\"$dest\",\"type\":\"bind\",\"options\":[\"rbind\",\"rw\"]}]" "$bundle/config.json" > "$bundle/config.json.tmp"
+}
+
 setup_rootfs

--- a/test/regression/helpers/runc.bash
+++ b/test/regression/helpers/runc.bash
@@ -91,6 +91,8 @@ add_bind_mount() {
 
     # add a new item to the mounts array, with the provided source and destination
     jq ".mounts += [{\"source\":\"$src\",\"destination\":\"$dest\",\"type\":\"bind\",\"options\":[\"rbind\",\"rw\"]}]" "$bundle/config.json" > "$bundle/config.json.tmp"
+
+    mv "$bundle/config.json.tmp" "$bundle/config.json"
 }
 
 setup_rootfs

--- a/test/regression/plugins/runc.bats
+++ b/test/regression/plugins/runc.bats
@@ -650,7 +650,7 @@ load_lib file
     run runc delete "$id"
 }
 
-@test "restore container (external binds mount)" {
+@test "restore container (external bind mounts)" {
     id=$(unix_nano)
     jid=$(unix_nano)
     bundle="$(create_workload_bundle "date-loop.sh")"
@@ -678,7 +678,7 @@ load_lib file
     run runc delete "$id"
 }
 
-@test "restore container (external binds mount and namespaces)" {
+@test "restore container (external bind mounts and namespaces)" {
     id=$(unix_nano)
     jid=$(unix_nano)
     bundle="$(create_workload_bundle "date-loop.sh")"

--- a/test/regression/plugins/runc.bats
+++ b/test/regression/plugins/runc.bats
@@ -316,6 +316,61 @@ load_lib file
     run runc delete "$id"
 }
 
+@test "dump container (external binds mount)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir"
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir2"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "dump container (external binds mount and namespaces)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir"
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir2"
+    share_namespace "$bundle" "network" "/proc/1/ns/net"
+    share_namespace "$bundle" "pid" "/proc/1/ns/pid"
+    share_namespace "$bundle" "ipc" "/proc/1/ns/ipc"
+    share_namespace "$bundle" "uts" "/proc/1/ns/uts"
+    share_namespace "$bundle" "cgroup" "/proc/1/ns/cgroup"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
 ###############
 ### Restore ###
 ###############
@@ -570,6 +625,66 @@ load_lib file
     jid=$(unix_nano)
     bundle="$(create_workload_bundle "date-loop.sh")"
 
+    share_namespace "$bundle" "network" "/proc/1/ns/net"
+    share_namespace "$bundle" "pid" "/proc/1/ns/pid"
+    share_namespace "$bundle" "ipc" "/proc/1/ns/ipc"
+    share_namespace "$bundle" "uts" "/proc/1/ns/uts"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external binds mount)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir"
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir2"
+
+    runc run --bundle "$bundle" "$id" &
+
+    sleep 1
+
+    run cedana manage runc "$id" --jid "$jid" --bundle "$bundle"
+    assert_success
+
+    run cedana dump job "$jid"
+    assert_success
+
+    dump_file=$(echo "$output" | awk '{print $NF}')
+    assert_exists "$dump_file"
+
+    run cedana restore job "$jid"
+    assert_success
+
+    run runc kill "$id" KILL
+    run runc delete "$id"
+}
+
+@test "restore container (external binds mount and namespaces)" {
+    id=$(unix_nano)
+    jid=$(unix_nano)
+    bundle="$(create_workload_bundle "date-loop.sh")"
+
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir"
+    add_bind_mount "$bundle" "$(mktemp -d)" "/random/path/to/dir2"
     share_namespace "$bundle" "network" "/proc/1/ns/net"
     share_namespace "$bundle" "pid" "/proc/1/ns/pid"
     share_namespace "$bundle" "ipc" "/proc/1/ns/ipc"


### PR DESCRIPTION
## Describe your changes
Fixes external bind mounts that got broken due to: https://github.com/cedana/cedana/pull/486.
Also adds additional tests for this scenario.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.