### PR TITLE
CED-2132: refresh CRIU external files after freeze

### DIFF
--- a/internal/cedana/gpu/dump_adapters.go
+++ b/internal/cedana/gpu/dump_adapters.go
@@ -6,6 +6,7 @@ import (
 	"regexp"
 
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
+	"github.com/cedana/cedana/pkg/criu"
 	"github.com/cedana/cedana/pkg/types"
 	"github.com/cedana/cedana/pkg/utils"
 	"github.com/rs/zerolog/log"
@@ -78,14 +79,33 @@ func AddExternalMountsForDump(next types.Dump) types.Dump {
 			)
 		}
 
-		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
-			if NVIDIA_MOUNTS_PATTERN.MatchString(m.Root) {
-				log.Trace().Interface("m", m).Msg("marking NVIDIA GPU mount as external")
-				req.Criu.External = append(req.Criu.External, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, m.MountPoint))
-			}
-			return true
+		initial := gpuExternalMountKeys(state)
+		req.Criu.External = append(req.Criu.External, initial...)
+
+		pid := state.PID
+		opts.CRIUCallback.Include(&criu.NotifyCallback{
+			Name: "gpu external mounts",
+			QueryExtFilesFunc: func(ctx context.Context) ([]string, error) {
+				frozen := &daemon.ProcessState{}
+				if err := utils.FillProcessState(ctx, pid, frozen, true); err != nil {
+					return nil, err
+				}
+				return gpuExternalMountKeys(frozen), nil
+			},
 		})
 
 		return next(ctx, opts, resp, req)
 	}
+}
+
+func gpuExternalMountKeys(state *daemon.ProcessState) []string {
+	var keys []string
+	utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
+		if NVIDIA_MOUNTS_PATTERN.MatchString(m.Root) {
+			log.Trace().Interface("m", m).Msg("marking NVIDIA GPU mount as external")
+			keys = append(keys, fmt.Sprintf("mnt[%s]:%s", m.MountPoint, m.MountPoint))
+		}
+		return true
+	})
+	return keys
 }

--- a/internal/cedana/process/dump_adapters.go
+++ b/internal/cedana/process/dump_adapters.go
@@ -8,6 +8,7 @@ import (
 	"buf.build/gen/go/cedana/cedana/protocolbuffers/go/daemon"
 	criu_proto "buf.build/gen/go/cedana/criu/protocolbuffers/go/criu"
 
+	"github.com/cedana/cedana/pkg/criu"
 	"github.com/cedana/cedana/pkg/types"
 	"github.com/cedana/cedana/pkg/utils"
 
@@ -146,6 +147,8 @@ func DetectIOUringForDump(next types.Dump) types.Dump {
 // Detects any open files that are in an external namespace
 // and sets appropriate options for CRIU.
 // Also detects any TTY files and sets options for CRIU.
+// Keeps the initial pass for older CRIU builds, then refreshes the list from
+// CRIU's query-ext-files hook after CRIU has seized the process tree.
 func AddExternalFilesForDump(next types.Dump) types.Dump {
 	return func(ctx context.Context, opts types.Opts, resp *daemon.DumpResp, req *daemon.DumpReq) (code func() <-chan int, err error) {
 		state := resp.GetState()
@@ -154,44 +157,69 @@ func AddExternalFilesForDump(next types.Dump) types.Dump {
 			return next(ctx, opts, resp, req)
 		}
 
-		mounts := make(map[uint64]any)
-		utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
-			mounts[m.ID] = nil
-			return true
-		})
-
 		if req.GetCriu() == nil {
 			req.Criu = &criu_proto.CriuOpts{}
 		}
 
-		utils.WalkTree(state, "OpenFiles", "Children", func(f *daemon.File) bool {
-			isPipe := strings.HasPrefix(f.Path, "pipe")
-			isSocket := strings.HasPrefix(f.Path, "socket")
-			isAnon := strings.HasPrefix(f.Path, "anon_inode")
-			isMemfd := strings.HasPrefix(f.Path, "/memfd:")
-			_, mountFound := mounts[f.MountID]
+		req.Criu.External = append(req.Criu.External, externalFileKeys(state)...)
 
-			// A file is external if it's from outside the process's mount namespace.
-			// Pipes, sockets, memfds and anon_inodes are internal (not real files from external mounts).
-			// A file is external only if its mount ID is not in the process's mount table AND it's a real file.
-			internal := mountFound || isPipe || isSocket || isAnon || isMemfd
-			external := !internal
-
-			if external {
-				if f.IsTTY {
-					log.Trace().Str("path", f.Path).Uint64("rdev", f.Rdev).Uint64("dev", f.Dev).Msg("marking TTY file as external")
-					req.Criu.External = append(req.Criu.External, fmt.Sprintf("tty[%x:%x]", f.Rdev, f.Dev))
-				} else {
-					log.Trace().Str("path", f.Path).Uint64("mount_id", f.MountID).Uint64("inode", f.Inode).Msg("marking file as external")
-					req.Criu.External = append(req.Criu.External, fmt.Sprintf("file[%x:%x]", f.MountID, f.Inode))
-				}
-			}
-
-			return true
-		})
+		// CRIU queries again after seizing the process tree. Re-read the frozen
+		// tree so file and mount changes since the initial snapshot are included.
+		if opts.CRIUCallback != nil {
+			pid := state.PID
+			opts.CRIUCallback.Include(&criu.NotifyCallback{
+				Name: "external-files",
+				QueryExtFilesFunc: func(ctx context.Context) ([]string, error) {
+					frozen := &daemon.ProcessState{}
+					if err := utils.FillProcessState(ctx, pid, frozen, true); err != nil {
+						return nil, err
+					}
+					return externalFileKeys(frozen), nil
+				},
+			})
+		}
 
 		return next(ctx, opts, resp, req)
 	}
+}
+
+// externalFileKeys returns the CRIU '--external' keys for every open file in the state tree that lives outside the process's mount table.
+func externalFileKeys(state *daemon.ProcessState) []string {
+	mounts := make(map[uint64]any)
+	utils.WalkTree(state, "Mounts", "Children", func(m *daemon.Mount) bool {
+		mounts[m.ID] = nil
+		return true
+	})
+
+	var keys []string
+
+	utils.WalkTree(state, "OpenFiles", "Children", func(f *daemon.File) bool {
+		isPipe := strings.HasPrefix(f.Path, "pipe")
+		isSocket := strings.HasPrefix(f.Path, "socket")
+		isAnon := strings.HasPrefix(f.Path, "anon_inode")
+		isMemfd := strings.HasPrefix(f.Path, "/memfd:")
+		_, mountFound := mounts[f.MountID]
+
+		// A file is external if it's from outside the process's mount namespace.
+		// Pipes, sockets, memfds and anon_inodes are internal (not real files from external mounts).
+		// A file is external only if its mount ID is not in the process's mount table AND it's a real file.
+		internal := mountFound || isPipe || isSocket || isAnon || isMemfd
+		external := !internal
+
+		if external {
+			if f.IsTTY {
+				log.Trace().Str("path", f.Path).Uint64("rdev", f.Rdev).Uint64("dev", f.Dev).Msg("marking TTY file as external")
+				keys = append(keys, fmt.Sprintf("tty[%x:%x]", f.Rdev, f.Dev))
+			} else {
+				log.Trace().Str("path", f.Path).Uint64("mount_id", f.MountID).Uint64("inode", f.Inode).Msg("marking file as external")
+				keys = append(keys, fmt.Sprintf("file[%x:%x]", f.MountID, f.Inode))
+			}
+		}
+
+		return true
+	})
+
+	return keys
 }
 
 func AddExternalMountsForDump(next types.Dump) types.Dump {

--- a/pkg/criu/criu.go
+++ b/pkg/criu/criu.go
@@ -262,6 +262,10 @@ func (c *Criu) doSwrkWithResp(
 		}
 
 		notify := resp.GetNotify()
+
+		// Only query-ext-files expects anything back other than an ack.
+		var replyOpts *criu.CriuOpts
+
 		switch notify.GetScript() {
 		case "pre-dump":
 			err = nfy.PreDump(ctx, opts)
@@ -285,6 +289,16 @@ func (c *Criu) doSwrkWithResp(
 			err = nfy.PostResume(ctx)
 		case "skip-namespaces":
 			err = nfy.SkipNamespaces(ctx, notify.GetPid())
+		case "query-ext-files":
+			var external []string
+			external, err = nfy.QueryExtFiles(ctx)
+			if err == nil {
+				replyOpts = &criu.CriuOpts{
+					// Required field, ignored by CRIU for this reply.
+					ImagesDirFd: proto.Int32(-1),
+					External:    external,
+				}
+			}
 		case "orphan-pts-master":
 			scm, err := syscall.ParseSocketControlMessage(oobB[:oobn])
 			if err != nil {
@@ -306,6 +320,7 @@ func (c *Criu) doSwrkWithResp(
 		req = criu.CriuReq{
 			Type:          &respType,
 			NotifySuccess: proto.Bool(true),
+			Opts:          replyOpts,
 		}
 	}
 

--- a/pkg/criu/notify.go
+++ b/pkg/criu/notify.go
@@ -25,6 +25,7 @@ type Notify interface {
 	PreResume(ctx context.Context) error
 	PostResume(ctx context.Context) error
 	OrphanPtsMaster(ctx context.Context, fd int32) error
+	QueryExtFiles(ctx context.Context) ([]string, error) // return external file keys after CRIU has seized the process tree.
 }
 
 // NoNotify struct
@@ -112,4 +113,8 @@ func (c NoNotify) PostResume(ctx context.Context) error {
 
 func (c NoNotify) OrphanPtsMaster(ctx context.Context, fd int32) error {
 	return nil
+}
+
+func (c NoNotify) QueryExtFiles(ctx context.Context) ([]string, error) {
+	return nil, nil
 }

--- a/pkg/criu/notify_callback.go
+++ b/pkg/criu/notify_callback.go
@@ -29,6 +29,7 @@ type NotifyCallback struct {
 	PreResumeFunc           NotifyFunc
 	PostResumeFunc          NotifyFunc
 	OrphanPtsMasterFunc     NotifyFuncFd
+	QueryExtFilesFunc       NotifyFuncExtFiles
 
 	Name string // to give some context to this callback
 }
@@ -40,6 +41,7 @@ type (
 	NotifyFuncOptsErr     func(ctx context.Context, opts *criu.CriuOpts, err error) error
 	NotifyFuncPid         func(ctx context.Context, pid int32) error
 	NotifyFuncFd          func(ctx context.Context, fd int32) error
+	NotifyFuncExtFiles    func(ctx context.Context) ([]string, error)
 	InitializeFunc        func(ctx context.Context, criuPid int32) error
 )
 
@@ -281,6 +283,22 @@ func (n NotifyCallback) PostResume(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+func (n NotifyCallback) QueryExtFiles(ctx context.Context) ([]string, error) {
+	if n.QueryExtFilesFunc != nil {
+		log.Trace().Str("name", n.Name).Msg("CRIU query-ext-files callback")
+		var end func()
+		ctx, end = profiling.StartTimingCategory(ctx, n.Name)
+		defer end()
+		external, err := n.QueryExtFilesFunc(ctx)
+		if err != nil {
+			log.Trace().Err(err).Str("name", n.Name).Msg("CRIU query-ext-files callback failed")
+			return nil, fmt.Errorf("query-ext-files callback: %v", err)
+		}
+		return external, nil
+	}
+	return nil, nil
 }
 
 func (n NotifyCallback) OrphanPtsMaster(ctx context.Context, fd int32) error {

--- a/pkg/criu/notify_callback_multi.go
+++ b/pkg/criu/notify_callback_multi.go
@@ -190,6 +190,18 @@ func (n NotifyCallbackMulti) SkipNamespaces(ctx context.Context, pid int32) erro
 	return nil
 }
 
+func (n NotifyCallbackMulti) QueryExtFiles(ctx context.Context) ([]string, error) {
+	var external []string
+	for i := len(n.callbacks) - 1; i >= 0; i-- {
+		files, err := n.callbacks[i].QueryExtFiles(ctx)
+		if err != nil {
+			return nil, err
+		}
+		external = append(external, files...)
+	}
+	return external, nil
+}
+
 func (n NotifyCallbackMulti) OrphanPtsMaster(ctx context.Context, fd int32) error {
 	for i := len(n.callbacks) - 1; i >= 0; i-- {
 		err := n.callbacks[i].OrphanPtsMaster(ctx, fd)


### PR DESCRIPTION
## Describe your changes
Fixes CED-2132, where a process dump could fail if a process kept an FD open
while its mount disappeared after Cedana read `/proc`, but before CRIU froze
the process tree. Cedana previously built CRIU's external file list from that
initial state, so the disappeared mount was missing when CRIU needed it. This
keeps that initial list for the existing path, then rebuilds it when CRIU sends
`query-ext-files` after freezing the tree, so CRIU gets the current list
without changing the normal behavior.

## Checklist before requesting a review
- [x] Have I performed a self-review?
- [x] Have I added regression or unit tests (where it makes sense) for my changes? N/A existing automated tests caught this bug
- [x] Have I updated the docs if changes have resulted in it being out of date? N/A internal CRIU fix
- [x] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [x] Have I ensured that there are no performance regressions by checking benchmark results? NA
- [x] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. Non breaking change
