### PR TITLE
CED-2289: Bump healthcheck shm size 

### DIFF
--- a/internal/cedana/gpu/controller.go
+++ b/internal/cedana/gpu/controller.go
@@ -47,8 +47,8 @@ const (
 	CONTROLLER_MISC_DIR_FORMATTER          = "/dev/shm/cedana-gpu.%s.misc"
 	CONTROLLER_BOOKING_LOCK_FILE_FORMATTER = "/dev/shm/cedana-gpu.%s.booking"
 	CONTROLLER_TERMINATE_SIGNAL            = syscall.SIGTERM
-	CONTROLLER_RESTORE_NEW_PID_SIGNAL      = syscall.SIGUSR1      // Signal to the restored process to notify it has a new PID
-	CONTROLLER_CHECK_SHM_SIZE              = 500 * utils.KIBIBYTE // Small size to run controller health check
+	CONTROLLER_RESTORE_NEW_PID_SIGNAL      = syscall.SIGUSR1    // Signal to the restored process to notify it has a new PID
+	CONTROLLER_CHECK_SHM_SIZE              = 8 * utils.MEBIBYTE // Small size to run controller health check
 
 	LOG_DIR_FORMATTER              = "%s/cedana-gpu.%s"
 	LOG_DIR_PATTERN                = "(.*)/cedana-gpu.(.*)"


### PR DESCRIPTION
## Describe your changes
Controller was crashing on healthcheck, which causes all sort of stupid annoyances in k8s. Requires a larger shm size so boost can do some allocations. 

## Checklist before requesting a review
- [ ] Have I performed a self-review?
- [ ] Have I added regression or unit tests (where it makes sense) for my changes?
- [ ] Have I updated the docs if changes have resulted in it being out of date?
- [ ] Have I checked to ensure my PR only introduces the changes it's intended to? E.g. No extraneous formatting changes.
- [ ] Have I ensured that there are no performance regressions by checking benchmark results?
- [ ] Is this a breaking change? If yes, please describe areas affected and request reviews from developer stakeholders. 
