### PR TITLE
CED-2073: Use New CRIU hook for regular processes

### DIFF
--- a/internal/cedana/gpu/controller.go
+++ b/internal/cedana/gpu/controller.go
@@ -569,7 +569,7 @@ func (p *pool) CRIUCallback(id string) *criu_client.NotifyCallback {
 
 	// Update GPU controller with the restore PID (which can be a new PID)
 	var restoredPid *int32
-	callback.PostRestoreFunc = func(ctx context.Context, pid int32) error {
+	callback.NoNsFunc = func(ctx context.Context, pid int32) error {
 		controller := p.Get(id)
 		restoredPid = &pid
 

--- a/internal/cedana/gpu/controller.go
+++ b/internal/cedana/gpu/controller.go
@@ -568,8 +568,17 @@ func (p *pool) CRIUCallback(id string) *criu_client.NotifyCallback {
 	}
 
 	// Update GPU controller with the restore PID (which can be a new PID)
+	// In case, there are no namespaces to restore CRIU will call this hook
 	var restoredPid *int32
 	callback.NoNsFunc = func(ctx context.Context, pid int32) error {
+		controller := p.Get(id)
+		restoredPid = &pid
+
+		return controller.Attach(ctx, uint32(pid))
+	}
+
+	// Will only be called if there are namespaces to restore
+	callback.SetupNamespacesFunc = func(ctx context.Context, pid int32) error {
 		controller := p.Get(id)
 		restoredPid = &pid
 

--- a/internal/cedana/gpu/controller.go
+++ b/internal/cedana/gpu/controller.go
@@ -570,7 +570,7 @@ func (p *pool) CRIUCallback(id string) *criu_client.NotifyCallback {
 	// Update GPU controller with the restore PID (which can be a new PID)
 	// In case, there are no namespaces to restore CRIU will call this hook
 	var restoredPid *int32
-	callback.NoNsFunc = func(ctx context.Context, pid int32) error {
+	callback.SkipNamespacesFunc = func(ctx context.Context, pid int32) error {
 		controller := p.Get(id)
 		restoredPid = &pid
 

--- a/internal/cedana/job/manager.go
+++ b/internal/cedana/job/manager.go
@@ -38,8 +38,8 @@ type Manager interface {
 	// Exists checks if a job with the given JID exists.
 	Exists(jid string) bool
 
-  // Find returns a job with the given PID.
-  Find(pid uint32) *Job
+	// Find returns a job with the given PID.
+	Find(pid uint32) *Job
 
 	// Starts managing a running job, updating state once it exits.
 	// Since this runs in background, it should be called with a waitgroup,

--- a/pkg/criu/criu.go
+++ b/pkg/criu/criu.go
@@ -275,8 +275,8 @@ func (c *Criu) doSwrkWithResp(
 			err = nfy.PreResume(ctx)
 		case "post-resume":
 			err = nfy.PostResume(ctx)
-		case "no-ns":
-			err = nfy.NoNs(ctx, notify.GetPid())
+		case "skip-namespaces":
+			err = nfy.SkipNamespaces(ctx, notify.GetPid())
 		case "orphan-pts-master":
 			scm, err := syscall.ParseSocketControlMessage(oobB[:oobn])
 			if err != nil {

--- a/pkg/criu/criu.go
+++ b/pkg/criu/criu.go
@@ -275,6 +275,8 @@ func (c *Criu) doSwrkWithResp(
 			err = nfy.PreResume(ctx)
 		case "post-resume":
 			err = nfy.PostResume(ctx)
+		case "no-ns":
+			err = nfy.NoNs(ctx, notify.GetPid())
 		case "orphan-pts-master":
 			scm, err := syscall.ParseSocketControlMessage(oobB[:oobn])
 			if err != nil {

--- a/pkg/criu/notify.go
+++ b/pkg/criu/notify.go
@@ -21,7 +21,7 @@ type Notify interface {
 	NetworkUnlock(ctx context.Context) error
 	SetupNamespaces(ctx context.Context, pid int32) error
 	PostSetupNamespaces(ctx context.Context) error
-	NoNs(ctx context.Context, pid int32) error
+	SkipNamespaces(ctx context.Context, pid int32) error
 	PreResume(ctx context.Context) error
 	PostResume(ctx context.Context) error
 	OrphanPtsMaster(ctx context.Context, fd int32) error
@@ -95,8 +95,8 @@ func (c NoNotify) PostSetupNamespaces(ctx context.Context) error {
 	return nil
 }
 
-// NoNs NoNotify
-func (c NoNotify) NoNs(ctx context.Context, pid int32) error {
+// SkipNamespaces NoNotify
+func (c NoNotify) SkipNamespaces(ctx context.Context, pid int32) error {
 	return nil
 }
 

--- a/pkg/criu/notify.go
+++ b/pkg/criu/notify.go
@@ -21,6 +21,7 @@ type Notify interface {
 	NetworkUnlock(ctx context.Context) error
 	SetupNamespaces(ctx context.Context, pid int32) error
 	PostSetupNamespaces(ctx context.Context) error
+	NoNs(ctx context.Context, pid int32) error
 	PreResume(ctx context.Context) error
 	PostResume(ctx context.Context) error
 	OrphanPtsMaster(ctx context.Context, fd int32) error
@@ -91,6 +92,11 @@ func (c NoNotify) SetupNamespaces(ctx context.Context, pid int32) error {
 
 // PostSetupNamespaces NoNotify
 func (c NoNotify) PostSetupNamespaces(ctx context.Context) error {
+	return nil
+}
+
+// NoNs NoNotify
+func (c NoNotify) NoNs(ctx context.Context, pid int32) error {
 	return nil
 }
 

--- a/pkg/criu/notify_callback.go
+++ b/pkg/criu/notify_callback.go
@@ -25,7 +25,7 @@ type NotifyCallback struct {
 	NetworkUnlockFunc       NotifyFunc
 	SetupNamespacesFunc     NotifyFuncPid
 	PostSetupNamespacesFunc NotifyFunc
-	NoNsFunc                NotifyFuncPid
+	SkipNamespacesFunc      NotifyFuncPid
 	PreResumeFunc           NotifyFunc
 	PostResumeFunc          NotifyFunc
 	OrphanPtsMasterFunc     NotifyFuncFd
@@ -253,16 +253,16 @@ func (n NotifyCallback) PostSetupNamespaces(ctx context.Context) error {
 	return nil
 }
 
-func (n NotifyCallback) NoNs(ctx context.Context, pid int32) error {
-	if n.NoNsFunc != nil {
-		log.Trace().Str("name", n.Name).Msg("CRIU no-ns callback")
+func (n NotifyCallback) SkipNamespaces(ctx context.Context, pid int32) error {
+	if n.SkipNamespacesFunc != nil {
+		log.Trace().Str("name", n.Name).Msg("CRIU skip-namespaces callback")
 		var end func()
 		ctx, end = profiling.StartTimingCategory(ctx, n.Name)
 		defer end()
-		err := n.NoNsFunc(ctx, pid)
+		err := n.SkipNamespacesFunc(ctx, pid)
 		if err != nil {
-			log.Trace().Err(err).Str("name", n.Name).Msg("CRIU no-ns callback failed")
-			return fmt.Errorf("no-ns callback: %v", err)
+			log.Trace().Err(err).Str("name", n.Name).Msg("CRIU skip-namespaces callback failed")
+			return fmt.Errorf("skip-namespaces callback: %v", err)
 		}
 	}
 	return nil

--- a/pkg/criu/notify_callback.go
+++ b/pkg/criu/notify_callback.go
@@ -25,6 +25,7 @@ type NotifyCallback struct {
 	NetworkUnlockFunc       NotifyFunc
 	SetupNamespacesFunc     NotifyFuncPid
 	PostSetupNamespacesFunc NotifyFunc
+	NoNsFunc                NotifyFuncPid
 	PreResumeFunc           NotifyFunc
 	PostResumeFunc          NotifyFunc
 	OrphanPtsMasterFunc     NotifyFuncFd
@@ -247,6 +248,21 @@ func (n NotifyCallback) PostSetupNamespaces(ctx context.Context) error {
 		if err != nil {
 			log.Trace().Err(err).Str("name", n.Name).Msg("CRIU post-setup-namespaces callback failed")
 			return fmt.Errorf("post-setup-namespaces callback: %v", err)
+		}
+	}
+	return nil
+}
+
+func (n NotifyCallback) NoNs(ctx context.Context, pid int32) error {
+	if n.NoNsFunc != nil {
+		log.Trace().Str("name", n.Name).Msg("CRIU no-ns callback")
+		var end func()
+		ctx, end = profiling.StartTimingCategory(ctx, n.Name)
+		defer end()
+		err := n.NoNsFunc(ctx, pid)
+		if err != nil {
+			log.Trace().Err(err).Str("name", n.Name).Msg("CRIU no-ns callback failed")
+			return fmt.Errorf("no-ns callback: %v", err)
 		}
 	}
 	return nil

--- a/pkg/criu/notify_callback.go
+++ b/pkg/criu/notify_callback.go
@@ -255,7 +255,7 @@ func (n NotifyCallback) PostSetupNamespaces(ctx context.Context) error {
 
 func (n NotifyCallback) SkipNamespaces(ctx context.Context, pid int32) error {
 	if n.SkipNamespacesFunc != nil {
-		log.Trace().Str("name", n.Name).Msg("CRIU skip-namespaces callback")
+		log.Trace().Int32("pid", pid).Str("name", n.Name).Msg("CRIU skip-namespaces callback")
 		var end func()
 		ctx, end = profiling.StartTimingCategory(ctx, n.Name)
 		defer end()

--- a/pkg/criu/notify_callback_multi.go
+++ b/pkg/criu/notify_callback_multi.go
@@ -180,6 +180,16 @@ func (n NotifyCallbackMulti) PostSetupNamespaces(ctx context.Context) error {
 	return nil
 }
 
+func (n NotifyCallbackMulti) NoNs(ctx context.Context, pid int32) error {
+	for i := len(n.callbacks) - 1; i >= 0; i-- {
+		err := n.callbacks[i].NoNs(ctx, pid)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 func (n NotifyCallbackMulti) OrphanPtsMaster(ctx context.Context, fd int32) error {
 	for i := len(n.callbacks) - 1; i >= 0; i-- {
 		err := n.callbacks[i].OrphanPtsMaster(ctx, fd)

--- a/pkg/criu/notify_callback_multi.go
+++ b/pkg/criu/notify_callback_multi.go
@@ -180,9 +180,9 @@ func (n NotifyCallbackMulti) PostSetupNamespaces(ctx context.Context) error {
 	return nil
 }
 
-func (n NotifyCallbackMulti) NoNs(ctx context.Context, pid int32) error {
+func (n NotifyCallbackMulti) SkipNamespaces(ctx context.Context, pid int32) error {
 	for i := len(n.callbacks) - 1; i >= 0; i-- {
-		err := n.callbacks[i].NoNs(ctx, pid)
+		err := n.callbacks[i].SkipNamespaces(ctx, pid)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
## Describe your changes
Requires
- https://github.com/cedana/criu/pull/21
- https://github.com/cedana/cedana-gpu/pull/233

We add a new hook to CRIU for regular processes at the point it which it skips namespace restore (CRIU pr does this). This allows us to  attach gpu controller earlier than PostRestore for regular processes
For Containers, we now dump env vars as part of the gpu checkpoint, allowing us to attach at SetupNamespaces once again.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
