### PR TITLE
ced-2055 fix path resolution for nvidia-persistenced/socket on restore

### DIFF
--- a/internal/cedana/gpu/restore_adapters.go
+++ b/internal/cedana/gpu/restore_adapters.go
@@ -328,7 +328,7 @@ func AddMountsForRestore(next types.Restore) types.Restore {
 				if resolvedSource, ok := resolvedMountSources[m.ID]; ok {
 					source = resolvedSource
 				}
-				log.Debug().Str("root", m.Root).Str("mount_path", m.MountPoint).Msg("marking NVIDIA GPU mount as external")
+				log.Debug().Str("root", source).Str("mount_path", m.MountPoint).Msg("marking NVIDIA GPU mount as external")
 				req.Criu.External = append(req.Criu.External, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, source))
 			}
 			return true

--- a/internal/cedana/gpu/restore_adapters.go
+++ b/internal/cedana/gpu/restore_adapters.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -18,6 +19,7 @@ import (
 	"github.com/cedana/cedana/pkg/types"
 	"github.com/cedana/cedana/pkg/utils"
 	"github.com/google/uuid"
+	"github.com/moby/sys/mountinfo"
 	"github.com/rs/zerolog/log"
 	"github.com/spf13/afero"
 	"google.golang.org/grpc/codes"
@@ -318,16 +320,62 @@ func AddMountsForRestore(next types.Restore) types.Restore {
 			)
 		}
 
+		resolvedMountSources := resolveExternalMountSources(state)
+
 		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
 			if NVIDIA_MOUNTS_PATTERN.MatchString(m.Root) {
+				source := m.Root
+				if resolvedSource, ok := resolvedMountSources[m.ID]; ok {
+					source = resolvedSource
+				}
 				log.Debug().Str("root", m.Root).Str("mount_path", m.MountPoint).Msg("marking NVIDIA GPU mount as external")
-				req.Criu.External = append(req.Criu.External, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, m.Root))
+				req.Criu.External = append(req.Criu.External, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, source))
 			}
 			return true
 		})
 
 		return next(ctx, opts, resp, req)
 	}
+}
+
+// resolveExternalMountSources returns host source path overrides for mounts
+// whose m.Root must be resolved through a matching host filesystem mount.
+func resolveExternalMountSources(state *daemon.ProcessState) map[uint64]string {
+	sources := map[uint64]string{}
+	hostMounts, err := mountinfo.GetMounts(nil)
+	if err != nil {
+		return sources
+	}
+
+	hostMountsByDevice := map[string]*mountinfo.Info{}
+	for _, hostMount := range hostMounts {
+		key := fmt.Sprintf("%d:%d", hostMount.Major, hostMount.Minor)
+		if current := hostMountsByDevice[key]; current == nil || len(hostMount.Root) < len(current.Root) {
+			hostMountsByDevice[key] = hostMount
+		}
+	}
+
+	utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
+		if _, err := os.Lstat(m.Root); err == nil {
+			return true
+		}
+
+		key := fmt.Sprintf("%d:%d", m.Major, m.Minor)
+		hostMount := hostMountsByDevice[key]
+		if hostMount == nil {
+			return true
+		}
+
+		pathInSourceMount, err := filepath.Rel(hostMount.Root, m.Root)
+		if err != nil || pathInSourceMount == ".." || strings.HasPrefix(pathInSourceMount, "../") {
+			return true
+		}
+
+		sources[m.ID] = filepath.Join(hostMount.Mountpoint, pathInSourceMount)
+		return true
+	})
+
+	return sources
 }
 
 ///////////////////////////////////////


### PR DESCRIPTION
## Describe your changes
Fixes runc GPU restore failure when the checkpoint includes NVIDIA persistenced socket. Mount.Root was being resolved as /nvidia-persistenced/socket which is not a valid host path, causing an error. This fix instead used MountPoint when possible restoring the socket from the correct directory /run/nvidia-persistenced/socket. 

## Checklist before requesting a review
- [Y] Have I performed a self-review?
- [NA] Have I added regression or unit tests (where it makes sense) for my changes?
- [NA] Have I updated the docs if changes have resulted in it being out of date?
- [Y] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [NA] Have I ensured that there are no performance regressions by checking benchmark results?
- [N] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
