### PR TITLE
CED-1611: Fix containerd GPU interception

### DIFF
--- a/plugins/containerd/internal/gpu/run_adapters.go
+++ b/plugins/containerd/internal/gpu/run_adapters.go
@@ -48,6 +48,11 @@ func Interception(next types.Run) types.Run {
 			return nil, status.Errorf(codes.Internal, "failed to add GPU interception to spec: %v", err)
 		}
 
+		err = container.Update(ctx, containerd.UpdateContainerOpts(containerd.WithSpec(spec)))
+		if err != nil {
+			return nil, status.Errorf(codes.Internal, "failed to update container with new spec: %v", err)
+		}
+
 		return next(ctx, opts, resp, req)
 	}
 }


### PR DESCRIPTION
## Describe your changes

Fixes GPU support for `cedana run containerd ...`

Below image is from running:
```bash
cedana run containerd -i docker.io/cedana/cedana-samples:cuda -ag -- 1 gpu_smr/vector_add
```
Same to run with native GPU support (assuming nvidia-container-toolkit is installed):
```bash
ctr run —gpus 0 docker.io/cedana/cedana-samples:cuda 1 gpu_smr/vector_add
```

![Uploading image.jpeg…]()

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 