### PR TITLE
ci: Upgrade bench runner to use CUDA 13.2 driver

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -72,7 +72,7 @@ env:
 jobs:
   dry-run:
     name: Dry Run
-    runs-on: runs-on=${{github.run_id}}/runner=${{ inputs.runner }}-amd64-cuda-12-8/extras=s3-cache
+    runs-on: runs-on=${{github.run_id}}/runner=${{ inputs.runner }}-amd64-cuda-13-2/extras=s3-cache
     container:
       image: cedana/cedana-bench:slim
       credentials:
@@ -117,7 +117,7 @@ jobs:
   run:
     name: Run
     needs: dry-run
-    runs-on: runs-on=${{github.run_id}}/runner=${{ inputs.runner }}-amd64-cuda-12-8/tag=${{ matrix.runtime }}-${{ matrix.metric }}-${{ matrix.workload }}/extras=s3-cache
+    runs-on: runs-on=${{github.run_id}}/runner=${{ inputs.runner }}-amd64-cuda-13-2/tag=${{ matrix.runtime }}-${{ matrix.metric }}-${{ matrix.workload }}/extras=s3-cache
     container:
       # sglang and vllm have incompatible dep sets, so cedana-bench publishes
       # two separate images. Match cedana-bench's own test.yml: pick the


### PR DESCRIPTION
## Describe your changes
Upgrade the bench runner to use CUDA 13.2 driver. This should give us more relevant benchmark results and also prevents compilation-related issues with workloads compiled with newer toolkits.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.