### PR TITLE
CED-2065: fix restores using the daemon (privileged mode) running detached from the SLURM job

### DIFF
--- a/plugins/slurm/internal/cgroup/restore_adapters.go
+++ b/plugins/slurm/internal/cgroup/restore_adapters.go
@@ -10,7 +10,6 @@ import (
 	"syscall"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
-	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 	"github.com/cedana/cedana/pkg/criu"
 	"github.com/cedana/cedana/pkg/types"
 	slurm_keys "github.com/cedana/cedana/plugins/slurm/pkg/keys"
@@ -36,14 +35,11 @@ func ApplyCgroupsOnRestore(next types.Restore) types.Restore {
 			return nil, status.Errorf(codes.InvalidArgument, "missing CRIU options in restore request")
 		}
 
-		// GetPaths() returns absolute filesystem paths (e.g., /sys/fs/cgroup/cpu/slurm/...).
-		// GetCgroups().Path is the relative cgroup path within each controller hierarchy,
-		// which is what CRIU expects for cg_root.
-		cgroupConfig, err := manager.GetCgroups()
-		if err != nil {
-			return nil, status.Errorf(codes.Internal, "failed to get cgroup config: %v", err)
-		}
-		relativePath := cgroupConfig.Path
+		// Disable CRIU cgroup management: CRIU cannot remap cross-job cgroup paths
+		// (e.g. job_1219/step_batch/task_0 -> job_1266/step_batch). With manage_cgroups
+		// disabled, restored processes inherit CRIU's cgroup, which we place into the
+		// new job's hierarchy via manager.Apply below.
+		req.Criu.ManageCgroups = proto.Bool(false)
 
 		callback := &criu.NotifyCallback{
 			InitializeFunc: func(ctx context.Context, criuPid int32) (err error) {
@@ -75,17 +71,6 @@ func ApplyCgroupsOnRestore(next types.Restore) types.Restore {
 					}
 				} else {
 					log.Trace().Msgf("applied cgroups to CRIU process %d\n", criuPid)
-				}
-
-				// set CgRoot to tell CRIU where to place restored processes
-				// CRIU expects paths relative to each controller's mount point
-				for c := range paths {
-					cgroupRoot := &criu_proto.CgroupRoot{
-						Ctrl: proto.String(c),
-						Path: proto.String(relativePath),
-					}
-					req.Criu.CgRoot = append(req.Criu.CgRoot, cgroupRoot)
-					log.Trace().Msgf("set CgRoot for controller %s: %s\n", c, relativePath)
 				}
 
 				return nil

--- a/plugins/slurm/internal/job/utils.go
+++ b/plugins/slurm/internal/job/utils.go
@@ -26,8 +26,8 @@ func GetJobCgroupPath(hostname string, jid uint32) (string, error) {
 	if err != nil {
 		return "", status.Errorf(codes.Internal, "failed to glob cgroup paths for slurm job %d with pattern %s: %v", jid, pattern, err)
 	}
-	if matches != nil && len(matches) > 0 {
-		path = matches[0][len("/sys/fs/cgroup"):]
+	if len(matches) > 0 {
+		path = matches[0][len("/sys/fs/cgroup/freezer"):]
 	}
 	if path == "" {
 		return "", status.Errorf(codes.NotFound, "cgroup path for slurm job %d does not exist: %s", jid, path)


### PR DESCRIPTION
## Describe your changes

When restoring a SLURM job in the daemon, the process would be restored detached from the SLURM job (even with --shell-job). The process would successfully restore, but the job would complete immediately.

### Problem

  SLURM checkpoint restore on cgroups v1 was failing with two related bugs:

  1. All cg_root entries in the CRIU request had /freezer/slurm/... as the path for every controller (cpuset, cpu, memory, etc.), not just freezer.
  2. Even after fixing the paths, CRIU errored with Can't move <pid> into cpuset//slurm/uid_1000/job_N/step_batch/task_0/cgroup.procs — the double slash and old job number
  indicating the remapping was silently failing.

### Root causes

  GetJobCgroupPath detects a cgroups v1 system by globbing for the freezer
  cgroup (/sys/fs/cgroup/freezer/slurm/uid_*/job_N/step_batch). It then stripped
  only /sys/fs/cgroup from the result, yielding /freezer/slurm/... as the
  relative path stored in cgroups.Cgroup.Path. The manager built from that path
  produced absolute paths with /freezer embedded for every controller (e.g.
  /sys/fs/cgroup/cpuset/freezer/slurm/...), which in turn corrupted every
  cg_root entry in the CRIU request.

  The second bug is architectural: CRIU's cg_root mechanism remaps cgroup paths by
  stripping a common prefix from dump-time paths and substituting the new root. For
  cross-job SLURM migration the dump path (job_1219/step_batch/task_0) and the new path
  (job_1266/step_batch) share no common prefix at the job level, so CRIU falls through
  with an empty root — producing the // double slash — and tries to move processes to
  the original dump path, which doesn't exist on the restore target.

### Changes

  - plugins/slurm/internal/job/utils.go: strip /sys/fs/cgroup/freezer (the full freezer
  mount prefix) instead of /sys/fs/cgroup, so the manager receives the correct relative
  path /slurm/uid_N/job_N/step_batch.
  - plugins/slurm/internal/cgroup/restore_adapters.go: replace the cg_root loop with
  req.Criu.ManageCgroups = false. This overrides the default true set by
  FillMissingRestoreDefaults and prevents CRIU from attempting to move restored
  processes to their dump-time cgroup paths. Restored processes instead inherit the CRIU   process's cgroup, which manager.Apply(criuPid) already places into the correct new
  job hierarchy. Removed the now-unused cg_root loop and its imports (criu_proto,
  strings).

## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.

<!-- Message of single commit: -->

fix: fixed cgroup path mapping and disable manage cgroups