### PR TITLE
fix: runc run race condition on container creation

### DIFF
--- a/plugins/runc/internal/container/run_handlers.go
+++ b/plugins/runc/internal/container/run_handlers.go
@@ -139,6 +139,12 @@ func run(ctx context.Context, opts types.Opts, resp *daemon.RunResp, req *daemon
 	if err != nil {
 		return nil, status.Errorf(codes.Internal, "failed to start container: %v", err)
 	}
+	defer func() {
+		if err != nil {
+			// Don't use cmd.Wait() as it will indefinitely wait for IO to complete
+			cmd.Process.Wait()
+		}
+	}()
 
 	// Wait for PID file to be created, until the process exists
 	utils.WaitForFile(ctx, pidFile, utils.WaitForPid(uint32(cmd.Process.Pid)))

--- a/plugins/runc/internal/container/run_handlers.go
+++ b/plugins/runc/internal/container/run_handlers.go
@@ -140,7 +140,7 @@ func run(ctx context.Context, opts types.Opts, resp *daemon.RunResp, req *daemon
 		return nil, status.Errorf(codes.Internal, "failed to start container: %v", err)
 	}
 
-	// Wait for PID file to be created
+	// Wait for PID file to be created, until the process exists
 	utils.WaitForFile(ctx, pidFile, utils.WaitForPid(uint32(cmd.Process.Pid)))
 
 	// Capture logs from runc

--- a/plugins/runc/internal/container/run_handlers.go
+++ b/plugins/runc/internal/container/run_handlers.go
@@ -33,9 +33,9 @@ import (
 const (
 	RUNC_BINARY    = "runc"
 	RUNC_LOG_FILE  = "runc.log"
-	RUNC_LOG_DEBUG = true
+	RUNC_LOG_DEBUG = false
 
-	waitForRunErrTimeout = 500 * time.Millisecond
+	waitForRunErrTimeout = 2 * time.Second
 )
 
 type RuncState struct {
@@ -88,17 +88,21 @@ func run(ctx context.Context, opts types.Opts, resp *daemon.RunResp, req *daemon
 	log.Trace().Interface("spec", spec).Str("runc", id).Msg("updated spec, backing up old spec")
 	defer runc.RestoreSpec(configFile)
 
-	os.Remove(RUNC_LOG_FILE)
+	logFile := filepath.Join(bundle, RUNC_LOG_FILE)
+	pidFile := filepath.Join(os.TempDir(), fmt.Sprintf("%s.pid", id))
+	os.Remove(logFile)
+	os.Remove(pidFile)
 
 	cmd := exec.CommandContext(ctx,
 		RUNC_BINARY,
 		fmt.Sprintf("--root=%s", root),
-		fmt.Sprintf("--log=%s", RUNC_LOG_FILE),
+		fmt.Sprintf("--log=%s", logFile),
 		fmt.Sprintf("--log-format=%s", "json"),
 		fmt.Sprintf("--debug=%t", RUNC_LOG_DEBUG),
 		"run", "--detach",
 		fmt.Sprintf("--no-pivot=%t", noPivot),
 		fmt.Sprintf("--no-new-keyring=%t", noNewKeyring),
+		fmt.Sprintf("--pid-file=%s", pidFile),
 		id,
 	)
 	cmd.SysProcAttr = &syscall.SysProcAttr{
@@ -132,21 +136,22 @@ func run(ctx context.Context, opts types.Opts, resp *daemon.RunResp, req *daemon
 	}
 
 	err = cmd.Start()
+	if err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to start container: %v", err)
+	}
 
-	time.Sleep(waitForRunErrTimeout)
+	// Wait for PID file to be created
+	utils.WaitForFile(ctx, pidFile, utils.WaitForPid(uint32(cmd.Process.Pid)))
 
 	// Capture logs from runc
 	lastMsg := utils.LogFromFile(
 		log.With().
 			Str("spec", spec.Version).
 			Logger().WithContext(ctx),
-		filepath.Join(RUNC_LOG_FILE),
+		logFile,
 		zerolog.TraceLevel,
 		RuncLogMsgToString,
 	)
-	if err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to start container: %v: %s", err, lastMsg)
-	}
 
 	container, err := libcontainer.Load(root, id)
 	if err != nil {

--- a/plugins/runc/internal/container/run_handlers.go
+++ b/plugins/runc/internal/container/run_handlers.go
@@ -183,7 +183,7 @@ func run(ctx context.Context, opts types.Opts, resp *daemon.RunResp, req *daemon
 		code := status.ExitCode()
 		log.Debug().Uint8("code", uint8(code)).Msg("runc container exited")
 
-		cmd.Wait()
+		cmd.Wait() // IO should be complete by now
 		container.Destroy()
 
 		exitCode <- code

--- a/test/workloads/bundle/config.json
+++ b/test/workloads/bundle/config.json
@@ -2,7 +2,7 @@
   "ociVersion": "1.0.2-dev",
   "process": {
     "user": { "uid": 0, "gid": 0 },
-    "args": ["/bi/sh", "-c", "while true; do date; sleep 1; done"],
+    "args": ["/bin/sh", "-c", "while true; do date; sleep 1; done"],
     "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm"],
     "cwd": "/",
     "capabilities": {

--- a/test/workloads/bundle/config.json
+++ b/test/workloads/bundle/config.json
@@ -2,7 +2,7 @@
   "ociVersion": "1.0.2-dev",
   "process": {
     "user": { "uid": 0, "gid": 0 },
-    "args": ["/bin/sh", "-c", "while true; do date; sleep 1; done"],
+    "args": ["/bi/sh", "-c", "while true; do date; sleep 1; done"],
     "env": ["PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin", "TERM=xterm"],
     "cwd": "/",
     "capabilities": {


### PR DESCRIPTION
## Describe your changes
Since `cmd.Start` starts the process in the background, we need to wait for sometime before the
container is actually created, before proceeding. Similarly, if the cmd.Start fails, we need to
wait for some time until the process has actually exited before returning an error.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.