### PR TITLE
CED-1503: fix: stale containers that are partially cleaned up specs cannot be l…

### DIFF
--- a/plugins/k8s/pkg/kube/container.go
+++ b/plugins/k8s/pkg/kube/container.go
@@ -114,7 +114,9 @@ func (c *DefaultKubeClient) ListContainers(fs afero.Fs, root, namespace string) 
 
 		spec, err = runc.LoadSpec(filepath.Join(bundle, "config.json"))
 		if err != nil {
-			return nil, err
+			// If we can't load the spec, skip this container
+			// This happens when cedana messes up and leaves a stale container behind
+			continue
 		}
 
 		var containerNameAnnotation, sandboxNameAnnotation string


### PR DESCRIPTION
…oaded

## Describe your changes
- Stale containers left over from an issue with restore that had been partially cleaned up by containerd, spec cannot be loaded from list containers. Should just continue to next container instead of error-ing out

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
