### PR TITLE
feat(k8s): provide /checkpoint as tmpfs for the memory storage tier

### DIFF
--- a/plugins/k8s/cmd/helper.go
+++ b/plugins/k8s/cmd/helper.go
@@ -76,6 +76,11 @@ var setupCmd = &cobra.Command{
 			script.Chroot("/host", k8scripts.ConfigureKubelet),
 			script.Chroot("/host", scripts.ConfigureShm),
 			script.Chroot("/host", scripts.ConfigureIoUring),
+			// Runs before the service so /checkpoint exists before anything can
+			// be asked to write a checkpoint into it. Disabled unless
+			// CHECKPOINT_TMPFS_ENABLED is set, so a node that does not host
+			// checkpointed workloads gives up no memory.
+			script.Chroot("/host", scripts.ConfigureCheckpointTmpfs),
 			script.Chroot("/host", scripts.InstallService),
 		)
 		if err != nil {

--- a/scripts/configure-checkpoint-tmpfs.sh
+++ b/scripts/configure-checkpoint-tmpfs.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# Source utils.sh if running as a standalone script (BASH_SOURCE is set)
+if [ -n "${BASH_SOURCE[0]:-}" ]; then
+    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    if [ -f "$SCRIPT_DIR/utils.sh" ]; then
+        source "$SCRIPT_DIR/utils.sh"
+    fi
+fi
+
+# Provides /checkpoint as tmpfs, the memory storage tier for Cedana checkpoints.
+#
+# tmpfs because a checkpoint's value is speed: restoring a model from RAM avoids
+# a weight load that measures eleven minutes from block storage on this hardware.
+# The trade is that the checkpoint dies with the node, so this tier serves model
+# swaps on a live node and cannot serve recovery from node loss — that needs a
+# durable tier.
+#
+# tmpfs pages are charged to node memory, and they compete directly with the
+# workload: a GPU worker here requests 48Gi and may limit at 80Gi on a node with
+# ~85GiB. An oversized /checkpoint does not fail loudly, it makes the kernel
+# reclaim or OOM-kill under load, so the size ceiling below is a safety property
+# rather than a preference.
+
+CHECKPOINT_PATH=${CHECKPOINT_TMPFS_PATH:-"/checkpoint"}
+FSTAB="/etc/fstab"
+SIZE=${CHECKPOINT_TMPFS_SIZE:-"50G"}
+MODE=${CHECKPOINT_TMPFS_MODE:-"1777"}
+ENABLED=${CHECKPOINT_TMPFS_ENABLED:-"false"}
+# Share of host RAM this mount may claim. tmpfs is allowed to grow to its size,
+# so a value near or above total RAM is a latent node failure.
+MAX_RAM_FRACTION=${CHECKPOINT_TMPFS_MAX_RAM_FRACTION:-80}
+
+if [ "$ENABLED" != "true" ]; then
+    echo "Checkpoint tmpfs is not enabled, skipping..."
+    exit 0
+fi
+
+SIZE_BYTES=$(numfmt --from=iec "$SIZE")
+TOTAL_RAM_BYTES=$(($(awk '/^MemTotal:/ {print $2}' /proc/meminfo) * 1024))
+MAX_ALLOWED_BYTES=$((TOTAL_RAM_BYTES * MAX_RAM_FRACTION / 100))
+
+echo "Configuring $CHECKPOINT_PATH as tmpfs, size $SIZE, mode $MODE"
+echo "Host RAM: $(numfmt --to=iec "$TOTAL_RAM_BYTES"), ceiling ${MAX_RAM_FRACTION}%: $(numfmt --to=iec "$MAX_ALLOWED_BYTES")"
+
+# Refuse rather than clamp. Silently shrinking the mount would let a checkpoint
+# fail mid-write with no space, which is harder to diagnose than not starting.
+if [ "$SIZE_BYTES" -gt "$MAX_ALLOWED_BYTES" ]; then
+    echo "ERROR: requested size $SIZE exceeds ${MAX_RAM_FRACTION}% of host RAM ($(numfmt --to=iec "$MAX_ALLOWED_BYTES"))." >&2
+    echo "       tmpfs is charged to node memory and competes with the workload." >&2
+    exit 1
+fi
+
+mkdir -p "$CHECKPOINT_PATH"
+
+# Idempotent: mounted at the right size and mode is success, not a reason to
+# remount. The helper runs this on every start.
+needs_mount=1
+if mountpoint -q "$CHECKPOINT_PATH"; then
+    CURRENT_FSTYPE=$(findmnt -no FSTYPE "$CHECKPOINT_PATH")
+    CURRENT_BYTES=$(df -B1 --output=size "$CHECKPOINT_PATH" | awk 'NR==2 {print $1}')
+    if [ "$CURRENT_FSTYPE" != "tmpfs" ]; then
+        echo "ERROR: $CHECKPOINT_PATH is mounted as $CURRENT_FSTYPE, not tmpfs." >&2
+        echo "       Refusing to replace a non-tmpfs mount that may hold data." >&2
+        exit 1
+    fi
+    if [ "$CURRENT_BYTES" -eq "$SIZE_BYTES" ]; then
+        echo "$CHECKPOINT_PATH already tmpfs at the requested size"
+        needs_mount=0
+    else
+        echo "Remounting: size is $(numfmt --to=iec "$CURRENT_BYTES"), want $SIZE"
+        mount -o "remount,size=$SIZE,mode=$MODE" "$CHECKPOINT_PATH"
+        needs_mount=0
+    fi
+fi
+
+if [ "$needs_mount" -eq 1 ]; then
+    echo "Mounting tmpfs at $CHECKPOINT_PATH"
+    if ! mount -t tmpfs -o "size=$SIZE,mode=$MODE" tmpfs "$CHECKPOINT_PATH"; then
+        echo "ERROR: failed to mount tmpfs at $CHECKPOINT_PATH" >&2
+        exit 1
+    fi
+fi
+
+# Mode is set explicitly: a checkpoint is written by the shim and may be read by
+# a differently-owned restore process, and mount options do not always apply the
+# mode to an existing directory.
+chmod "$MODE" "$CHECKPOINT_PATH"
+
+# Persist so a node reboot does not silently lose the tier. The checkpoint
+# contents do not survive either way — this only keeps the mount present, so a
+# restore attempt fails a compatibility check rather than writing to the root
+# filesystem and filling it.
+FSTAB_ENTRY="tmpfs $CHECKPOINT_PATH tmpfs defaults,size=$SIZE,mode=$MODE 0 0"
+if [ -f "$FSTAB" ] && grep -qE "^\s*[^#]*\s+${CHECKPOINT_PATH}\s+tmpfs" "$FSTAB"; then
+    if ! grep -qF "$FSTAB_ENTRY" "$FSTAB"; then
+        echo "Updating existing $FSTAB entry for $CHECKPOINT_PATH"
+        sed -i "\|^\s*[^#]*\s\+${CHECKPOINT_PATH}\s\+tmpfs.*|c\\${FSTAB_ENTRY}" "$FSTAB"
+    fi
+else
+    echo "Adding $FSTAB entry for $CHECKPOINT_PATH"
+    echo "$FSTAB_ENTRY" >>"$FSTAB"
+fi
+
+# Report what the tier can actually hold. A checkpoint of a 27B FP8 model is
+# ~30GB, so an operator sizing this needs the number, not just success.
+echo "Checkpoint tmpfs ready:"
+df -h "$CHECKPOINT_PATH" | awk 'NR==2 {print "  " $2 " total, " $4 " available at " $6}'

--- a/scripts/scripts.go
+++ b/scripts/scripts.go
@@ -17,5 +17,13 @@ var ConfigureShm string
 //go:embed configure-io-uring.sh
 var ConfigureIoUring string
 
+// ConfigureCheckpointTmpfs provides /checkpoint as tmpfs, the memory storage
+// tier for checkpoints. Gated behind CHECKPOINT_TMPFS_ENABLED and a ceiling on
+// the share of host RAM it may claim, because tmpfs pages compete with the
+// workload's own memory.
+//
+//go:embed configure-checkpoint-tmpfs.sh
+var ConfigureCheckpointTmpfs string
+
 //go:embed utils.sh
 var Utils string


### PR DESCRIPTION
## What

Provides `/checkpoint` as tmpfs for the memory storage tier, via a
`configure-checkpoint-tmpfs.sh` helper script wired into the k8s plugin.

## Why

The memory storage tier has to be memory-backed to mean anything. This is what
makes a 42 GiB CRIU + GPU checkpoint complete in about 30 seconds with the model
still serving; on a disk-backed path that figure does not hold, and the checkpoint
competes with the very workload it is trying to snapshot.

It also constrains restore: a memory-tier checkpoint is node- and boot-local,
which is why the controller's restore gate checks the node's boot id before
trusting one.

## Stacking

Base is `swarnim/k8s-helper-image-plugins` (PR 2 of 2 in this repo's stack).

## Depends on

- **cedana-helm-charts `swarnim/nebius-checkpoint-tmpfs`** — configures this on the
  Nebius GPU nodes.
- **cedana-controller `swarnim/dynamo-checkpoint-restore`** — the consumer.

## Note

`plugins/runc` is a submodule in this repo and its pointer is **not** advanced by
this PR. The `/dev/shm` archive/restore work that the restore path needs lives in
`cedana/cedana-runc` and is still uncommitted locally — it needs its own PR there
first, after which the submodule pointer can be bumped in a separate change.
