### PR TITLE
Feat: Default Otel logging in k8s

### DIFF
--- a/scripts/host/k8s-setup-host.sh
+++ b/scripts/host/k8s-setup-host.sh
@@ -4,12 +4,12 @@ set -e
 
 # get the directory of the script
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE"  ]; do
-    DIR="$( cd -P "$( dirname "$SOURCE"  )" >/dev/null 2>&1 && pwd  )"
+while [ -h "$SOURCE" ]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
     SOURCE="$(readlink "$SOURCE")"
-    [[ $SOURCE != /*  ]] && SOURCE="$DIR/$SOURCE"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
-DIR="$( cd -P "$( dirname "$SOURCE"  )" >/dev/null 2>&1 && pwd  )"
+DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
 
 source "$DIR"/utils.sh
 
@@ -41,16 +41,16 @@ install_yum_packages() {
 if [ -f /etc/os-release ]; then
     . /etc/os-release
     case "$ID" in
-        debian | ubuntu)
-            install_apt_packages
-            ;;
-        rhel | centos | fedora | amzn)
-            install_yum_packages
-            ;;
-        *)
-            echo "Unknown distribution"
-            exit 1
-            ;;
+    debian | ubuntu)
+        install_apt_packages
+        ;;
+    rhel | centos | fedora | amzn)
+        install_yum_packages
+        ;;
+    *)
+        echo "Unknown distribution"
+        exit 1
+        ;;
     esac
 elif [ -f /etc/debian_version ]; then
     install_apt_packages

--- a/scripts/host/systemd-install.sh
+++ b/scripts/host/systemd-install.sh
@@ -4,17 +4,17 @@ set -e
 
 # get the directory of the script
 SOURCE="${BASH_SOURCE[0]}"
-while [ -h "$SOURCE"  ]; do
-    DIR="$( cd -P "$( dirname "$SOURCE"  )" >/dev/null 2>&1 && pwd  )"
+while [ -h "$SOURCE" ]; do
+    DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
     SOURCE="$(readlink "$SOURCE")"
-    [[ $SOURCE != /*  ]] && SOURCE="$DIR/$SOURCE"
+    [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
 done
-DIR="$( cd -P "$( dirname "$SOURCE"  )" >/dev/null 2>&1 && pwd  )"
+DIR="$(cd -P "$(dirname "$SOURCE")" >/dev/null 2>&1 && pwd)"
 
 source "$DIR"/utils.sh
 
 CEDANA_METRICS_ASR=${CEDANA_METRICS_ASR:-false}
-CEDANA_METRICS_OTEL=${CEDANA_METRICS_OTEL:-false}
+CEDANA_METRICS_OTEL=${CEDANA_METRICS_OTEL:true}
 DAEMON_ARGS=""
 
 if ! test -f "$APP_PATH"; then


### PR DESCRIPTION
## Describe your changes
Kubernetes needs Otel logging by default for us to have any visibility into daemons on clusters. 

## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
