### PR TITLE
Increase /dev/shm size when setting up k8s nodes for cedana

### DIFF
--- a/scripts/host/k8s-setup-host.sh
+++ b/scripts/host/k8s-setup-host.sh
@@ -57,6 +57,11 @@ else
     exit 1
 fi
 
+# FIXME HACK - permanently increase SHM size to ~10GB
+echo "increasing SHM size to 10GB..."
+mount -o remount,size=10G /host/dev/shm
+echo "tmpfs /dev/shm tmpfs defaults,size=10G 0 0" >>/host/etc/fstab
+
 "$DIR"/k8s-install-plugins.sh # install the plugins (including shim)
 
 "$DIR"/systemd-reset.sh


### PR DESCRIPTION
## Describe your changes
Hacky increase of shm size to prevent manual intervention for now. 

## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
