### PR TITLE
fix: Don't install unsupported plugin

### DIFF
--- a/pkg/plugins/manager_propagator.go
+++ b/pkg/plugins/manager_propagator.go
@@ -143,7 +143,9 @@ func (m *PropagatorManager) Install(names []string) (chan int, chan string, chan
 
 	availableSet := make(map[string]*Plugin)
 	for _, plugin := range list {
-		availableSet[plugin.Name] = &plugin
+		if plugin.Status == AVAILABLE || plugin.Status == OUTDATED {
+			availableSet[plugin.Name] = &plugin
+		}
 	}
 
 	installList := make([]string, 0, len(names))

--- a/scripts/host/k8s-install-plugins.sh
+++ b/scripts/host/k8s-install-plugins.sh
@@ -13,6 +13,7 @@ DIR="$( cd -P "$( dirname "$SOURCE"  )" >/dev/null 2>&1 && pwd  )"
 
 source "$DIR"/utils.sh
 
+# NOTE: Assuming Go plugins like k8s, runc, containerd, etc are already built with the image
 PLUGINS="criu" # bare minimum plugins required for k8s
 
 # if gpu driver present then add gpu plugin

--- a/scripts/host/k8s-install-plugins.sh
+++ b/scripts/host/k8s-install-plugins.sh
@@ -13,7 +13,7 @@ DIR="$( cd -P "$( dirname "$SOURCE"  )" >/dev/null 2>&1 && pwd  )"
 
 source "$DIR"/utils.sh
 
-PLUGINS="criu runc k8s containerd" # bare minimum plugins required for k8s
+PLUGINS="criu" # bare minimum plugins required for k8s
 
 # if gpu driver present then add gpu plugin
 if [ -d /proc/driver/nvidia/gpus/ ]; then


### PR DESCRIPTION
## Describe your changes
`cedana plugin list` would show this following warning if a plugin a supported plugin is not
available for the current binary version. E.g. here the k8s plugin is not available:
![image](https://github.com/user-attachments/assets/b80111cb-b2ee-4ac7-9c2d-46e314e0abae)

However, when you would do `cedana install k8s` it would still download the latest one and install
it. This PR fixes it.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.