### PR TITLE
hotfix: on cancel we should still resume pod

### DIFF
--- a/plugins/containerd/internal/filesystem/dump_adapters.go
+++ b/plugins/containerd/internal/filesystem/dump_adapters.go
@@ -57,7 +57,7 @@ func DumpRootfs(next types.Dump) types.Dump {
 			return nil, status.Errorf(codes.Internal, "failed to pause container %s: %v", details.ID, err)
 		}
 		defer func() {
-			err := task.Resume(ctx)
+			err := task.Resume(context.Background())
 			if err != nil {
 				log.Error().Str("container", details.ID).Msg("failed to resume container")
 			}

--- a/plugins/containerd/internal/filesystem/dump_adapters.go
+++ b/plugins/containerd/internal/filesystem/dump_adapters.go
@@ -57,7 +57,7 @@ func DumpRootfs(next types.Dump) types.Dump {
 			return nil, status.Errorf(codes.Internal, "failed to pause container %s: %v", details.ID, err)
 		}
 		defer func() {
-			err := task.Resume(context.Background())
+			err := task.Resume(context.WithoutCancel(ctx))
 			if err != nil {
 				log.Error().Str("container", details.ID).Msg("failed to resume container")
 			}


### PR DESCRIPTION
We missed this, defer can run on context cancelled, but then context.Background is needed otherwise Resume won't happen.

This can happen often as containerd dump is very long.

I should also add a containerd test for this. 

Fixes CED-1093