### PR TITLE
feat: Parallel GPU dump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/cedana/cedana
 go 1.23.0
 
 require (
-	buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-6f030530e3d9.2
-	buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-6f030530e3d9.1
+	buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-0cc145b25d1e.2
+	buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-0cc145b25d1e.1
 	buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2
 	buf.build/gen/go/cedana/cedana/protocolbuffers/go v1.36.3-00000000000000-4d54deb59aa0.1
 	buf.build/gen/go/cedana/criu/protocolbuffers/go v1.36.3-20250123205248-8e8bdecabee9.1

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,8 @@ module github.com/cedana/cedana
 go 1.23.0
 
 require (
-	buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-0cc145b25d1e.2
-	buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-0cc145b25d1e.1
+	buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-3a3f8e393b2b.2
+	buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-3a3f8e393b2b.1
 	buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2
 	buf.build/gen/go/cedana/cedana/protocolbuffers/go v1.36.3-00000000000000-4d54deb59aa0.1
 	buf.build/gen/go/cedana/criu/protocolbuffers/go v1.36.3-20250123205248-8e8bdecabee9.1

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-0cc145b25d1e.2 h1:d2OUuRcLjtQIBt3ISwpgUANeiQCoeC0VHE92IxagBMs=
-buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-0cc145b25d1e.2/go.mod h1:IatGv3g1s3Cbm8LKkYL5huIZGkORXS81UFelSAbtKnI=
-buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-0cc145b25d1e.1 h1:ZWNlHw1OqfKGrOYcf6YhgPUz99brzQDbUt2B1IjGH7c=
-buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-0cc145b25d1e.1/go.mod h1:RoDVyq9Z0G9myjkZI2oQk90AOR/lBBesb+MoxMBcOiw=
+buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-3a3f8e393b2b.2 h1:AiQTnmWuQg2Dcf4UN4DznIrt647xCFNxpaTYqav6FnE=
+buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-3a3f8e393b2b.2/go.mod h1:tHQOLLuGVnFRLsvKLtCRTZEAkt7AvCPP3fbT3Yww3jo=
+buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-3a3f8e393b2b.1 h1:DfHL/JS34o4ESEsFb5mZzPjejIusc9vvrBYXuylcIJ0=
+buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-3a3f8e393b2b.1/go.mod h1:RoDVyq9Z0G9myjkZI2oQk90AOR/lBBesb+MoxMBcOiw=
 buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2 h1:iRLt94w3lZJR8qXlziExK8HXGXpKtKbYF+VpP+YT560=
 buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2/go.mod h1:wvJKo4x/c9J2U97MKkIPKSpYpR5CtoE+jEBPE06brgE=
 buf.build/gen/go/cedana/cedana/protocolbuffers/go v1.36.3-00000000000000-4d54deb59aa0.1 h1:8/JPDysTPGnFA9ptG72cqhv1BLUNLv7TpsFwZhufKcQ=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,7 @@
-buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-6f030530e3d9.2 h1:MGpWxWtn2AvjNUTNUcMy28suVQGVE420uPMx+ttFGpU=
-buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-6f030530e3d9.2/go.mod h1:66lazxgMJ/X1yUlQiZJs8xjIh2k8hSVl9lJYzqesAck=
-buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-6f030530e3d9.1 h1:CuqljsPrTo/yFPuc8cUAbu2tHMWLh8ufNUOTeVKmckQ=
-buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-6f030530e3d9.1/go.mod h1:RoDVyq9Z0G9myjkZI2oQk90AOR/lBBesb+MoxMBcOiw=
+buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-0cc145b25d1e.2 h1:d2OUuRcLjtQIBt3ISwpgUANeiQCoeC0VHE92IxagBMs=
+buf.build/gen/go/cedana/cedana-gpu/grpc/go v1.5.1-00000000000000-0cc145b25d1e.2/go.mod h1:IatGv3g1s3Cbm8LKkYL5huIZGkORXS81UFelSAbtKnI=
+buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-0cc145b25d1e.1 h1:ZWNlHw1OqfKGrOYcf6YhgPUz99brzQDbUt2B1IjGH7c=
+buf.build/gen/go/cedana/cedana-gpu/protocolbuffers/go v1.36.3-00000000000000-0cc145b25d1e.1/go.mod h1:RoDVyq9Z0G9myjkZI2oQk90AOR/lBBesb+MoxMBcOiw=
 buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2 h1:iRLt94w3lZJR8qXlziExK8HXGXpKtKbYF+VpP+YT560=
 buf.build/gen/go/cedana/cedana/grpc/go v1.5.1-00000000000000-4d54deb59aa0.2/go.mod h1:wvJKo4x/c9J2U97MKkIPKSpYpR5CtoE+jEBPE06brgE=
 buf.build/gen/go/cedana/cedana/protocolbuffers/go v1.36.3-00000000000000-4d54deb59aa0.1 h1:8/JPDysTPGnFA9ptG72cqhv1BLUNLv7TpsFwZhufKcQ=

--- a/internal/server/gpu/manager_simple.go
+++ b/internal/server/gpu/manager_simple.go
@@ -22,6 +22,7 @@ import (
 )
 
 const (
+	FREEZE_TIMEOUT  = 20 * time.Second
 	DUMP_TIMEOUT    = 5 * time.Minute
 	RESTORE_TIMEOUT = 5 * time.Minute
 	HEALTH_TIMEOUT  = 30 * time.Second
@@ -145,10 +146,11 @@ func (m *ManagerSimple) Checks() types.Checks {
 func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string, user *syscall.Credential) *criu_client.NotifyCallback {
 	callback := &criu_client.NotifyCallback{Name: "gpu"}
 
-	// Add pre-dump hook for GPU dump. This ensures that the GPU is dumped before
-	// CRIU freezes the process.
+	// Add pre-dump hook for GPU dump. We freeze the GPU controller so we can
+	// do the GPU dump in parallel to CRIU dump.
+	dumpErr := make(chan error, 1)
 	callback.PreDumpFunc = func(ctx context.Context, opts *criu_proto.CriuOpts) error {
-		waitCtx, cancel := context.WithTimeout(ctx, DUMP_TIMEOUT)
+		waitCtx, cancel := context.WithTimeout(ctx, FREEZE_TIMEOUT)
 		defer cancel()
 
 		controller := m.controllers.Get(jid)
@@ -156,13 +158,32 @@ func (m *ManagerSimple) CRIUCallback(lifetime context.Context, jid string, user 
 			return fmt.Errorf("GPU controller not found, is the task still running?")
 		}
 
-		_, err := controller.Dump(waitCtx, &gpu.DumpReq{Dir: opts.GetImagesDir(), LeaveRunning: opts.GetLeaveRunning()})
+		_, err := controller.Freeze(waitCtx, &gpu.FreezeReq{})
 		if err != nil {
-			log.Error().Err(err).Str("JID", jid).Msg("failed to dump GPU")
-			return fmt.Errorf("failed to dump GPU: %v", err)
+			log.Error().Err(err).Str("JID", jid).Msg("failed to freeze GPU")
+			return fmt.Errorf("failed to freeze GPU: %v", err)
 		}
-		log.Info().Str("JID", jid).Msg("GPU dump complete")
+
+		// Begin GPU dump in parallel to CRIU dump
+
+		go func() {
+			defer close(dumpErr)
+			waitCtx, cancel = context.WithTimeout(ctx, DUMP_TIMEOUT)
+			defer cancel()
+
+			_, err := controller.Dump(waitCtx, &gpu.DumpReq{Dir: opts.GetImagesDir()})
+			if err != nil {
+				log.Error().Err(err).Str("JID", jid).Msg("failed to dump GPU")
+				dumpErr <- fmt.Errorf("failed to dump GPU: %v", err)
+			}
+			log.Info().Str("JID", jid).Msg("GPU dump complete")
+		}()
 		return nil
+	}
+
+	// Wait for GPU dump to finish before finalizing the dump
+	callback.PostDumpFunc = func(ctx context.Context, opts *criu_proto.CriuOpts) error {
+		return <-dumpErr
 	}
 
 	// Add pre-restore hook for GPU restore, that begins GPU restore in parallel

--- a/internal/server/job/job.go
+++ b/internal/server/job/job.go
@@ -12,6 +12,7 @@ import (
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	"github.com/cedana/cedana/pkg/criu"
 	"github.com/cedana/cedana/pkg/utils"
+	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/process"
 	"google.golang.org/protobuf/proto"
@@ -211,6 +212,7 @@ func (j *Job) latestState() (state *daemon.ProcessState) {
 		return
 	}
 	if cmdline != state.Cmdline {
+    log.Warn().Str("cmdline", cmdline).Str("state.Cmdline", state.Cmdline).Msg("cmdline != state.Cmdline")
 		return
 	}
 

--- a/internal/server/job/job.go
+++ b/internal/server/job/job.go
@@ -92,13 +92,6 @@ func (j *Job) SetState(state *daemon.ProcessState) {
 	j.proto.State = state
 }
 
-func (j *Job) FillState(ctx context.Context, pid uint32) error {
-	j.Lock()
-	defer j.Unlock()
-
-	return utils.FillProcessState(ctx, pid, j.proto.State)
-}
-
 func (j *Job) GetDetails() *daemon.Details {
 	j.RLock()
 	defer j.RUnlock()

--- a/internal/server/job/job.go
+++ b/internal/server/job/job.go
@@ -12,7 +12,6 @@ import (
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	"github.com/cedana/cedana/pkg/criu"
 	"github.com/cedana/cedana/pkg/utils"
-	"github.com/rs/zerolog/log"
 	"github.com/shirou/gopsutil/v4/host"
 	"github.com/shirou/gopsutil/v4/process"
 	"google.golang.org/protobuf/proto"
@@ -203,16 +202,12 @@ func (j *Job) latestState() (state *daemon.ProcessState) {
 	// Now check if this exact process is running on this
 	// machine. Because, you could simply have another process
 	// running right now with this saved job PID.
-	// This is especially important since the job DB is shared
-	// across multiple machines.
-	// XXX: Cmdline is not a fool-proof check but it's something.
 
-	cmdline, err := p.Cmdline()
+	createTime, err := p.CreateTime()
 	if err != nil {
 		return
 	}
-	if cmdline != state.Cmdline {
-		log.Warn().Str("cmdline", cmdline).Str("state.Cmdline", state.Cmdline).Msg("cmdline != state.Cmdline")
+	if state.StartTime != uint64(createTime) {
 		return
 	}
 

--- a/internal/server/job/manager_lazy.go
+++ b/internal/server/job/manager_lazy.go
@@ -258,10 +258,7 @@ func (m *ManagerLazy) Manage(lifetime context.Context, jid string, pid uint32, e
 
 	// Try to update the process state with the latest information,
 	// Only possible if process is still running, otherwise ignore errors.
-	err := job.FillState(lifetime, pid)
-	if err != nil {
-		log.Warn().Err(err).Str("JID", jid).Str("type", job.GetType()).Uint32("PID", pid).Msg("ignoring: failed to fill process state after manage")
-	}
+	job.SetState(job.latestState())
 
 	m.pending <- action{putJob, jid}
 

--- a/internal/server/job/manager_lazy.go
+++ b/internal/server/job/manager_lazy.go
@@ -153,7 +153,7 @@ func (m *ManagerLazy) Get(jid string) *Job {
 		return nil
 	}
 
-	job.(*Job).SetState(job.(*Job).latestState())
+	job.(*Job).SetState(job.(*Job).LatestState())
 	if !job.(*Job).GPUEnabled() {
 		job.(*Job).SetGPUEnabled(m.gpus.IsAttached(jid))
 	}
@@ -195,7 +195,7 @@ func (m *ManagerLazy) List(jids ...string) []*Job {
 		if _, ok := jidSet[jid]; len(jids) > 0 && !ok {
 			return true
 		}
-		job.SetState(job.latestState())
+		job.SetState(job.LatestState())
 		if !job.GPUEnabled() {
 			job.SetGPUEnabled(m.gpus.IsAttached(jid))
 		}
@@ -226,7 +226,7 @@ func (m *ManagerLazy) ListByHostIDs(hostIDs ...string) []*Job {
 		if _, ok := hostIDSet[hostID]; len(hostIDs) > 0 && !ok {
 			return true
 		}
-		job.SetState(job.latestState())
+		job.SetState(job.LatestState())
 		if !job.GPUEnabled() {
 			job.SetGPUEnabled(m.gpus.IsAttached(job.JID))
 		}
@@ -257,8 +257,8 @@ func (m *ManagerLazy) Manage(lifetime context.Context, jid string, pid uint32, e
 	}
 
 	// Try to update the process state with the latest information,
-	// Only possible if process is still running, otherwise ignore errors.
-	job.SetState(job.latestState())
+	// Only possible if process is still running.
+	job.FillState(lifetime, pid)
 
 	m.pending <- action{putJob, jid}
 

--- a/internal/server/job/manager_lazy.go
+++ b/internal/server/job/manager_lazy.go
@@ -153,7 +153,7 @@ func (m *ManagerLazy) Get(jid string) *Job {
 		return nil
 	}
 
-	job.(*Job).SetState(job.(*Job).LatestState())
+	job.(*Job).SetState(job.(*Job).latestState())
 	if !job.(*Job).GPUEnabled() {
 		job.(*Job).SetGPUEnabled(m.gpus.IsAttached(jid))
 	}
@@ -195,7 +195,7 @@ func (m *ManagerLazy) List(jids ...string) []*Job {
 		if _, ok := jidSet[jid]; len(jids) > 0 && !ok {
 			return true
 		}
-		job.SetState(job.LatestState())
+		job.SetState(job.latestState())
 		if !job.GPUEnabled() {
 			job.SetGPUEnabled(m.gpus.IsAttached(jid))
 		}
@@ -226,7 +226,7 @@ func (m *ManagerLazy) ListByHostIDs(hostIDs ...string) []*Job {
 		if _, ok := hostIDSet[hostID]; len(hostIDs) > 0 && !ok {
 			return true
 		}
-		job.SetState(job.LatestState())
+		job.SetState(job.latestState())
 		if !job.GPUEnabled() {
 			job.SetGPUEnabled(m.gpus.IsAttached(job.JID))
 		}


### PR DESCRIPTION
## Describe your changes
Just like GPU restore, we can also dump GPU parallelly to CRIU dump.

Although, this requires the addition of a `Freeze` RPC call in the controller, so that the barrier
is acquired beforehand, and the actual dump can continue parallelly to the CRIU dump.

Accompanying PRs:
- cedana-api: https://github.com/cedana/cedana-api/pull/57
- cedana-gpu: https://github.com/cedana/cedana-gpu/pull/114

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.