### PR TITLE
fix: dump dir flag not being recognized

### DIFF
--- a/cmd/dump.go
+++ b/cmd/dump.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cedana/cedana/pkg/keys"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -51,12 +50,6 @@ func init() {
 	dumpCmd.PersistentFlags().
 		BoolP(flags.LinkRemapFlag.Full, flags.LinkRemapFlag.Short, false, "remap links to files in the dump")
 
-	// Bind to config
-	viper.BindPFlag("checkpoint.dir", dumpCmd.PersistentFlags().Lookup(flags.DirFlag.Full))
-	viper.BindPFlag("checkpoint.compression", dumpCmd.PersistentFlags().Lookup(flags.CompressionFlag.Full))
-	viper.BindPFlag("checkpoint.stream", dumpCmd.PersistentFlags().Lookup(flags.StreamFlag.Full))
-	viper.BindPFlag("criu.leave_running", dumpCmd.PersistentFlags().Lookup(flags.LeaveRunningFlag.Full))
-
 	///////////////////////////////////////////
 	// Add subcommands from supported plugins
 	///////////////////////////////////////////
@@ -85,11 +78,11 @@ var dumpCmd = &cobra.Command{
 	Short: "Dump a container/process",
 	Args:  cobra.ArbitraryArgs,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		dir := config.Global.Checkpoint.Dir
+		dir, _ := cmd.Flags().GetString(flags.DirFlag.Full)
 		name, _ := cmd.Flags().GetString(flags.NameFlag.Full)
-		compression := config.Global.Checkpoint.Compression
+		compression, _ := cmd.Flags().GetString(flags.CompressionFlag.Full)
 		stream, _ := cmd.Flags().GetInt32(flags.StreamFlag.Full)
-		leaveRunning := config.Global.CRIU.LeaveRunning
+    leaveRunning, _ := cmd.Flags().GetBool(flags.LeaveRunningFlag.Full)
 		tcpEstablished, _ := cmd.Flags().GetBool(flags.TcpEstablishedFlag.Full)
 		tcpSkipInFlight, _ := cmd.Flags().GetBool(flags.TcpSkipInFlightFlag.Full)
 		fileLocks, _ := cmd.Flags().GetBool(flags.FileLocksFlag.Full)

--- a/cmd/dump_vm.go
+++ b/cmd/dump_vm.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cedana/cedana/pkg/flags"
 	"github.com/cedana/cedana/pkg/keys"
 	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
 )
 
 func init() {
@@ -19,9 +18,6 @@ func init() {
 	dumpVMCmd.PersistentFlags().
 		StringP(flags.DirFlag.Full, flags.DirFlag.Short, "", "directory to dump into")
 	dumpVMCmd.MarkPersistentFlagDirname(flags.DirFlag.Full)
-
-	// Bind to config
-	viper.BindPFlag("checkpoint.dir", dumpVMCmd.PersistentFlags().Lookup(flags.DirFlag.Full))
 
 	///////////////////////////////////////////
 	// Add subcommands from supported plugins
@@ -31,7 +27,7 @@ func init() {
 		func(name string, pluginCmd *cobra.Command) error {
 			dumpVMCmd.AddCommand(pluginCmd)
 
-      // TODO: Uncomment below once jobDumpVMCmd is defined
+			// TODO: Uncomment below once jobDumpVMCmd is defined
 
 			// Apply all the flags from the plugin command to job subcommand (as optional flags),
 			// since the job subcommand can be used to dump any managed entity (even from plugins, like runc),
@@ -52,7 +48,7 @@ var dumpVMCmd = &cobra.Command{
 	Short: "Dump a VM",
 	Args:  cobra.ArbitraryArgs,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		dir := config.Global.Checkpoint.Dir
+		dir, _ := cmd.Flags().GetString(flags.DirFlag.Full)
 
 		// Create half-baked request
 		req := &daemon.DumpVMReq{Dir: dir}

--- a/cmd/restore.go
+++ b/cmd/restore.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cedana/cedana/pkg/keys"
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
-	"github.com/spf13/viper"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -53,9 +52,6 @@ func init() {
 		flags.AttachFlag.Full,
 		flags.LogFlag.Full,
 	) // only one of these can be set
-
-	// Bind to config
-	viper.BindPFlag("checkpoint.stream", restoreCmd.PersistentFlags().Lookup(flags.StreamFlag.Full))
 
 	///////////////////////////////////////////
 	// Add subcommands from supported plugins

--- a/internal/server/defaults/dump_vm_adapters.go
+++ b/internal/server/defaults/dump_vm_adapters.go
@@ -1,0 +1,20 @@
+package defaults
+
+import (
+	"context"
+
+	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/pkg/config"
+	"github.com/cedana/cedana/pkg/types"
+)
+
+// Adapter that fills missing info from the request using config defaults
+func FillMissingDumpVMDefaults(next types.DumpVM) types.DumpVM {
+	return func(ctx context.Context, opts types.Opts, resp *daemon.DumpVMResp, req *daemon.DumpVMReq) (exited chan int, err error) {
+		if req.Dir == "" {
+			req.Dir = config.Global.Checkpoint.Dir
+		}
+
+		return next(ctx, opts, resp, req)
+	}
+}

--- a/internal/server/dump_vm.go
+++ b/internal/server/dump_vm.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/internal/server/defaults"
 	"github.com/cedana/cedana/internal/server/validation"
 	"github.com/cedana/cedana/pkg/features"
 	"github.com/cedana/cedana/pkg/profiling"
@@ -17,6 +18,7 @@ import (
 func (s *Server) DumpVM(ctx context.Context, req *daemon.DumpVMReq) (*daemon.DumpVMResp, error) {
 
 	middleware := types.Middleware[types.DumpVM]{
+    defaults.FillMissingDumpVMDefaults,
 		validation.ValidateDumpVMRequest,
 
 		pluginDumpVMMiddleware, // middleware from plugins

--- a/test/regression/cr.bats
+++ b/test/regression/cr.bats
@@ -44,6 +44,8 @@ load_lib file
     pid=$!
     name=$(unix_nano)
 
+    mkdir -p /tmp/"$name"
+
     run cedana dump process $pid --name "$name" --dir /tmp/"$name" --compression none
     assert_success
 

--- a/test/regression/cr.bats
+++ b/test/regression/cr.bats
@@ -39,6 +39,19 @@ load_lib file
     run kill $pid
 }
 
+@test "dump process (custom dir)" {
+    "$WORKLOADS"/date-loop.sh &
+    pid=$!
+    name=$(unix_nano)
+
+    run cedana dump process $pid --name "$name" --dir /tmp/"$name" --compression none
+    assert_success
+
+    assert_exists "/tmp/$name/$name"
+
+    run kill $pid
+}
+
 @test "dump process (tar compression)" {
     "$WORKLOADS"/date-loop.sh &
     pid=$!


### PR DESCRIPTION
## Describe your changes
The dump `--dir` flag was not being recognized due to a bug (or feature?) in cobra/viper, when a
flag is bound to a config item more than once. For now, I've removed most of the flag bindings that
can potentially cause these failures, given that we have logic in the daemon already to read from
config when necessary.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the README if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.