### PR TITLE
fix: Add cedana-shim-runc-v2 binary to k8s plugin

### DIFF
--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -58,6 +58,6 @@ var Registry = []Plugin{
 		Name:      "k8s",
 		Type:      SUPPORTED,
 		Libraries: []Binary{{Name: "libcedana-k8s.so"}},
-		Binaries:  []Binary{}, // TODO: add containerd shim binary
+		Binaries:  []Binary{{Name: "cedana-shim-runc-v2"}},
 	},
 }


### PR DESCRIPTION
## Describe your changes
Adds the shim binary to list of binaries for k8s plugin.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.