### PR TITLE
Renamed `libslurm-cedana` to `spank_cedana` to avoid confusion

### DIFF
--- a/.github/workflows/download.yml
+++ b/.github/workflows/download.yml
@@ -488,7 +488,7 @@ jobs:
             } > "$ORIGIN_FILE"
 
             cd slurm
-            for binary in cedana-slurm libslurm-cedana.so task_cedana.so cli_filter_cedana.so job_submit_cedana.so; do
+            for binary in cedana-slurm spank_cedana.so task_cedana.so cli_filter_cedana.so job_submit_cedana.so; do
               URL1="https://dl.cloudsmith.io/${API_KEY}/${REPO}/raw/versions/${VERSION_REF}/${binary}-${ARCH}"
               URL2="https://dl.cloudsmith.io/${API_KEY}/${REPO}/raw/names/${binary}-${ARCH}/versions/${VERSION_REF}/${binary}"
               if ! curl -1Lf -O "$URL1"; then
@@ -510,7 +510,7 @@ jobs:
               make all
             )
             cp slurm/cedana-slurm/build/cedana-slurm slurm/build/cedana-slurm
-            cp slurm/cedana-slurm/build/libslurm-cedana.so slurm/build/libslurm-cedana.so
+            cp slurm/cedana-slurm/build/spank_cedana.so slurm/build/spank_cedana.so
             cp slurm/cedana-slurm/build/task_cedana.so slurm/build/task_cedana.so
             cp slurm/cedana-slurm/build/cli_filter_cedana.so slurm/build/cli_filter_cedana.so
             cp slurm/cedana-slurm/build/job_submit_cedana.so slurm/build/job_submit_cedana.so

--- a/.github/workflows/test_slurm.yml
+++ b/.github/workflows/test_slurm.yml
@@ -178,7 +178,7 @@ jobs:
         run: |
           chmod +x slurm-bin/build/cedana-slurm
           sudo cp slurm-bin/build/cedana-slurm /usr/local/bin/cedana-slurm
-          sudo cp slurm-bin/build/libslurm-cedana.so /usr/local/lib/libslurm-cedana.so
+          sudo cp slurm-bin/build/spank_cedana.so /usr/local/lib/spank_cedana.so
           sudo cp slurm-bin/build/task_cedana.so /usr/local/lib/task_cedana.so
           sudo cp slurm-bin/build/cli_filter_cedana.so /usr/local/lib/cli_filter_cedana.so
           sudo cp slurm-bin/build/job_submit_cedana.so /usr/local/lib/job_submit_cedana.so

--- a/pkg/plugins/registry.go
+++ b/pkg/plugins/registry.go
@@ -106,7 +106,7 @@ var Registry = []Plugin{
 		Name: "slurm/wlm",
 		Type: EXTERNAL,
 		Libraries: []Binary{
-			{Name: "libslurm-cedana.so"},
+			{Name: "spank_cedana.so"},
 			{Name: "task_cedana.so"},
 			{Name: "cli_filter_cedana.so"},
 			{Name: "job_submit_cedana.so"},

--- a/test/helpers/slurm_setup.bash
+++ b/test/helpers/slurm_setup.bash
@@ -491,7 +491,7 @@ install_cedana_in_slurm() {
     debug_log "Copying plugin libraries into containers..."
     for so in /usr/local/lib/libcedana-*.so \
         /usr/local/lib/task_cedana.so \
-        /usr/local/lib/libslurm-cedana.so \
+        /usr/local/lib/spank_cedana.so \
         /usr/local/lib/cli_filter_cedana.so \
         /usr/local/lib/job_submit_cedana.so; do
         [ -f "$so" ] || continue
@@ -714,9 +714,9 @@ for f in task_cedana.so cli_filter_cedana.so job_submit_cedana.so; do
     chmod 755 "$src"
     cp "$src" "$PLUGIN_DIR/"
 done
-if [ -f /usr/local/lib/libslurm-cedana.so ]; then
-    chmod 755 /usr/local/lib/libslurm-cedana.so
-    cp /usr/local/lib/libslurm-cedana.so "${PLUGIN_DIR}/spank_cedana.so"
+if [ -f /usr/local/lib/spank_cedana.so ]; then
+    chmod 755 /usr/local/lib/spank_cedana.so
+    cp /usr/local/lib/spank_cedana.so "${PLUGIN_DIR}/spank_cedana.so"
 fi
 ldconfig
 
@@ -734,7 +734,7 @@ if [ -f "${PLUGIN_DIR}/job_submit_cedana.so" ]; then
         echo 'JobSubmitPlugins=job_submit/cedana' >> "$SLURM_CONF"
 fi
 
-if [ -f /usr/local/lib/libslurm-cedana.so ]; then
+if [ -f /usr/local/lib/spank_cedana.so ]; then
     grep -q 'spank_cedana.so' "$PLUGSTACK_CONF" 2>/dev/null || \
         echo "required ${PLUGIN_DIR}/spank_cedana.so" >> "$PLUGSTACK_CONF"
 fi
@@ -760,8 +760,8 @@ for f in task_cedana.so cli_filter_cedana.so job_submit_cedana.so; do
     [ -f "$src" ] || continue
     chmod 755 "$src"; cp "$src" "$PLUGIN_DIR/"
 done
-[ -f /usr/local/lib/libslurm-cedana.so ] && \
-    cp /usr/local/lib/libslurm-cedana.so "${PLUGIN_DIR}/spank_cedana.so"
+[ -f /usr/local/lib/spank_cedana.so ] && \
+    cp /usr/local/lib/spank_cedana.so "${PLUGIN_DIR}/spank_cedana.so"
 ldconfig
 
 grep -q 'task/cedana' "$SLURM_CONF" || \
@@ -775,7 +775,7 @@ grep -q 'NO_CONF_HASH' "$SLURM_CONF" || \
 
 PLUGSTACK_CONF=$(scontrol show config 2>/dev/null | awk '/^PlugStackConfig/{print $3}' || true)
 PLUGSTACK_CONF="${PLUGSTACK_CONF:-/etc/slurm/plugstack.conf}"
-if [ -f /usr/local/lib/libslurm-cedana.so ]; then
+if [ -f /usr/local/lib/spank_cedana.so ]; then
     grep -q 'spank_cedana.so' "$PLUGSTACK_CONF" 2>/dev/null || \
         echo "required ${PLUGIN_DIR}/spank_cedana.so" >> "$PLUGSTACK_CONF"
 fi


### PR DESCRIPTION
## Describe your changes

Currently, we renamed `libslurm-cedana.so` to `spank_cedana.so` during the final installation process. This results in confusion for users who install the plugins manually---as they must rename the plugin themselves. This pull request removes this possible confusion.

## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.

<!-- Message of single commit: -->

feat: renamed `libslurm-cedana` to `spank_cedana` to avoid confusion