### PR TITLE
hotfix: Support v2 containerd conf in RKE2

### DIFF
--- a/plugins/k8s/scripts/install-plugins.sh
+++ b/plugins/k8s/scripts/install-plugins.sh
@@ -193,7 +193,7 @@ EOF
     if ! grep -q 'runtimes."cedana"' "$RKE2_CONFIG"; then
         cat <<EOF | sudo tee -a "$RKE2_CONFIG" >/dev/null
 
-[plugins.io.containerd.grpc.v1.cri.containerd.runtimes."cedana"]
+[plugins."io.containerd.grpc.v1.cri".containerd.runtimes."cedana"]
   runtime_type = "io.containerd.runc.v2"
   runtime_path = "/usr/local/bin/cedana-shim-runc-v2"
 EOF

--- a/plugins/k8s/scripts/install-plugins.sh
+++ b/plugins/k8s/scripts/install-plugins.sh
@@ -191,14 +191,9 @@ EOF
 
     # only append if not already present
     if ! grep -q 'runtimes."cedana"' "$RKE2_CONFIG"; then
-        if [ "$CONTAINERD_VERSION" = "2" ]; then
-            PLUGIN_KEY='io.containerd.grpc.v1.cri'
-        else
-            PLUGIN_KEY='io.containerd.cri.v1.runtime'
-        fi
         cat <<EOF | sudo tee -a "$RKE2_CONFIG" >/dev/null
 
-[plugins."${PLUGIN_KEY}".containerd.runtimes."cedana"]
+[plugins.io.containerd.grpc.v1.cri.containerd.runtimes."cedana"]
   runtime_type = "io.containerd.runc.v2"
   runtime_path = "/usr/local/bin/cedana-shim-runc-v2"
 EOF


### PR DESCRIPTION
## Describe your changes
Reducing version detecting complexity by only sticking with v2 containerd version
## Configuring containerd
### Version Gate

**Containerd 2.0 is backwards compatible with prior config versions, and RKE2 will continue to render legacy version 2 configuration from config.toml.tmpl if config-v3.toml.tmpl is not found.**

RKE2 includes containerd 2.0 as of the February 2025 releases: v1.31.6+rke2r1 and v1.32.2+rke2r1.
Be aware that containerd 2.0 prefers config version 3, while containerd 1.7 prefers config version 2.

RKE2 will generate a configuration file for containerd at /var/lib/rancher/rke2/agent/etc/containerd/config.toml, using values specific to the current cluster and node configuration.

For advanced customization, you can create a containerd config template in the same directory:

For containerd 2.0, place a version 3 configuration template in config-v3.toml.tmpl
See the [containerd 2.0 documentation](https://github.com/containerd/containerd/blob/release/2.0/docs/cri/config.md) for more information.
For containerd 1.7 and earlier, place a version 2 configuration template in config.toml.tmpl
See the [containerd 1.7 documentation](https://github.com/containerd/containerd/blob/release/1.7/docs/cri/config.md) for more information.

The template file is rendered into the containerd config using the [text/template](https://pkg.go.dev/text/template) library. See ContainerdConfigTemplateV3 and ContainerdConfigTemplate in [templates.go](https://github.com/k3s-io/k3s/blob/master/pkg/agent/templates/templates.go) for the default template content. The template is executed with a [ContainerdConfig](https://github.com/k3s-io/k3s/blob/master/pkg/agent/templates/templates.go#L22-L33) struct as its dot value (data argument).
## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
