### PR TITLE
GPU VRAM utilization

### DIFF
--- a/internal/server/gpu/controller.go
+++ b/internal/server/gpu/controller.go
@@ -108,9 +108,14 @@ func (m *controllers) spawnAsync(
 		return fmt.Errorf("failed to get free port: %w", err)
 	}
 
+	observability := ""
+	if config.Global.GPU.Observability {
+		observability = "--observability"
+	}
+
 	controller := &controller{
 		ErrBuf: &bytes.Buffer{},
-		Cmd:    exec.CommandContext(lifetime, binary, jid, "--port", strconv.Itoa(port)),
+		Cmd:    exec.CommandContext(lifetime, binary, jid, "--port", strconv.Itoa(port), observability),
 	}
 
 	controller.Stderr = controller.ErrBuf

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -90,6 +90,8 @@ type (
 		PoolSize int `json:"pool_size" key:"pool_size" yaml:"pool_size" mapstructure:"pool_size"`
 		// LogDir is the directory to write GPU logs to. By default, logs are written to daemon's stdout
 		LogDir string `json:"log_dir" key:"log_dir" yaml:"log_dir" mapstructure:"log_dir"`
+		// Track metrics associated with observability
+		Observability bool `json:"observability" key:"observability" yaml:"observability" mapstructure:"observability`
 	}
 
 	Plugins struct {


### PR DESCRIPTION
## Describe your changes
We do not have a tool that automates migration detection when a GPU is being underutilized, and this is the beginnings of one. We collect VRAM data in the form of allocations (cuMemAlloc) and frees (cuMemFree) in a file for visualizations. Later, this will be communicated to daemon at regular intervals.

<img width="1512" alt="example" src="https://github.com/user-attachments/assets/cea7bc0e-7126-41d5-9fb7-164a4ade7526" />

Related: [GPU controller #127](https://github.com/cedana/cedana-gpu/pull/127)

## Checklist before requesting a review
- [X] Have I performed a self-review?
- [X] Have I added regression or unit tests (where it makes sense) for my changes? N/A
- [ ] Have I updated the README if changes have resulted in it being out of date? This feature is WIP, not exposing to users yet.
- [X] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. No.
