### PR TITLE
ced-2184: Fix cgroup v1 path detection for SLURM

### DIFF
--- a/plugins/slurm/internal/job/utils.go
+++ b/plugins/slurm/internal/job/utils.go
@@ -72,7 +72,7 @@ func cgroupPathFromProc(pid uint32) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(string(data)), "\n") {
 		path, ok := strings.CutPrefix(line, "0::")
 		if !ok {
 			continue
@@ -86,7 +86,7 @@ func cgroupPathFromProc(pid uint32) (string, error) {
 }
 
 func getJobCgroupPathV1(jid uint32) (string, error) {
-	v1Pattern := fmt.Sprintf("/sys/fs/cgroup/freezer/slurm/uid_*/job_%d/step_batch", jid)
+	v1Pattern := fmt.Sprintf("/sys/fs/cgroup/freezer/slurm*/uid_*/job_%d/step_batch", jid)
 
 	for attempt := range cgroupRetryAttempts {
 		matches, err := filepath.Glob(v1Pattern)


### PR DESCRIPTION
## Describe your changes
Relax path detection for cgroup v1, required for GMU's test cluster for example.

SLURM cgroup paths can be like `/sys/fs/cgroup/freezer/slurm_<node_name>/**/*`.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes?
- [x] Have I updated the docs if changes have resulted in it being out of date?
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders.