### PR TITLE
CED-2077: Fix GPU C/R/C/R restore causes a file size mismatch error

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/coreos/go-systemd/v22 v22.6.0
 	github.com/cyphar/filepath-securejoin v0.5.0
 	github.com/gofrs/flock v0.12.1
-	github.com/gogo/protobuf v1.3.2
 	github.com/google/uuid v1.6.0
 	github.com/jedib0t/go-pretty/v6 v6.6.8
 	github.com/mattn/go-isatty v0.0.20
@@ -103,6 +102,7 @@ require (
 	github.com/go-ole/go-ole v1.2.6 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/godbus/dbus/v5 v5.1.0 // indirect
+	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.3 // indirect

--- a/internal/cedana/gpu/dump_adapters.go
+++ b/internal/cedana/gpu/dump_adapters.go
@@ -80,7 +80,7 @@ func AddMountsForDump(next types.Dump) types.Dump {
 
 		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
 			if NVIDIA_MOUNTS_PATTERN.MatchString(m.Root) {
-				log.Trace().Interface("m", m).Msg("marking NVIDIA GPU mount as external")
+				log.Debug().Interface("m", m).Msg("marking NVIDIA GPU mount as external")
 				req.Criu.External = append(req.Criu.External, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, m.MountPoint))
 			}
 			return true

--- a/internal/cedana/gpu/restore_adapters.go
+++ b/internal/cedana/gpu/restore_adapters.go
@@ -100,7 +100,7 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 		mounts := make(map[uint64]any)
 		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
 			// If the shm file appears in the mounts, it means this restore is for a container
-			isContainer = isContainer || shmFileRegex.MatchString(m.Root)
+			isContainer = isContainer || shmFileRegex.MatchString(m.MountPoint)
 
 			mounts[m.ID] = nil
 			return true

--- a/internal/cedana/gpu/restore_adapters.go
+++ b/internal/cedana/gpu/restore_adapters.go
@@ -258,6 +258,14 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 				return true // not a file we care about
 			}
 
+			log.Debug().Str("path", path).Str("newPath", newPath).Msg("opening GPU file for inheriting")
+			newFile, err = os.OpenFile(newPath, os.O_RDWR|os.O_CREATE, 0o644)
+			if err != nil {
+				err = status.Errorf(codes.Internal, "failed to reopen file for inheriting FD %s: %v", newPath, err)
+				return false
+			}
+			toClose = append(toClose, newFile)
+
 			if external {
 				key = fmt.Sprintf("file[%x:%x]", file.MountID, file.Inode)
 			} else {
@@ -273,14 +281,6 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 			// Open new GPU shm file only if not restoring a container because for container restore we expect the shm file to be
 			// bind-mounted from the host at the same path inside the container (CED-2077)
 			if !isContainer {
-				log.Debug().Str("path", path).Str("newPath", newPath).Msg("opening GPU file for inheriting")
-				newFile, err = os.OpenFile(newPath, os.O_RDWR|os.O_CREATE, 0o644)
-				if err != nil {
-					err = status.Errorf(codes.Internal, "failed to reopen file for inheriting FD %s: %v", newPath, err)
-					return false
-				}
-				toClose = append(toClose, newFile)
-
 				log.Debug().Str("key", key).Int32("fd", fd).Bool("external", external).Str("old", path).Str("new", newPath).Msgf("inheriting GPU file")
 
 				opts.ExtraFiles = append(opts.ExtraFiles, newFile)

--- a/internal/cedana/gpu/restore_adapters.go
+++ b/internal/cedana/gpu/restore_adapters.go
@@ -258,14 +258,6 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 				return true // not a file we care about
 			}
 
-			log.Debug().Str("path", path).Str("newPath", newPath).Msg("opening GPU file for inheriting")
-			newFile, err = os.OpenFile(newPath, os.O_RDWR|os.O_CREATE, 0o644)
-			if err != nil {
-				err = status.Errorf(codes.Internal, "failed to reopen file for inheriting FD %s: %v", newPath, err)
-				return false
-			}
-			toClose = append(toClose, newFile)
-
 			if external {
 				key = fmt.Sprintf("file[%x:%x]", file.MountID, file.Inode)
 			} else {
@@ -281,6 +273,14 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 			// Open new GPU shm file only if not restoring a container because for container restore we expect the shm file to be
 			// bind-mounted from the host at the same path inside the container (CED-2077)
 			if !isContainer {
+				log.Debug().Str("path", path).Str("newPath", newPath).Msg("opening GPU file for inheriting")
+				newFile, err = os.OpenFile(newPath, os.O_RDWR|os.O_CREATE, 0o644)
+				if err != nil {
+					err = status.Errorf(codes.Internal, "failed to reopen file for inheriting FD %s: %v", newPath, err)
+					return false
+				}
+				toClose = append(toClose, newFile)
+
 				log.Debug().Str("key", key).Int32("fd", fd).Bool("external", external).Str("old", path).Str("new", newPath).Msgf("inheriting GPU file")
 
 				opts.ExtraFiles = append(opts.ExtraFiles, newFile)

--- a/internal/cedana/gpu/restore_adapters.go
+++ b/internal/cedana/gpu/restore_adapters.go
@@ -92,6 +92,20 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 			req.Criu = &criu.CriuOpts{}
 		}
 
+		var toClose []*os.File
+		var logDir string
+		var isContainer bool
+		shmFileRegex := regexp.MustCompile(CONTROLLER_SHM_FILE_PATTERN)
+
+		mounts := make(map[uint64]any)
+		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
+			// If the shm file appears in the mounts, it means this restore is for a container
+			isContainer = isContainer || shmFileRegex.MatchString(m.Root)
+
+			mounts[m.ID] = nil
+			return true
+		})
+
 		key := strings.TrimPrefix(fmt.Sprintf(CONTROLLER_SHM_FILE_FORMATTER, state.GPUID), "/")
 		fd := int32(3 + len(opts.ExtraFiles))
 
@@ -101,13 +115,21 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 		opts.InheritFdMap[key] = fd
 
 		id, ok := ctx.Value(keys.GPU_ID_CONTEXT_KEY).(string)
-		if ok {
-			// Open new GPU shm file
+		if !ok {
+			return nil, status.Errorf(codes.Internal, "failed to get GPU ID from context")
+		}
+
+		// Open new GPU shm file only if not restoring a container because for container restore we expect the shm file to be
+		// bind-mounted from the host at the same path inside the container (CED-2077)
+		if !isContainer {
+			log.Debug().Str("key", key).Str("path", fmt.Sprintf(CONTROLLER_SHM_FILE_FORMATTER, id)).Int32("fd", fd).Msg("opening GPU file for inheriting")
 			shmFile, err := os.OpenFile(fmt.Sprintf(CONTROLLER_SHM_FILE_FORMATTER, id), os.O_RDWR, 0o644)
 			if err != nil {
 				return nil, status.Errorf(codes.Internal, "failed to open GPU shm file: %v", err)
 			}
-			defer shmFile.Close()
+			toClose = append(toClose, shmFile)
+
+			log.Debug().Str("key", key).Str("new", fmt.Sprintf(CONTROLLER_SHM_FILE_FORMATTER, id)).Int32("fd", fd).Msg("inheriting GPU file")
 
 			opts.ExtraFiles = append(opts.ExtraFiles, shmFile)
 			req.Criu.InheritFd = append(req.Criu.InheritFd, &criu.InheritFd{
@@ -116,16 +138,7 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 			})
 		}
 
-		mounts := make(map[uint64]any)
-		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
-			mounts[m.ID] = nil
-			return true
-		})
-
-		var toClose []*os.File
-		var logDir string
-
-		// Inherit hostmem files as well, if any
+		// Inherit other known GPU files as well, if any
 		utils.WalkTree(state, "OpenFiles", "Children", func(file *daemon.File) bool {
 			path := file.Path
 
@@ -245,11 +258,13 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 				return true // not a file we care about
 			}
 
+			log.Debug().Str("path", path).Str("newPath", newPath).Msg("opening GPU file for inheriting")
 			newFile, err = os.OpenFile(newPath, os.O_RDWR|os.O_CREATE, 0o644)
 			if err != nil {
 				err = status.Errorf(codes.Internal, "failed to reopen file for inheriting FD %s: %v", newPath, err)
 				return false
 			}
+			toClose = append(toClose, newFile)
 
 			if external {
 				key = fmt.Sprintf("file[%x:%x]", file.MountID, file.Inode)
@@ -261,16 +276,19 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 			if _, ok := opts.InheritFdMap[key]; ok {
 				return true // already inherited
 			}
-
-			log.Debug().Str("key", key).Int32("fd", fd).Bool("external", external).Str("old", path).Str("new", newPath).Msgf("inheriting file")
-
 			opts.InheritFdMap[key] = fd
-			opts.ExtraFiles = append(opts.ExtraFiles, newFile)
-			toClose = append(toClose, newFile)
-			req.Criu.InheritFd = append(req.Criu.InheritFd, &criu.InheritFd{
-				Key: proto.String(key),
-				Fd:  proto.Int32(fd),
-			})
+
+			// Open new GPU shm file only if not restoring a container because for container restore we expect the shm file to be
+			// bind-mounted from the host at the same path inside the container (CED-2077)
+			if !isContainer {
+				log.Debug().Str("key", key).Int32("fd", fd).Bool("external", external).Str("old", path).Str("new", newPath).Msgf("inheriting GPU file")
+
+				opts.ExtraFiles = append(opts.ExtraFiles, newFile)
+				req.Criu.InheritFd = append(req.Criu.InheritFd, &criu.InheritFd{
+					Key: proto.String(key),
+					Fd:  proto.Int32(fd),
+				})
+			}
 
 			return true
 		})
@@ -284,6 +302,29 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 		}
 
 		ctx = context.WithValue(ctx, keys.GPU_LOG_DIR_CONTEXT_KEY, logDir)
+
+		return next(ctx, opts, resp, req)
+	}
+}
+
+// Adapter that tells CRIU about the external GPU mounts.
+func AddMountsForRestore(next types.Restore) types.Restore {
+	return func(ctx context.Context, opts types.Opts, resp *daemon.RestoreResp, req *daemon.RestoreReq) (code func() <-chan int, err error) {
+		state := resp.GetState()
+		if state == nil {
+			return nil, status.Errorf(
+				codes.InvalidArgument,
+				"missing state. at least PID is required in resp.state",
+			)
+		}
+
+		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
+			if NVIDIA_MOUNTS_PATTERN.MatchString(m.Root) {
+				log.Debug().Str("root", m.Root).Str("mount_path", m.MountPoint).Msg("marking NVIDIA GPU mount as external")
+				req.Criu.External = append(req.Criu.External, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, m.Root))
+			}
+			return true
+		})
 
 		return next(ctx, opts, resp, req)
 	}
@@ -330,29 +371,6 @@ func InterceptionRestore(next types.Restore) types.Restore {
 		}
 
 		log.Info().Str("plugin", "gpu").Str("ID", id).Str("type", t).Msg("restoring GPU interception")
-
-		return next(ctx, opts, resp, req)
-	}
-}
-
-// Adapter that tells CRIU about the external GPU mounts.
-func AddMountsForRestore(next types.Restore) types.Restore {
-	return func(ctx context.Context, opts types.Opts, resp *daemon.RestoreResp, req *daemon.RestoreReq) (code func() <-chan int, err error) {
-		state := resp.GetState()
-		if state == nil {
-			return nil, status.Errorf(
-				codes.InvalidArgument,
-				"missing state. at least PID is required in resp.state",
-			)
-		}
-
-		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
-			if NVIDIA_MOUNTS_PATTERN.MatchString(m.Root) {
-				log.Trace().Str("root", m.Root).Str("mount_path", m.MountPoint).Msg("marking NVIDIA GPU mount as external")
-				req.Criu.External = append(req.Criu.External, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, m.Root))
-			}
-			return true
-		})
 
 		return next(ctx, opts, resp, req)
 	}

--- a/internal/cedana/process/dump_adapters.go
+++ b/internal/cedana/process/dump_adapters.go
@@ -168,9 +168,13 @@ func AddExternalFilesForDump(next types.Dump) types.Dump {
 			isPipe := strings.HasPrefix(f.Path, "pipe")
 			isSocket := strings.HasPrefix(f.Path, "socket")
 			isAnon := strings.HasPrefix(f.Path, "anon_inode")
-			_, internal := mounts[f.MountID]
+			_, mountFound := mounts[f.MountID]
 
-			external := !(internal || isPipe || isSocket || isAnon) // sockets and pipes are always in external mounts
+			// A file is external if it's from outside the process's mount namespace.
+			// Pipes, sockets, and anon_inodes are internal (not real files from external mounts).
+			// A file is external only if its mount ID is not in the process's mount table AND it's a real file.
+			internal := mountFound || isPipe || isSocket || isAnon
+			external := !internal
 
 			if external {
 				if f.IsTTY {

--- a/internal/cedana/process/restore_adapters.go
+++ b/internal/cedana/process/restore_adapters.go
@@ -249,3 +249,4 @@ func InheritFilesForRestore(next types.Restore) types.Restore {
 		return next(ctx, opts, resp, req)
 	}
 }
+

--- a/plugins/k8s/internal/eventstream/rmq.go
+++ b/plugins/k8s/internal/eventstream/rmq.go
@@ -24,11 +24,11 @@ import (
 	"github.com/cedana/cedana/pkg/features"
 	"github.com/cedana/cedana/pkg/profiling"
 	"github.com/cedana/cedana/plugins/runc/pkg/runc"
-	"github.com/gogo/protobuf/proto"
 	"github.com/opencontainers/runtime-spec/specs-go"
 	amqp "github.com/rabbitmq/amqp091-go"
 	"github.com/rs/zerolog/log"
 	"github.com/wagslane/go-rabbitmq"
+	"google.golang.org/protobuf/proto"
 )
 
 type EventStream struct {

--- a/plugins/slurm/internal/job/restore_adapters.go
+++ b/plugins/slurm/internal/job/restore_adapters.go
@@ -17,12 +17,12 @@ import (
 	slurm_keys "github.com/cedana/cedana/plugins/slurm/pkg/keys"
 	slurm_utils "github.com/cedana/cedana/plugins/slurm/pkg/utils"
 
-	"github.com/gogo/protobuf/proto"
 	"github.com/opencontainers/cgroups"
 	cgroupsManager "github.com/opencontainers/cgroups/manager"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 func GetSlurmJobForRestore(next types.Restore) types.Restore {
@@ -87,13 +87,13 @@ func RestoreSlurmScript(next types.Restore) types.Restore {
 					return false
 				}
 
-				err = os.MkdirAll(filepath.Dir(path), 0755)
+				err = os.MkdirAll(filepath.Dir(path), 0o755)
 				if err != nil {
 					log.Warn().Err(err).Msgf("failed to create directory for slurm script %s", path)
 					return false
 				}
 
-				err = os.WriteFile(path, contents, 0700)
+				err = os.WriteFile(path, contents, 0o700)
 				if err != nil {
 					log.Warn().Err(err).Msgf("failed to restore slurm script file %s", path)
 					return false

--- a/plugins/slurm/internal/namespaces/restore_adapters.go
+++ b/plugins/slurm/internal/namespaces/restore_adapters.go
@@ -8,11 +8,11 @@ import (
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 	"github.com/cedana/cedana/pkg/types"
-	"github.com/gogo/protobuf/proto"
 	"github.com/opencontainers/runc/libcontainer/configs"
 	"github.com/rs/zerolog/log"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"google.golang.org/protobuf/proto"
 )
 
 func IgnoreNamespacesForRestore(nsTypes ...configs.NamespaceType) types.Adapter[types.Restore] {


### PR DESCRIPTION
## Describe your changes
Fixes an issue where GPU hostmem/log files would fail CRIU restore when restoring 2nd generation checkpoints. The fix is to completely avoid using `--inherit-fd` CRIU option when a container is involved, because for containers these files are always bind-mounted onto the same path inside the container.

Accompanying GPU changes: https://github.com/cedana/cedana-gpu/pull/234

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.