### PR TITLE
feat: Add criu/cuda plugin

### DIFF
--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -4,13 +4,13 @@
 
 1. Create an account with Cedana, to get access to the GPU plugin. See [authentication](../../get-started/authentication.md).
 2. Set the Cedana URL & authentication token in the [configuration](../../get-started/configuration.md).
-3. Install the GPU plugin with `sudo cedana plugin install gpu`.
+3. Install the GPU plugin with `sudo cedana plugin install gpu`. The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, you may instead install CRIU's CUDA plugin with `sudo cedana plugin install criu/cuda`.
 4. Ensure the daemon is running, see [installation](../../get-started/installation.md).
 5. Do a health check to ensure the plugin is ready, see [health checks](../../get-started/health.md).
 
-## Usage
+## Usage [Cedana GPU plugin]
 
-**NOTE**: GPU checkpoint/restore is only possible for managed processes/containers, i.e., those that are spawned using `cedana run` (see [managed process/container](../managed.md)).
+**NOTE**: Cedana GPU checkpoint/restore is only possible for managed processes/containers, i.e., those that are spawned using `cedana run --gpu-enabled` (see [managed process/container](../managed.md)).
 
 1. You may clone the [cedana-samples repository](https://github.com/cedana/cedana-samples) for some example GPU workloads.
 2. Run a process with GPU support:
@@ -30,5 +30,9 @@ cedana dump job <job_id>
 ```sh
 cedana restore job --attach <job_id>
 ```
+
+## Usage [CRIU CUDA plugin]
+
+You can checkpoint/restore normally as you do for CPU workloads. See [checkpoint/restore basics](../cr.md).
 
 For all available CLI options, see [CLI reference](../../references/cli/cedana.md). Directly interacting with daemon is also possible through gRPC, see [API reference](../../references/api.md).

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -10,11 +10,9 @@
 
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
 
-    __Minimum NVIDIA driver version: 452.39 (API 11.8)__
-
-    __Maximum NVIDIA driver API version: 12.4 (12.8 works but unstable)__
-
-    __Minimum CRIU version: 3.0__
+    _Minimum NVIDIA driver version: 452.39 (API 11.8)_
+    _Maximum NVIDIA driver API version: 12.4 (12.8 works but unstable)_
+    _Minimum CRIU version: 3.0_
 
     ```sh
     sudo cedana plugin install gpu
@@ -22,9 +20,7 @@
   - **Option 2: CRIU CUDA Plugin**
 
     __Minimum NVIDIA driver version: 570.65 (API 12.8)__
-
     __Minimum CRIU version: 4.0__
-
     ```sh
     sudo cedana plugin install criu/cuda
     ```

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -13,12 +13,14 @@
     - _Maximum NVIDIA driver version: 550 (API 12.4). Newer drivers are unstable and may not work._
     - _Minimum CRIU version: 3.0_
 
+
     ```sh
     sudo cedana plugin install gpu
     ```
   - **Option 2: CRIU CUDA Plugin**
     - _Minimum NVIDIA driver version: 570 (API 12.8)_
     - _Minimum CRIU version: 4.0. Or, simply [install CRIU plugin](../../get-started/installation.md#install-criu)._
+
 
     ```sh
     sudo cedana plugin install criu/cuda

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -11,7 +11,9 @@
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
 
     _Minimum NVIDIA driver version: 452.39 (API 11.8)_
+
     _Maximum NVIDIA driver API version: 12.4 (12.8 works but unstable)_
+
     _Minimum CRIU version: 3.0_
 
     ```sh
@@ -19,8 +21,9 @@
     ```
   - **Option 2: CRIU CUDA Plugin**
 
-    __Minimum NVIDIA driver version: 570.65 (API 12.8)__
-    __Minimum CRIU version: 4.0__
+    _Minimum NVIDIA driver version: 570.65 (API 12.8)_
+
+    _Minimum CRIU version: 4.0_
     ```sh
     sudo cedana plugin install criu/cuda
     ```

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -9,15 +9,22 @@
   - **Option 1: GPU Plugin**
 
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
+
     __Minimum NVIDIA driver version: 452.39 (API 11.8)__
+
     __Maximum NVIDIA driver API version: 12.4 (12.8 works but unstable)__
+
     __Minimum CRIU version: 3.0__
+
     ```sh
     sudo cedana plugin install gpu
     ```
   - **Option 2: CRIU CUDA Plugin**
+
     __Minimum NVIDIA driver version: 570.65 (API 12.8)__
+
     __Minimum CRIU version: 4.0__
+
     ```sh
     sudo cedana plugin install criu/cuda
     ```

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -8,7 +8,7 @@
 4. Ensure the daemon is running, see [installation](../../get-started/installation.md).
 5. Do a health check to ensure the plugin is ready, see [health checks](../../get-started/health.md).
 
-## Usage [Cedana GPU plugin]
+## Usage (GPU plugin)
 
 **NOTE**: Cedana GPU checkpoint/restore is only possible for managed processes/containers, i.e., those that are spawned using `cedana run --gpu-enabled` (see [managed process/container](../managed.md)).
 
@@ -31,7 +31,7 @@ cedana dump job <job_id>
 cedana restore job --attach <job_id>
 ```
 
-## Usage [CRIU CUDA plugin]
+## Usage (CRIU CUDA plugin)
 
 You can checkpoint/restore normally as you do for CPU workloads. See [checkpoint/restore basics](../cr.md).
 

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -22,7 +22,9 @@
     sudo cedana plugin install criu/cuda
     ```
     - _Minimum NVIDIA driver version: 570 (API 12.8)_
-    - _Minimum CRIU version: 4.0. Or, simply [install CRIU plugin](../../get-started/installation.md#install-criu)._
+    - _Minimum CRIU version: 4.0_
+
+    Also, check out [installing CRIU](../../get-started/installation.md#install-criu).
 
 4. Ensure the daemon is running, see [installation](../../get-started/installation.md).
 5. Do a health check to ensure the plugin is ready, see [health checks](../../get-started/health.md).

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -4,7 +4,8 @@
 
 1. Create an account with Cedana, to get access to the GPU plugin. See [authentication](../../get-started/authentication.md).
 2. Set the Cedana URL & authentication token in the [configuration](../../get-started/configuration.md).
-3. Install a GPU plugin with `sudo cedana plugin install gpu`. 
+3. Install a GPU plugin:
+
   - **Option 1: GPU Plugin**
 
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -9,21 +9,17 @@
   - **Option 1: GPU Plugin**
 
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
-
-    _Minimum NVIDIA driver version: 452.39 (API 11.8)_
-
-    _Maximum NVIDIA driver API version: 12.4 (12.8 works but unstable)_
-
-    _Minimum CRIU version: 3.0_
+    - _Minimum NVIDIA driver version: 452.39 (API 11.8)_
+    - _Maximum NVIDIA driver version: 550 (API 12.4). Newer drivers are unstable and may not work._
+    - _Minimum CRIU version: 3.0_
 
     ```sh
     sudo cedana plugin install gpu
     ```
   - **Option 2: CRIU CUDA Plugin**
+    - _Minimum NVIDIA driver version: 570.65 (API 12.8)_
+    - _Minimum CRIU version: 4.0_
 
-    _Minimum NVIDIA driver version: 570.65 (API 12.8)_
-
-    _Minimum CRIU version: 4.0_
     ```sh
     sudo cedana plugin install criu/cuda
     ```

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -5,12 +5,14 @@
 1. Create an account with Cedana, to get access to the GPU plugin. See [authentication](../../get-started/authentication.md).
 2. Set the Cedana URL & authentication token in the [configuration](../../get-started/configuration.md).
 3. Install a GPU plugin with `sudo cedana plugin install gpu`. 
-  - Option 1: GPU Plugin
+  - **Option 1: GPU Plugin**
+
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
     ```sh
     sudo cedana plugin install gpu
     ```
-  - Option 2: CRIU CUDA Plugin
+  - **Option 2: CRIU CUDA Plugin**
+
     ```sh
     sudo cedana plugin install criu/cuda
     ```

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -9,7 +9,7 @@
   - **Option 1: GPU Plugin**
 
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
-    - _Minimum NVIDIA driver version: 452.39 (API 11.8)_
+    - _Minimum NVIDIA driver version: 452 (API 11.8)_
     - _Maximum NVIDIA driver version: 550 (API 12.4). Newer drivers are unstable and may not work._
     - _Minimum CRIU version: 3.0_
 
@@ -17,8 +17,8 @@
     sudo cedana plugin install gpu
     ```
   - **Option 2: CRIU CUDA Plugin**
-    - _Minimum NVIDIA driver version: 570.65 (API 12.8)_
-    - _Minimum CRIU version: 4.0_
+    - _Minimum NVIDIA driver version: 570 (API 12.8)_
+    - _Minimum CRIU version: 4.0. Or, simply [install CRIU plugin](../../get-started/installation.md#install-criu)._
 
     ```sh
     sudo cedana plugin install criu/cuda

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -8,23 +8,22 @@
 
   - **Option 1: GPU Plugin**
 
+    ```sh
+    sudo cedana plugin install gpu
+    ```
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
     - _Minimum NVIDIA driver version: 452 (API 11.8)_
     - _Maximum NVIDIA driver version: 550 (API 12.4). Newer drivers are unstable and may not work._
     - _Minimum CRIU version: 3.0_
 
-
-    ```sh
-    sudo cedana plugin install gpu
-    ```
   - **Option 2: CRIU CUDA Plugin**
-    - _Minimum NVIDIA driver version: 570 (API 12.8)_
-    - _Minimum CRIU version: 4.0. Or, simply [install CRIU plugin](../../get-started/installation.md#install-criu)._
-
 
     ```sh
     sudo cedana plugin install criu/cuda
     ```
+    - _Minimum NVIDIA driver version: 570 (API 12.8)_
+    - _Minimum CRIU version: 4.0. Or, simply [install CRIU plugin](../../get-started/installation.md#install-criu)._
+
 4. Ensure the daemon is running, see [installation](../../get-started/installation.md).
 5. Do a health check to ensure the plugin is ready, see [health checks](../../get-started/health.md).
 

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -1,5 +1,7 @@
 # Checkpoint/restore with GPUs
 
+Checkpoint/restore with GPUs is currently only supported for NVIDIA GPUs.
+
 ## Prerequisites
 
 1. Create an account with Cedana, to get access to the GPU plugin. See [authentication](../../get-started/authentication.md).

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -4,7 +4,16 @@
 
 1. Create an account with Cedana, to get access to the GPU plugin. See [authentication](../../get-started/authentication.md).
 2. Set the Cedana URL & authentication token in the [configuration](../../get-started/configuration.md).
-3. Install the GPU plugin with `sudo cedana plugin install gpu`. The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, you may instead install CRIU's CUDA plugin with `sudo cedana plugin install criu/cuda`.
+3. Install a GPU plugin with `sudo cedana plugin install gpu`. 
+  - Option 1: GPU Plugin
+    The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
+    ```sh
+    sudo cedana plugin install gpu
+    ```
+  - Option 2: CRIU CUDA Plugin
+    ```sh
+    sudo cedana plugin install criu/cuda
+    ```
 4. Ensure the daemon is running, see [installation](../../get-started/installation.md).
 5. Do a health check to ensure the plugin is ready, see [health checks](../../get-started/health.md).
 

--- a/docs/guides/gpu/cr.md
+++ b/docs/guides/gpu/cr.md
@@ -9,11 +9,15 @@
   - **Option 1: GPU Plugin**
 
     The GPU plugin is Cedana's proprietary plugin for high performance GPU checkpoint/restore. If unavailable to you, check option 2.
+    __Minimum NVIDIA driver version: 452.39 (API 11.8)__
+    __Maximum NVIDIA driver API version: 12.4 (12.8 works but unstable)__
+    __Minimum CRIU version: 3.0__
     ```sh
     sudo cedana plugin install gpu
     ```
   - **Option 2: CRIU CUDA Plugin**
-
+    __Minimum NVIDIA driver version: 570.65 (API 12.8)__
+    __Minimum CRIU version: 4.0__
     ```sh
     sudo cedana plugin install criu/cuda
     ```

--- a/internal/server/criu/checks_cuda.go
+++ b/internal/server/criu/checks_cuda.go
@@ -1,0 +1,110 @@
+package criu
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/criu"
+	"github.com/cedana/cedana/pkg/plugins"
+	"github.com/cedana/cedana/pkg/types"
+)
+
+const (
+	CRIU_MIN_VERSION_FOR_CUDA = 40000
+	CRIU_MIN_CUDA_VERSION     = 570
+)
+
+func CheckCudaDriverVersion() types.Check {
+	return func(ctx context.Context) (res []*daemon.HealthCheckComponent) {
+		component := &daemon.HealthCheckComponent{Name: "driver version"}
+		res = append(res, component)
+
+		cmd := exec.Command("nvidia-smi")
+		output, err := cmd.CombinedOutput()
+		if err != nil {
+			component.Errors = append(component.Errors, fmt.Sprintf("Failed to run nvidia-smi: %s", err))
+			return
+		}
+
+		re := regexp.MustCompile(`Driver Version: ([\d.]+)`)
+		match := re.FindStringSubmatch(string(output))
+
+		if len(match) < 2 {
+			component.Errors = append(component.Errors, "Failed to parse nvidia-smi output")
+			return
+		}
+
+		version := match[1]
+
+		if len(strings.Split(version, ".")) != 3 {
+			component.Errors = append(component.Errors, "Failed to parse nvidia-smi output")
+			return
+		}
+
+		baseVersionStr := strings.Split(version, ".")[0]
+
+		baseVersion, err := strconv.Atoi(baseVersionStr)
+		if err != nil {
+			component.Errors = append(component.Errors, fmt.Sprintf("Failed to parse driver version: %s", err))
+			return
+		}
+
+		component.Data = version
+
+		if baseVersion < CRIU_MIN_CUDA_VERSION {
+			component.Errors = append(component.Errors, fmt.Sprintf("Driver version %s is not supported. Minimum supported is %d", version, CRIU_MIN_CUDA_VERSION))
+		}
+
+		return
+	}
+}
+
+func CheckCriuForCuda(manager plugins.Manager) types.Check {
+	return func(ctx context.Context) []*daemon.HealthCheckComponent {
+		c := criu.MakeCriu()
+
+		component := &daemon.HealthCheckComponent{Name: "criu version"}
+
+		// Check if CRIU plugin is installed, then use that binary
+		var p *plugins.Plugin
+		installed := true
+		if p = manager.Get("criu"); !p.IsInstalled() {
+			// Set custom path if specified in config, as a fallback
+			if custom_path := config.Global.CRIU.BinaryPath; custom_path != "" {
+				c.SetCriuPath(custom_path)
+			} else if path, err := exec.LookPath("criu"); err == nil {
+				c.SetCriuPath(path)
+			} else {
+				installed = false
+				component.Errors = append(component.Errors,
+					"CRIU plugin is not installed. This is required for CUDA C/R.",
+				)
+			}
+		} else {
+			c.SetCriuPath(p.Binaries[0].Name)
+		}
+
+		if installed {
+			version, err := c.GetCriuVersion(ctx)
+			if err == nil {
+				component.Data = strconv.Itoa(version)
+				if version < CRIU_MIN_VERSION_FOR_CUDA {
+					component.Errors = append(component.Errors,
+						fmt.Sprintf("Version %d is not supported for CUDA C/R. Minimum supported is %d", version, CRIU_MIN_VERSION),
+					)
+				}
+			} else {
+				component.Data = "unknown"
+				component.Errors = append(component.Errors, fmt.Sprintf("Failed to get version: %v", err))
+			}
+		}
+
+		return []*daemon.HealthCheckComponent{component}
+	}
+}

--- a/internal/server/healthcheck.go
+++ b/internal/server/healthcheck.go
@@ -39,6 +39,17 @@ func (s *Server) HealthCheck(ctx context.Context, req *daemon.HealthCheckReq) (*
 func (s *Server) pluginChecklist() types.Checklist {
 	checklist := []types.Checks{}
 
+	// Add a criu/cuda health check if plugin is installed
+	if s.plugins.IsInstalled("criu/cuda") {
+		checklist = append(checklist, types.Checks{
+			Name: "criu/cuda",
+			List: []types.Check{
+				criu.CheckCriuForCuda(s.plugins),
+				criu.CheckCudaDriverVersion(),
+			},
+		})
+	}
+
 	// Add a GPU health check if plugin is installed
 	if s.plugins.IsInstalled("gpu") {
 		checklist = append(checklist, s.gpus.Checks())

--- a/pkg/plugins/manager_local.go
+++ b/pkg/plugins/manager_local.go
@@ -171,6 +171,7 @@ func (m *LocalManager) Install(names []string) (chan int, chan string, chan erro
 				src := filepath.Join(srcDir, file.Name)
 				var dest string
 				if file.InstallDir != "" {
+					os.MkdirAll(file.InstallDir, os.ModePerm)
 					dest = filepath.Join(file.InstallDir, file.Name)
 				} else {
 					dest = filepath.Join(LibDir, file.Name)
@@ -189,6 +190,7 @@ func (m *LocalManager) Install(names []string) (chan int, chan string, chan erro
 				src := filepath.Join(srcDir, file.Name)
 				var dest string
 				if file.InstallDir != "" {
+					os.MkdirAll(file.InstallDir, os.ModePerm)
 					dest = filepath.Join(file.InstallDir, file.Name)
 				} else {
 					dest = filepath.Join(BinDir, file.Name)

--- a/pkg/plugins/manager_local.go
+++ b/pkg/plugins/manager_local.go
@@ -169,7 +169,12 @@ func (m *LocalManager) Install(names []string) (chan int, chan string, chan erro
 			var err error
 			for _, file := range plugin.Libraries {
 				src := filepath.Join(srcDir, file.Name)
-				dest := filepath.Join(LibDir, file.Name)
+				var dest string
+				if file.InstallDir != "" {
+					dest = filepath.Join(file.InstallDir, file.Name)
+				} else {
+					dest = filepath.Join(LibDir, file.Name)
+				}
 				if s, e := os.Stat(src); e != nil || os.IsNotExist(e) || s.IsDir() {
 					err = fmt.Errorf("No local plugin found")
 					break
@@ -182,7 +187,12 @@ func (m *LocalManager) Install(names []string) (chan int, chan string, chan erro
 			}
 			for _, file := range plugin.Binaries {
 				src := filepath.Join(srcDir, file.Name)
-				dest := filepath.Join(BinDir, file.Name)
+				var dest string
+				if file.InstallDir != "" {
+					dest = filepath.Join(file.InstallDir, file.Name)
+				} else {
+					dest = filepath.Join(BinDir, file.Name)
+				}
 				if s, e := os.Stat(src); e != nil || os.IsNotExist(e) || s.IsDir() {
 					err = fmt.Errorf("No local plugin found")
 					break
@@ -251,14 +261,24 @@ func (m *LocalManager) Remove(names []string) (chan int, chan string, chan error
 
 			// Remove the plugin files from the installation directory
 			for _, file := range plugin.Libraries {
-				dest := filepath.Join(LibDir, file.Name)
+				var dest string
+				if file.InstallDir != "" {
+					dest = filepath.Join(file.InstallDir, file.Name)
+				} else {
+					dest = filepath.Join(LibDir, file.Name)
+				}
 				if e := os.Remove(dest); e != nil {
 					errs <- fmt.Errorf("Failed to remove %s: %w", name, e)
 					break
 				}
 			}
 			for _, file := range plugin.Binaries {
-				dest := filepath.Join(BinDir, file.Name)
+				var dest string
+				if file.InstallDir != "" {
+					dest = filepath.Join(file.InstallDir, file.Name)
+				} else {
+					dest = filepath.Join(BinDir, file.Name)
+				}
 				if e := os.Remove(dest); e != nil {
 					errs <- fmt.Errorf("Failed to remove %s: %w", name, e)
 					break

--- a/pkg/plugins/plugin.go
+++ b/pkg/plugins/plugin.go
@@ -48,8 +48,9 @@ type Plugin struct {
 }
 
 type Binary struct {
-	Name     string `json:"name"`
-	Checksum string `json:"checksum"` // MD5
+	Name       string `json:"name"`
+	Checksum   string `json:"checksum"`     // MD5
+	InstallDir string `json:"install_path"` // Fixed path where the binary must be installed
 }
 
 /////////////////
@@ -122,7 +123,22 @@ func (p *Plugin) SyncVersion() {
 		if !strings.HasPrefix(version, "v") {
 			version = "v" + version
 		}
+	}
 
+	// If still unknown, get version from parent plugin
+	if version == "unknown" {
+		parentName := strings.Split(p.Name, "/")[0]
+		var parent *Plugin
+		for _, plugin := range Registry {
+			if plugin.Name == parentName {
+				parent = &plugin
+				break
+			}
+		}
+		if parent != nil {
+			parent.SyncVersion()
+			version = parent.Version
+		}
 	}
 
 	p.Version = version
@@ -138,7 +154,12 @@ func (p *Plugin) SyncInstalled() {
 	size := int64(0)
 
 	for i, file := range p.Libraries {
-		path := filepath.Join(LibDir, file.Name)
+		var path string
+		if file.InstallDir == "" {
+			path = filepath.Join(LibDir, file.Name)
+		} else {
+			path = filepath.Join(file.InstallDir, file.Name)
+		}
 		if s, err = os.Stat(path); err != nil {
 			continue
 		}
@@ -152,7 +173,12 @@ func (p *Plugin) SyncInstalled() {
 
 	found = 0
 	for i, file := range p.Binaries {
-		path := filepath.Join(BinDir, file.Name)
+		var path string
+		if file.InstallDir == "" {
+			path = filepath.Join(BinDir, file.Name)
+		} else {
+			path = filepath.Join(file.InstallDir, file.Name)
+		}
 		if s, err = os.Stat(path); err != nil {
 			continue
 		}
@@ -172,7 +198,11 @@ func (p *Plugin) SyncInstalled() {
 func (p *Plugin) BinaryPaths() []string {
 	paths := make([]string, len(p.Binaries))
 	for i, bin := range p.Binaries {
-		paths[i] = filepath.Join(BinDir, bin.Name)
+		if bin.InstallDir != "" {
+			paths[i] = filepath.Join(bin.InstallDir, bin.Name)
+		} else {
+			paths[i] = filepath.Join(BinDir, bin.Name)
+		}
 	}
 	return paths
 }
@@ -181,7 +211,11 @@ func (p *Plugin) BinaryPaths() []string {
 func (p *Plugin) LibraryPaths() []string {
 	paths := make([]string, len(p.Libraries))
 	for i, lib := range p.Libraries {
-		paths[i] = filepath.Join(LibDir, lib.Name)
+		if lib.InstallDir != "" {
+			paths[i] = filepath.Join(lib.InstallDir, lib.Name)
+		} else {
+			paths[i] = filepath.Join(LibDir, lib.Name)
+		}
 	}
 	return paths
 }

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -12,6 +12,12 @@ var Registry = []Plugin{
 		Type:     EXTERNAL,
 		Binaries: []Binary{{Name: "criu"}},
 	},
+	{
+		Name:      "criu/cuda",
+		Type:      EXTERNAL,
+		Binaries:  []Binary{{Name: "cuda-checkpoint"}},
+		Libraries: []Binary{{Name: "cuda_plugin.so", InstallDir: "/usr/lib/criu"}},
+	},
 	// TODO: can add hypervisor C/R tools
 
 	// Container runtimes


### PR DESCRIPTION
## Describe your changes
Adds a `criu/cuda` plugin that enables CUDA checkpointing using just CRIU. [Docs have been updated](https://github.com/cedana/cedana/blob/feat/criu-cuda-plugin/docs/guides/gpu/cr.md) for GPU C/R to suggest this as an alternative option.

Also requires this propagator PR for it to be available in the registry: https://github.com/cedana/cedana-propagator/pull/30

A health check component has been added as well:

<img width="971" alt="image" src="https://github.com/user-attachments/assets/fb739e72-da47-464d-b3b9-003e8a2eb02f" />

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.