### PR TITLE
fix: don't wait if streamer exits early on error

### DIFF
--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -181,6 +181,7 @@ func NewStreamingFs(
 			log.Trace().Err(err).Msg("streamer Wait()")
 		}
 		log.Trace().Int("code", cmd.ProcessState.ExitCode()).Msg("streamer exited")
+    ready <- false
 
 		// FIXME: Remove socket files. Should be cleaned up by the streamer itself
 		matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))

--- a/internal/server/streamer/fs.go
+++ b/internal/server/streamer/fs.go
@@ -146,6 +146,7 @@ func NewStreamingFs(
 	}
 
 	ready := make(chan bool, 1)
+  exited := make(chan bool, 1)
 	defer close(ready)
 
 	// Mark ready when we read init progress message on stderr
@@ -175,13 +176,13 @@ func NewStreamingFs(
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
+    defer close(exited)
 
 		err := cmd.Wait()
 		if err != nil {
 			log.Trace().Err(err).Msg("streamer Wait()")
 		}
 		log.Trace().Int("code", cmd.ProcessState.ExitCode()).Msg("streamer exited")
-    ready <- false
 
 		// FIXME: Remove socket files. Should be cleaned up by the streamer itself
 		matches, err := filepath.Glob(filepath.Join(dir, "*.sock"))
@@ -198,6 +199,7 @@ func NewStreamingFs(
 	case <-time.After(CONNECTION_TIMEOUT):
 		return nil, nil, fmt.Errorf("timed out waiting for streamer to start")
 	case <-ready:
+  case <-exited:
 	}
 
 	// Connect to the streamer


### PR DESCRIPTION
## Describe your changes
If the streamer failed to spawn, we were waiting for the entire timeout before returning an error.
This change makes it so that we return an error immediately if the streamer exits early.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.