### PR TITLE
CED-1426: Check for NVIDIA driver version to determine whether drivers are installed for cedana-helper

### DIFF
--- a/scripts/host/k8s-install-plugins.sh
+++ b/scripts/host/k8s-install-plugins.sh
@@ -30,7 +30,7 @@ if [ -d /proc/driver/nvidia/gpus/ ]; then
     if [ ! -d /run/driver/nvidia ]; then
         # Check if the NVIDIA driver is installed by checking the version
         # as nvidia-smi is not installed by GPU Operator
-        if [ -r /proc/driver/nvidia/version ]; then
+        if [ -r /proc/driver/nvidia/version ] || command -v nvidia-smi >/dev/null 2>&1; then
             PLUGINS="$PLUGINS gpu@$CEDANA_PLUGINS_GPU_VERSION"
             echo "Detected NVIDIA GPU! Ensuring CUDA drivers are installed..."
             echo "Driver version is $(nvidia-smi --query-gpu=driver_version --format=csv,noheader)"

--- a/scripts/host/k8s-install-plugins.sh
+++ b/scripts/host/k8s-install-plugins.sh
@@ -28,7 +28,9 @@ PLUGINS="
 # if gpu driver present then add gpu plugin
 if [ -d /proc/driver/nvidia/gpus/ ]; then
     if [ ! -d /run/driver/nvidia ]; then
-        if command -v nvidia-smi &>/dev/null ; then
+        # Check if the NVIDIA driver is installed by checking the version
+        # as nvidia-smi is not installed by GPU Operator
+        if [ -r /proc/driver/nvidia/version ]; then
             PLUGINS="$PLUGINS gpu@$CEDANA_PLUGINS_GPU_VERSION"
             echo "Detected NVIDIA GPU! Ensuring CUDA drivers are installed..."
             echo "Driver version is $(nvidia-smi --query-gpu=driver_version --format=csv,noheader)"


### PR DESCRIPTION
## Describe your changes
In addition to using `command -v nvidia-smi &>/dev/null` to check whether the NVIDIA drivers exist, `[ -r /proc/driver/nvidia/version ]` checks for drivers as `nvidia-smi` is not installed on some GPU nodes.

## Checklist before requesting a review
- [X] Have I performed a self-review?
- [X] Have I added regression or unit tests (where it makes sense) for my changes?
- [X] Have I updated the docs if changes have resulted in it being out of date?
- [X] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [X] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
