### PR TITLE
fix: Always show latest job state

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -544,7 +544,7 @@ jobs:
 
   helper-image-push:
     name: Push Helper Test Image
-    runs-on: ubicloud-standard-2
+    runs-on: ubicloud-standard-4
     needs: [build]
     if: ${{ !inputs.skip_helper_image_push }}
     steps:

--- a/internal/server/job/job.go
+++ b/internal/server/job/job.go
@@ -189,13 +189,10 @@ func (j *Job) latestState() (state *daemon.ProcessState) {
 		return
 	}
 
-	// Try to fill as much as possible, let it error
-	utils.FillProcessState(context.TODO(), state.PID, state)
-
 	state.Status = "halted"
 	state.IsRunning = false
 
-	// Get latest status and isRunning
+	// Get latest process info
 
 	p, err := process.NewProcess(int32(state.PID))
 	if err != nil {
@@ -217,13 +214,8 @@ func (j *Job) latestState() (state *daemon.ProcessState) {
 		return
 	}
 
-	status, err := p.Status()
-	if err != nil {
-		return
-	}
-
-	state.Status = status[0]
-	state.IsRunning = true
+	// Try to fill rest as much as possible, let it error
+	utils.FillProcessState(context.TODO(), state.PID, state)
 
 	return
 }

--- a/internal/server/job/manager_lazy.go
+++ b/internal/server/job/manager_lazy.go
@@ -153,6 +153,7 @@ func (m *ManagerLazy) Get(jid string) *Job {
 		return nil
 	}
 
+	job.(*Job).SetState(job.(*Job).latestState())
 	if !job.(*Job).GPUEnabled() {
 		job.(*Job).SetGPUEnabled(m.gpus.IsAttached(jid))
 	}
@@ -194,6 +195,7 @@ func (m *ManagerLazy) List(jids ...string) []*Job {
 		if _, ok := jidSet[jid]; len(jids) > 0 && !ok {
 			return true
 		}
+		job.SetState(job.latestState())
 		if !job.GPUEnabled() {
 			job.SetGPUEnabled(m.gpus.IsAttached(jid))
 		}
@@ -224,6 +226,7 @@ func (m *ManagerLazy) ListByHostIDs(hostIDs ...string) []*Job {
 		if _, ok := hostIDSet[hostID]; len(hostIDs) > 0 && !ok {
 			return true
 		}
+		job.SetState(job.latestState())
 		if !job.GPUEnabled() {
 			job.SetGPUEnabled(m.gpus.IsAttached(job.JID))
 		}

--- a/pkg/utils/process.go
+++ b/pkg/utils/process.go
@@ -45,6 +45,8 @@ func FillProcessState(ctx context.Context, pid uint32, state *daemon.ProcessStat
 		return fmt.Errorf("could not get process: %v", err)
 	}
 
+	state.IsRunning = true
+
 	cmdline, err := p.CmdlineWithContext(ctx)
 	if err != nil {
 		errs = append(errs, err)


### PR DESCRIPTION
## Describe your changes
When listing a job, through `cedana ps` for example, the jobs were being returned as is from the
DB/ram. Instead, we should always show the latest state of the job.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.