### PR TITLE
CED-2084: Update unit-tests image from golang:bullseye to golang:bookworm 1.25.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -83,7 +83,7 @@ jobs:
           - amd64
           - arm64
     container:
-      image: golang:1.25rc3-bullseye
+      image: golang:1.25-bookworm
       credentials:
         username: ${{ vars.DOCKER_USERNAME }}
         password: ${{ secrets.DOCKER_TOKEN }}


### PR DESCRIPTION
## Describe your changes
Previously breaking changes
https://github.com/cedana/cedana/actions/runs/25813107056/job/75836862739
```
Run make test-unit
Running unit tests...
go: go.mod requires go >= 1.25.0 (running go 1.25rc3; GOTOOLCHAIN=local)
make: *** [Makefile:141: test-unit] Error 1
Error: Process completed with exit code 2.
```
## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
